### PR TITLE
VCDA-217: Retrieve access control settings of a catalog

### DIFF
--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -128,8 +128,12 @@ def control_access(ctx, catalog_name):
         org = Org(client, in_use_org_href, org_name == 'System')
         control_access = org.get_catalog_access_control_settings(catalog_name)
         stdout('Access Settings for catalog :' + catalog_name)
-        stdout(control_access.get('AccessSettings'), ctx, show_id=True)
-        del control_access['AccessSettings']
+        access_settings = control_access.get('AccessSettings')
+        if access_settings is not None:
+            stdout(control_access.get('AccessSettings'), ctx, show_id=True)
+            del control_access['AccessSettings']
+        else:
+            stdout('No access control information set for the catalog yet')
         stdout(control_access, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -16,6 +16,7 @@ import os
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import to_dict
+from pyvcloud.vcd.utils import print_access_settings
 from pyvcloud.vcd.utils import vapp_to_dict
 from pyvcloud.vcd.vapp import VApp
 from vcd_cli.utils import is_admin
@@ -129,12 +130,12 @@ def control_access(ctx, catalog_name):
         control_access = org.get_catalog_access_control_settings(catalog_name)
         stdout('Access Settings for catalog :' + catalog_name)
         access_settings = control_access.get('AccessSettings')
+        del control_access['AccessSettings']
+        stdout(control_access, ctx)
         if access_settings is not None:
-            stdout(control_access.get('AccessSettings'), ctx, show_id=True)
-            del control_access['AccessSettings']
+            stdout(access_settings, ctx, show_id=True)
         else:
             stdout('No access control information set for the catalog yet')
-        stdout(control_access, ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -16,7 +16,6 @@ import os
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import to_dict
-from pyvcloud.vcd.utils import print_access_settings
 from pyvcloud.vcd.utils import vapp_to_dict
 from pyvcloud.vcd.vapp import VApp
 from vcd_cli.utils import is_admin
@@ -132,6 +131,7 @@ def control_access(ctx, catalog_name):
         access_settings = control_access.get('AccessSettings')
         del control_access['AccessSettings']
         stdout(control_access, ctx)
+        stdout('')
         if access_settings is not None:
             stdout(access_settings, ctx, show_id=True)
         else:

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -114,6 +114,27 @@ def info(ctx, catalog_name, item_name):
     except Exception as e:
         stderr(e, ctx)
 
+
+@catalog.command(short_help='catalog control access details')
+@click.pass_context
+@click.argument('catalog-name',
+                metavar='<catalog-name>',
+                required=True)
+def control_access(ctx, catalog_name):
+    try:
+        client = ctx.obj['client']
+        org_name = ctx.obj['profiles'].get('org')
+        in_use_org_href = ctx.obj['profiles'].get('org_href')
+        org = Org(client, in_use_org_href, org_name == 'System')
+        control_access = org.get_catalog_access_control_settings(catalog_name)
+        stdout('Access Settings for catalog :' + catalog_name)
+        stdout(control_access.get('AccessSettings'), ctx, show_id=True)
+        del control_access['AccessSettings']
+        stdout(control_access, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
 @catalog.command(short_help='rename catalog and/or change catalog description')
 @click.pass_context
 @click.argument('catalog-name',


### PR DESCRIPTION
(pyvcloud) malakars-m01:pyvcloud malakars$ pwd
/Users/malakars/pyworkspace/pyvcloud
(pyvcloud) malakars-m01:pyvcloud malakars$ cd tests
(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_catalog.TestCatalog.test_catalog_control_access_retrieval
/Users/malakars/.virtualenvs/pyvcloud/lib/python3.6/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)
.

Ran 1 test in 0.435s

OK