### PR TITLE
Add code of conduct and PR/issue templates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+Contributor Code of Conduct
+======================
+
+As contributors and maintainers of this project, we pledge to respect
+everyone who contributes by posting issues, updating documentation,
+submitting pull requests, providing feedback in comments, and any other
+activities.
+
+Communication through any project channels (GitHub, mailing lists,
+Twitter, and so on) must be constructive and never resort to personal
+attacks, trolling, public or private harassment, insults, or other
+unprofessional conduct.
+
+We promise to extend courtesy and respect to everyone involved in this
+project, regardless of gender, gender identity, sexual orientation,
+disability, age, race, ethnicity, religion, or level of experience. We
+expect anyone contributing to this project to do the same.
+
+If any member of the community violates this code of conduct, the
+maintainers of this project may take action, including removing issues,
+comments, and PRs or blocking accounts, as deemed appropriate.
+
+If you are subjected to or witness unacceptable behavior, or have any
+other concerns, please communicate with us.
+
+If you have suggestions to improve the code of donduct, please submit
+an issue or PR.
+
+
+**Attribution**
+
+This Code of Conduct is adapted from the VMware Clarity project, available at this page: https://github.com/vmware/clarity/blob/master/CODE_OF_CONDUCT.md

--- a/ISSUE_REQUEST.md
+++ b/ISSUE_REQUEST.md
@@ -1,0 +1,5 @@
+To help us diagnose issues efficiently, please include:
+
+- A short but descriptive title
+- A detailed description of the problem including relevant software versions and steps to reproduce
+- A fix or workaround if you know it

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+To help us process your pull request efficiently, please include: 
+
+- (Required) Short description of changes in the PR topic line
+
+- (Required) Detailed description of changes include tests and
+  documentation.  If the pull request contains multiple commits with 
+  detailed messages, refer to those instead
+
+- (Optional) Names of reviewers using @ sign + name


### PR DESCRIPTION
Added files to fulfill GitHub community standards.  Code of conduct
adapted from VMware Clarity project.  PR and issue conventions are
derived from current practice.