### PR TITLE
Fixing text color issue after an error

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 tox
 flake8
+flake8-import-order
 hacking
 mock
 yapf

--- a/vcd_cli/info.py
+++ b/vcd_cli/info.py
@@ -81,7 +81,7 @@ def info(ctx, resource_type, resource_id):
         elif len(records) > 1:
             raise Exception('multiple found')
         resource = client.get_resource(records[0].get('href'))
-        stdout_xml(resource)
+        stdout_xml(resource, ctx.find_root().params['is_colorized'])
         # result = to_dict(records[0], resource_type)
         # stdout(result, ctx, show_id=True)
     except Exception as e:

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -12,24 +12,32 @@
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
 
-import click
-from colorama import Fore
 import json
 import logging
-from lxml.objectify import ObjectifiedElement
+import sys
+import traceback
 from os import environ
+
+import click
+
+from colorama import Fore
+
+from lxml.objectify import ObjectifiedElement
+
 from pygments import formatters
 from pygments import highlight
 from pygments import lexers
+
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.client import VcdErrorResponseException
 from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.utils import to_dict
+
 import requests
-import sys
+
 from tabulate import tabulate
-import traceback
+
 from vcd_cli.profiles import Profiles
 
 
@@ -129,7 +137,7 @@ def stdout(obj, ctx=None, alt_text=None, show_id=False):
                           separators=(',', ': '))
         if sys.version_info[0] < 3:
             text = str(text, 'utf-8')
-        if ctx.find_root().params['is_colorized'] is True:
+        if ctx.find_root().params['is_colorized']:
             click.echo(highlight(text, lexers.JsonLexer(),
                                  formatters.TerminalFormatter()))
         else:
@@ -201,7 +209,7 @@ def stderr(exception, ctx=None):
                           separators=(',', ': '))
         if sys.version_info[0] < 3:
             text = str(text, 'utf-8')
-        if ctx.find_root().params['is_colorized'] is True:
+        if ctx.find_root().params['is_colorized']:
             message = highlight(text, lexers.JsonLexer(),
                                 formatters.TerminalFormatter())
         else:
@@ -211,12 +219,12 @@ def stderr(exception, ctx=None):
     else:
         click.echo('\x1b[2K\r', nl=False)
         if ctx is not None:
-            if ctx.find_root().params['is_colorized'] is True:
+            if ctx.find_root().params['is_colorized']:
                 message = Fore.RED + str(message)
             ctx.fail(message)
         else:
-            if 'USE_COLORED_OUTPUT' in environ.keys() and \
-               environ['USE_COLORED_OUTPUT'] != '0':
+            if 'VCD_USE_COLORED_OUTPUT' in environ.keys() and \
+               environ['VCD_USE_COLORED_OUTPUT'] != '0':
                 message = Fore.RED + str(message)
             click.echo(message)
             sys.exit(1)

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -129,8 +129,11 @@ def stdout(obj, ctx=None, alt_text=None, show_id=False):
                           separators=(',', ': '))
         if sys.version_info[0] < 3:
             text = str(text, 'utf-8')
-        click.echo(highlight(text, lexers.JsonLexer(),
-                             formatters.TerminalFormatter()))
+        if ctx.find_root().params['is_colorized'] is True:
+            click.echo(highlight(text, lexers.JsonLexer(),
+                                 formatters.TerminalFormatter()))
+        else:
+            click.echo(text)
     else:
         if alt_text is not None:
             text = alt_text
@@ -198,8 +201,11 @@ def stderr(exception, ctx=None):
                           separators=(',', ': '))
         if sys.version_info[0] < 3:
             text = str(text, 'utf-8')
-        message = highlight(text, lexers.JsonLexer(),
-                            formatters.TerminalFormatter())
+        if ctx.find_root().params['is_colorized'] is True:
+            message = highlight(text, lexers.JsonLexer(),
+                                formatters.TerminalFormatter())
+        else:
+            message = text
         click.echo(message)
         sys.exit(1)
     else:

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -209,13 +209,15 @@ def stderr(exception, ctx=None):
         click.echo(message)
         sys.exit(1)
     else:
-        if 'USE_COLORED_OUTPUT' not in environ.keys() or \
-           environ['USE_COLORED_OUTPUT'] == '1':
-            message = Fore.RED + str(message)
         click.echo('\x1b[2K\r', nl=False)
         if ctx is not None:
+            if ctx.find_root().params['is_colorized'] is True:
+                message = Fore.RED + str(message)
             ctx.fail(message)
         else:
