### PR TITLE
Command to list rights for a given role in an Org

### DIFF
--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -1,6 +1,8 @@
 import click
 from pyvcloud.vcd.org import Org
+from pyvcloud.vcd.role import Role
 
+from vcd_cli.utils import is_sysadmin
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
@@ -34,5 +36,24 @@ def list_roles(ctx):
         org = Org(client, in_use_org_href, org_name == 'System')
         result = org.list_roles()
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@role.command('list-rights', short_help='list rights of a role')
+@click.pass_context
+@click.argument('role-name',
+                metavar='<role-name>',
+                required=True)
+def list_rights(ctx, role_name):
+    try:
+        client = ctx.obj['client']
+        org_name = ctx.obj['profiles'].get('org')
+        in_use_org_href = ctx.obj['profiles'].get('org_href')
+        org = Org(client, in_use_org_href, is_sysadmin(ctx))
+        role_record = org.get_role(role_name)
+        role = Role(client, href=role_record.get('href'))
+        rights = role.list_rights()
+        stdout(rights, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -17,7 +17,7 @@ def role(ctx):
 \b
     Examples
         vcd role list
-            Get list of roles in the specified or current organization.
+            Get list of roles in the current organization.
             
         vcd role list_rights
             Get list of rights in a given role.

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -43,7 +43,7 @@ def list_roles(ctx):
         stderr(e, ctx)
 
 
-@role.command('list_rights', short_help='list rights of a role')
+@role.command('list-rights', short_help='list rights of a role')
 @click.pass_context
 @click.argument('role-name',
                 metavar='<role-name>',

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -40,17 +40,26 @@ def list_roles(ctx):
         stderr(e, ctx)
 
 
-@role.command('list-rights', short_help='list rights of a role')
+@role.command('list_rights', short_help='list rights of a role')
 @click.pass_context
 @click.argument('role-name',
                 metavar='<role-name>',
                 required=True)
-def list_rights(ctx, role_name):
+@click.option('-o',
+              '--org',
+              'org_name',
+              required=False,
+              metavar='<org-name>',
+              help='name of the org')
+def list_rights(ctx, role_name, org_name=None):
     try:
         client = ctx.obj['client']
-        org_name = ctx.obj['profiles'].get('org')
-        in_use_org_href = ctx.obj['profiles'].get('org_href')
-        org = Org(client, in_use_org_href, is_sysadmin(ctx))
+        if (org_name is not None):
+            org_href = client.get_org_by_name(org_name).get('href')
+        else:
+            org_href = ctx.obj['profiles'].get('org_href')
+        stdout(org_href,ctx)
+        org = Org(client, org_href, is_sysadmin(ctx))
         role_record = org.get_role(role_name)
         role = Role(client, href=role_record.get('href'))
         rights = role.list_rights()

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -58,7 +58,6 @@ def list_rights(ctx, role_name, org_name=None):
             org_href = client.get_org_by_name(org_name).get('href')
         else:
             org_href = ctx.obj['profiles'].get('org_href')
-        stdout(org_href,ctx)
         org = Org(client, org_href, is_sysadmin(ctx))
         role_record = org.get_role(role_name)
         role = Role(client, href=role_record.get('href'))

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -20,7 +20,7 @@ def role(ctx):
             Get list of roles in the current organization.
             
         vcd role list_rights
-            Get list of rights in a given role.
+            Get list of rights associated with a given role.
     """  # NOQA
     if ctx.invoked_subcommand is not None:
         try:

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -12,12 +12,15 @@ from vcd_cli.vcd import vcd
 @vcd.group(short_help='work with roles')
 @click.pass_context
 def role(ctx):
-    """Work with roles in current organization.
+    """Work with roles and rights
 
 \b
     Examples
         vcd role list
-            Get list of roles in current organization.
+            Get list of roles in the specified or current organization.
+            
+        vcd role list_rights
+            Get list of rights in a given role.
     """  # NOQA
     if ctx.invoked_subcommand is not None:
         try:


### PR DESCRIPTION
Ran pep8 code violation inspection.
-----------------
Sample command output
> vcd role list-rights 'vApp User'

name
---------------------------------
vApp Template: Checkout
UI Plugins: View
vApp: Snapshot Operations
vApp: Copy
vApp: Manage VM Password Settings
vApp Template / Media: View
vApp: Edit VM Properties
vApp: View VM metrics
vApp: Delete
vApp: Use Console
Disk: View Properties
vApp: Power Operations
vApp: Sharing
vApp: Edit Properties
vApp: Edit VM Network