### PR TITLE
Implementing new params for vcd cluster create command

### DIFF
--- a/vcd_cli/cluster.py
+++ b/vcd_cli/cluster.py
@@ -117,17 +117,21 @@ def list(ctx):
               metavar='<storage-profile>',
               help='Name of the storage profile for the nodes')
 @click.option('-k',
-              '--ssh_key',
-              'ssh_key',
+              '--ssh-key',
+              'ssh_key_file',
               required=False,
               default=None,
-              metavar='<ssh_key>',
+              type=click.File('r'),
+              metavar='<ssh-key>',
               help='SSH key to talk to the guest os on the vm')
 def create(ctx, name, node_count, cpu_count, memory, network_name,
-           storage_profile, ssh_key):
+           storage_profile, ssh_key_file):
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
+        ssh_key = None
+        if ssh_key_file is not None:
+            ssh_key = ssh_key_file.read()
         result = cluster.create_cluster(
                     ctx.obj['profiles'].get('vdc_in_use'),
                     network_name,

--- a/vcd_cli/cluster.py
+++ b/vcd_cli/cluster.py
@@ -88,6 +88,20 @@ def list(ctx):
               default=2,
               metavar='<nodes>',
               help='Number of nodes to create')
+@click.option('-c',
+              '--cpu',
+              'cpu_count',
+              required=False,
+              default=None,
+              metavar='<cpu-count>',
+              help='Number of virtual cpus on each node')
+@click.option('-m',
+              '--memory',
+              'memory',
+              required=False,
+              default=None,
+              metavar='<memory>',
+              help='Amount of memory (in MB) on each node')
 @click.option('-n',
               '--network',
               'network_name',
@@ -95,14 +109,20 @@ def list(ctx):
               required=False,
               metavar='<network>',
               help='Network name')
-@click.option('storage_profile',
-              '-s',
+@click.option('-s',
               '--storage-profile',
+              'storage_profile',
               required=False,
               default=None,
               metavar='<storage-profile>',
               help='Name of the storage profile for the nodes')
-def create(ctx, name, node_count, network_name, storage_profile):
+@click.option('--ssh_key',
+              'vm-guest-os-ssh-key',
+              required=False,
+              default=None,
+              metavar='<ssh_key>',
+              help='SSH key to talk to the guest os on the vm')
+def create(ctx, name, node_count, cpu_count, memory, network_name, storage_profile, ssh_key):
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)
@@ -111,7 +131,10 @@ def create(ctx, name, node_count, network_name, storage_profile):
                     network_name,
                     name,
                     node_count=node_count,
-                    storage_profile=storage_profile)
+                    cpu_count=cpu_count,
+                    memory=memory,
+                    storage_profile=storage_profile,
+                    ssh_key=ssh_key)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/cluster.py
+++ b/vcd_cli/cluster.py
@@ -123,7 +123,8 @@ def list(ctx):
               default=None,
               metavar='<ssh_key>',
               help='SSH key to talk to the guest os on the vm')
-def create(ctx, name, node_count, cpu_count, memory, network_name, storage_profile, ssh_key):
+def create(ctx, name, node_count, cpu_count, memory, network_name,
+           storage_profile, ssh_key):
     try:
         client = ctx.obj['client']
         cluster = Cluster(client)

--- a/vcd_cli/cluster.py
+++ b/vcd_cli/cluster.py
@@ -116,8 +116,9 @@ def list(ctx):
               default=None,
               metavar='<storage-profile>',
               help='Name of the storage profile for the nodes')
-@click.option('--ssh_key',
-              'vm-guest-os-ssh-key',
+@click.option('-k',
+              '--ssh_key',
+              'ssh_key',
               required=False,
               default=None,
               metavar='<ssh_key>',


### PR DESCRIPTION
Testing done :
CLI command :
(vcd-cli) C:\code\vcd-cli>vcd cluster create -n net1 -N 2 -c 2 -m 1025 --ssh-key ssh-key.txt "aritra-test-cluster"

cse.log :
DEBUG    2017-11-29 08:14:08,615 container_service_extension.processor    process_request                      55  : request body: {"name": "aritra-test-cluster", "node_count": 2, "vdc": "vdc1", "cpu-count": "2", "memory": "1025", "network": "net1", "storage_profile": null, "ssh-key": "sample SSH key"}

Note : the command failed with an error stating 'not enough IP addresses' on the extension. But I believe it's not related to my changes.