+            if 'USE_COLORED_OUTPUT' in environ.keys() and \
+               environ['USE_COLORED_OUTPUT'] != '0':
+                message = Fore.RED + str(message)
             click.echo(message)
             sys.exit(1)
 

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -17,6 +17,7 @@ from colorama import Fore
 import json
 import logging
 from lxml.objectify import ObjectifiedElement
+from os import environ
 from pygments import formatters
 from pygments import highlight
 from pygments import lexers
@@ -202,7 +203,9 @@ def stderr(exception, ctx=None):
         click.echo(message)
         sys.exit(1)
     else:
-        message = Fore.RED + str(message) + Fore.BLACK
+        if 'USE_COLORED_OUTPUT' not in environ.keys() or \
+           environ['USE_COLORED_OUTPUT'] == '1':
+            message = Fore.RED + str(message)
         click.echo('\x1b[2K\r', nl=False)
         if ctx is not None:
             ctx.fail(message)

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -15,6 +15,7 @@
 import click
 import pkg_resources
 import platform
+from colorama import init
 from vcd_cli.plugin import load_user_plugins
 from vcd_cli.utils import stdout
 
@@ -116,3 +117,4 @@ else:
     from vcd_cli import vdc  # NOQA
     from vcd_cli import vm  # NOQA
     load_user_plugins()
+    init(autoreset=True)

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -12,10 +12,14 @@
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
 
-import click
-import pkg_resources
 import platform
+
+import click
+
 from colorama import init
+
+import pkg_resources
+
 from vcd_cli.plugin import load_user_plugins
 from vcd_cli.utils import stdout
 
@@ -50,14 +54,22 @@ def abort_if_false(ctx, param, value):
 @click.option('--colorized/--no-colorized',
               'is_colorized',
               default=True,
-              envvar='USE_COLORED_OUTPUT',
+              envvar='VCD_USE_COLORED_OUTPUT',
               help='print info in color or monochrome')
 def vcd(ctx,
         debug,
         json_output,
         no_wait,
         is_colorized):
-    """VMware vCloud Director Command Line Interface."""
+    """VMware vCloud Director Command Line Interface.
+
+\b
+    Environment Variables
+        VCD_USE_COLORED_OUTPUT
+            If this environment variable is set, and it's value is not '0',
+            the comand vcd info will print the output in color. It will be
+            overridden by the param --colorized/--no-colorized.
+     """
     if ctx.invoked_subcommand is None:
         click.secho(ctx.get_help())
         return

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -67,8 +67,9 @@ def vcd(ctx,
     Environment Variables
         VCD_USE_COLORED_OUTPUT
             If this environment variable is set, and it's value is not '0',
-            the comand vcd info will print the output in color. It will be
-            overridden by the param --colorized/--no-colorized.
+            the command vcd info will print the output in color. The effect
+            of the environment variable will be overridden by the param
+            --colorized/--no-colorized.
      """
     if ctx.invoked_subcommand is None:
         click.secho(ctx.get_help())

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -50,6 +50,7 @@ def abort_if_false(ctx, param, value):
 @click.option('--colorized/--no-colorized',
               'is_colorized',
               default=True,
+              envvar='USE_COLORED_OUTPUT',
               help='print info in color or monochrome')
 def vcd(ctx,
         debug,

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -47,10 +47,15 @@ def abort_if_false(ctx, param, value):
               is_flag=True,
               default=False,
               help='Don\'t wait for task')
+@click.option('--colorized/--no-colorized',
+              'is_colorized',
+              default=True,
+              help='print info in color or monochrome')
 def vcd(ctx,
         debug,
         json_output,
-        no_wait):
+        no_wait,
+        is_colorized):
     """VMware vCloud Director Command Line Interface."""
     if ctx.invoked_subcommand is None:
         click.secho(ctx.get_help())


### PR DESCRIPTION
Also exposing option to turn off colored output entirely.

Tested manually to delete a non existent independent disk,
Before fix : After error console text color became dark gray
After fix : After error console text color remained the same as the foreground color

Also checked that setting the environment variable USE_COLROED_OUTPUT to anything other than '1' lead to error messages being printed out in normal text color. If the environment variable is unset or set to '1' color RED is used to print error messages.

Tested the following scenarios

Environment variable USE_COLORED_OUPUT not set
------------------------------------------------------
vcd info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --no-colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Monochrome output

Environment variable USE_COLORED_OUPUT is set to 0
------------------------------------------------------
vcd info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 :  Monochrome output
vcd --colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --no-colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Monochrome output

Environment variable USE_COLORED_OUPUT is set to 1
------------------------------------------------------
vcd info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 :  Colored output
vcd --colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --no-colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Monochrome output


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/145)
<!-- Reviewable:end -->
