### PR TITLE
 VCDA-311 : Unifying argument 'name' and option 'id' for independent disk related commands

### DIFF
--- a/vcd_cli/disk.py
+++ b/vcd_cli/disk.py
@@ -19,6 +19,7 @@ from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import disk_to_dict
 from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.vdc import VDC
+
 from vcd_cli.utils import convert_disk_name_user_input_to_name_and_id
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr

--- a/vcd_cli/disk.py
+++ b/vcd_cli/disk.py
@@ -13,15 +13,12 @@
 #
 
 import click
-
 import humanfriendly
-
 from pyvcloud.vcd.client import VCLOUD_STATUS_MAP
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import disk_to_dict
 from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.vdc import VDC
-
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
@@ -37,7 +34,7 @@ def disk(ctx):
 \b
     Examples
         vcd disk list
-            Get list of independent disks in current virtual datacenter.
+            Get list of independent disks in the current virtual datacenter.
 \b
         vcd disk create disk1 10g --description '10 GB Disk'
             Create a 10 GB independent disk using the default storage profile.
@@ -45,11 +42,11 @@ def disk(ctx):
         vcd disk info disk1
             Get details of the disk named 'disk1'.
 \b
-        vcd disk info disk1 --id 91b3a2e2-fd02-412b-9914-9974d60b2351
-            Get details of the disk named 'disk1' that has the supplied id.
+        vcd disk info uuid:91b3a2e2-fd02-412b-9914-9974d60b2351
+            Get details of the disk for a given id.
 \b
-        vcd disk update disk1 20g
-            Update an existing independent disk with new size.
+        vcd disk update disk1 --size 20g --description "new description"
+            Update an existing independent disk with new size and description.
 \b
         vcd disk delete disk1
             Delete an existing independent disk named 'disk1'.
@@ -65,29 +62,27 @@ def disk(ctx):
             stderr(e, ctx)
 
 
-@disk.command('info', short_help='show disk details')
+@disk.command('info', short_help='show details of an independent disk')
 @click.pass_context
-@click.argument('name',
-                metavar='<name>',
-                required=True)
-@click.option('-i',
-              '--id',
-              'disk_id',
-              required=False,
-              metavar='<id>',
-              help='Disk id')
-def info(ctx, name, disk_id):
+@click.argument('name', metavar='<name>')
+def info(ctx, name):
     try:
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
+
+        disk_id = None
+        if name.startswith('uuid:'):
+            disk_id = name[5:]
+            name = None
         disk = vdc.get_disk(name, disk_id=disk_id)
+
         stdout(disk_to_dict(disk), ctx)
     except Exception as e:
         stderr(e, ctx)
 
 
-@disk.command('list', short_help='list disks')
+@disk.command('list', short_help='list independent disks')
 @click.pass_context
 def list_disks(ctx):
     try:
@@ -115,42 +110,39 @@ def list_disks(ctx):
         stderr(e, ctx)
 
 
-@disk.command(short_help='create a disk with name and size(bytes)')
+@disk.command(short_help='create an independent disk')
 @click.pass_context
-@click.argument('name',
-                metavar='<name>',
-                required=True)
-@click.argument('size',
-                metavar='<size>',
-                required=True)
+@click.argument('name', metavar='<name>')
+@click.argument('size', metavar='<size in bytes>')
 @click.option('-d',
               '--description',
               'description',
               required=False,
               metavar='<description>',
-              help='Description of the independent disk')
-@click.option('-io',
+              help='Description of the new disk')
+@click.option('-s',
+              '--storage-profile',
+              'storage_profile',
+              required=False,
+              metavar='<storage-profile-name>',
+              help='Name of the Storage Profile to be used for the new disk.')
+@click.option('-i',
               '--iops',
               'iops',
               required=False,
               metavar='<iops>',
-              help='Iops of the independent disk')
-@click.option('storage_profile',
-              '-s',
-              '--storage-profile',
-              required=False,
-              metavar='<storage-profile>',
-              help='Name of Storage Profile to be used for new disk.')
-def create(ctx, name, size, iops, description, storage_profile):
+              help='Iops requirements of the new disk')
+def create(ctx, name, size, description, storage_profile, iops):
     try:
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
-        disk_resource = vdc.add_disk(name=name,
-                                     size=humanfriendly.parse_size(size),
-                                     iops=iops,
-                                     description=description,
-                                     storage_profile_name=storage_profile)
+        disk_resource = vdc.create_disk(
+            name=name,
+            size=humanfriendly.parse_size(size),
+            description=description,
+            storage_profile_name=storage_profile,
+            iops=iops)
         stdout(disk_resource.Tasks.Task[0], ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -158,27 +150,25 @@ def create(ctx, name, size, iops, description, storage_profile):
 
 @disk.command(short_help='delete a disk')
 @click.pass_context
-@click.argument('name',
-                metavar='<name>',
-                required=True)
-@click.option('-i',
-              '--id',
-              'disk_id',
-              required=False,
-              metavar='<id>',
-              help='Disk id')
+@click.argument('name', metavar='<name>')
 @click.option('-y',
               '--yes',
               is_flag=True,
               callback=abort_if_false,
               expose_value=False,
               prompt='Are you sure you want to delete the disk?')
-def delete(ctx, name, disk_id):
+def delete(ctx, name):
     try:
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
-        task = vdc.delete_disk(name, disk_id=disk_id)
+
+        disk_id = None
+        if name.startswith('uuid:'):
+            disk_id = name[5:]
+            name = None
+        task = vdc.delete_disk(name=name, disk_id=disk_id)
+
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -189,53 +179,58 @@ def delete(ctx, name, disk_id):
 @click.argument('name',
                 metavar='<name>',
                 required=True)
-@click.argument('size',
-                metavar='<new-size>',
-                required=False)
+@click.option('-n',
+              '--new-name',
+              'new_name',
+              required=False,
+              metavar='<new name>',
+              help='New name of the disk')
+@click.option('-s',
+              '--size',
+              'size',
+              metavar='<new size in bytes>',
+              required=False,
+              help='New size of the disk in bytes')
 @click.option('-d',
               '--description',
               'description',
               required=False,
               metavar='<description>',
-              help='New Description')
-@click.option('new_name',
-              '-new-name',
-              '--new-name',
+              help='New Description of the disk')
+@click.option('-S',
+              '--storage-profile',
+              'storage_profile',
               required=False,
-              metavar='<new-name>',
-              help='New name')
-@click.option('iops',
-              '-i',
+              metavar='<storage profile name>',
+              help='Name of the new Storage Profile to be used for the disk.')
+@click.option('-i',
               '--iops',
+              'iops',
               required=False,
               metavar='<iops>',
               default=None,
-              help='iops')
-@click.option('storage_profile',
-              '-s',
-              '--storage-profile',
-              required=False,
-              metavar='<storage-profile>',
-              help='Name of new Storage Profile to be used for new disk.')
-@click.option('-id',
-              '--id',
-              'disk_id',
-              required=False,
-              metavar='<id>',
-              help='Disk id')
-def update(ctx, name, size, description, new_name, storage_profile, iops,
-           disk_id):
+              help='New iops requirement of the disk')
+def update(ctx, name, new_name, size, description, storage_profile, iops):
     try:
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
-        task = vdc.update_disk(name,
-                               size=humanfriendly.parse_size(size),
+
+        new_size = None
+        if size is not None:
+            new_size = humanfriendly.parse_size(size)
+
+        disk_id = None
+        if name.startswith('uuid:'):
+            disk_id = name[5:]
+            name = None
+        task = vdc.update_disk(name=name,
+                               disk_id=disk_id,
                                new_name=new_name,
-                               description=description,
-                               storage_profile_name=storage_profile,
-                               iops=iops,
-                               disk_id=disk_id)
+                               new_size=new_size,
+                               new_description=description,
+                               new_storage_profile_name=storage_profile,
+                               new_iops=iops)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -243,27 +238,27 @@ def update(ctx, name, size, description, new_name, storage_profile, iops,
 
 @disk.command('change-owner', short_help='change owner of disk')
 @click.pass_context
-@click.argument('disk-name',
-                metavar='<disk-name>',
-                required=True)
-@click.argument('user_name',
-                metavar='<user_name>',
-                required=True)
-@click.option('-i',
-              '--id',
-              'disk_id',
-              required=False,
-              metavar='<id>',
-              help='Disk id')
-def change_disk_owner(ctx, disk_name, user_name, disk_id):
+@click.argument('disk-name', metavar='<disk-name>')
+@click.argument('user_name', metavar='<user_name>')
+def change_disk_owner(ctx, disk_name, user_name):
     try:
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
+
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
         user_resource = org.get_user(user_name)
-        vdc.change_disk_owner(disk_name, user_resource.get('href'), disk_id)
-        stdout('disk owner changed', ctx)
+
+        disk_id = None
+        if disk_name.startswith('uuid:'):
+            disk_id = disk_name[5:]
+            disk_name = None
+        vdc.change_disk_owner(user_href=user_resource.get('href'),
+                              name=disk_name,
+                              disk_id=disk_id)
+
+        stdout('Owner of disk \'%s\' changed to \'%s\'' %
+               (disk_name, user_name), ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/disk.py
+++ b/vcd_cli/disk.py
@@ -20,7 +20,7 @@ from pyvcloud.vcd.utils import disk_to_dict
 from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.vdc import VDC
 
-from vcd_cli.utils import convert_disk_name_user_input_to_name_and_id
+from vcd_cli.utils import extract_name_and_id
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
@@ -73,7 +73,7 @@ def info(ctx, name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
 
-        name, id = convert_disk_name_user_input_to_name_and_id(name)
+        name, id = extract_name_and_id(name)
         disk = vdc.get_disk(name=name, disk_id=id)
 
         stdout(disk_to_dict(disk), ctx)
@@ -162,7 +162,7 @@ def delete(ctx, name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
 
-        name, id = convert_disk_name_user_input_to_name_and_id(name)
+        name, id = extract_name_and_id(name)
         task = vdc.delete_disk(name=name, disk_id=id)
 
         stdout(task, ctx)
@@ -216,7 +216,7 @@ def update(ctx, name, new_name, size, description, storage_profile, iops):
         if size is not None:
             new_size = humanfriendly.parse_size(size)
 
-        name, id = convert_disk_name_user_input_to_name_and_id(name)
+        name, id = extract_name_and_id(name)
         task = vdc.update_disk(name=name,
                                disk_id=id,
                                new_name=new_name,
@@ -243,8 +243,7 @@ def change_disk_owner(ctx, disk_name, user_name):
         org = Org(client, in_use_org_href)
         user_resource = org.get_user(user_name)
 
-        disk_name, disk_id = \
-            convert_disk_name_user_input_to_name_and_id(disk_name)
+        disk_name, disk_id = extract_name_and_id(disk_name)
         vdc.change_disk_owner(user_href=user_resource.get('href'),
                               name=disk_name,
                               disk_id=disk_id)

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -318,3 +318,10 @@ def access_settings_to_list(control_access_params, org_in_use=''):
                                access_setting.Subject.get('type')],
                            'access_level': access_setting.AccessLevel})
     return result
+
+
+def convert_disk_name_user_input_to_name_and_id(str):
+    if str.lower().startswith('id:'):
+        return None, str[3:]
+    else:
+        return str, None

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -19,24 +19,18 @@ import traceback
 from os import environ # NOQA
 
 import click
-
 from colorama import Fore
-
 from lxml.objectify import ObjectifiedElement
-
 from pygments import formatters
 from pygments import highlight
 from pygments import lexers
-
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.client import VcdErrorResponseException
 from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.utils import to_dict
-
 import requests
-
 from tabulate import tabulate
 
 from vcd_cli.profiles import Profiles

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -314,8 +314,15 @@ def access_settings_to_list(control_access_params, org_in_use=''):
     return result
 
 
-def convert_disk_name_user_input_to_name_and_id(str):
-    if str.lower().startswith('id:'):
-        return None, str[3:]
+def extract_name_and_id(user_input):
+    """
+    Determines if the string user_input is a name or an id.
+    :param user_input: (str): input string from user
+    :return: (name, id) pair
+    """
+    name = id = None
+    if user_input.lower().startswith('id:'):
+        id = user_input[3:]
     else:
-        return str, None
+        name = user_input
+    return name, id

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -19,6 +19,7 @@ from pyvcloud.vcd.utils import to_dict
 from pyvcloud.vcd.utils import vapp_to_dict
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vdc import VDC
+from vcd_cli.utils import convert_disk_name_user_input_to_name_and_id
 from vcd_cli.utils import is_sysadmin
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
@@ -161,10 +162,8 @@ def attach(ctx, vapp_name, vm_name, disk_name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
 
-        disk_id = None
-        if disk_name.startswith('uuid:'):
-            disk_id = disk_name[5:]
-            disk_name = None
+        disk_name, disk_id = \
+            convert_disk_name_user_input_to_name_and_id(disk_name)
         disk = vdc.get_disk(name=disk_name, disk_id=disk_id)
 
         vapp_resource = vdc.get_vapp(vapp_name)
@@ -195,10 +194,8 @@ def detach(ctx, vapp_name, vm_name, disk_name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
 
-        disk_id = None
-        if disk_name.startswith('uuid:'):
-            disk_id = disk_name[5:]
-            disk_name = None
+        disk_name, disk_id = \
+            convert_disk_name_user_input_to_name_and_id(disk_name)
         disk = vdc.get_disk(name=disk_name, disk_id=disk_id)
 
         vapp_resource = vdc.get_vapp(vapp_name)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -21,7 +21,7 @@ from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vm import VM
 
-from vcd_cli.utils import convert_disk_name_user_input_to_name_and_id
+from vcd_cli.utils import extract_name_and_id
 from vcd_cli.utils import is_sysadmin
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
@@ -176,8 +176,7 @@ def attach(ctx, vapp_name, vm_name, disk_name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
 
-        disk_name, disk_id = \
-            convert_disk_name_user_input_to_name_and_id(disk_name)
+        disk_name, disk_id = extract_name_and_id(disk_name)
         disk = vdc.get_disk(name=disk_name, disk_id=disk_id)
 
         vapp_resource = vdc.get_vapp(vapp_name)
@@ -208,8 +207,7 @@ def detach(ctx, vapp_name, vm_name, disk_name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
 
-        disk_name, disk_id = \
-            convert_disk_name_user_input_to_name_and_id(disk_name)
+        disk_name, disk_id = extract_name_and_id(disk_name)
         disk = vdc.get_disk(name=disk_name, disk_id=disk_id)
 
         vapp_resource = vdc.get_vapp(vapp_name)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -165,7 +165,7 @@ def attach(ctx, vapp_name, vm_name, disk_name):
         if disk_name.startswith('uuid:'):
             disk_id = disk_name[5:]
             disk_name = None
-        disk = vdc.get_disk(disk_name, disk_id)
+        disk = vdc.get_disk(name=disk_name, disk_id=disk_id)
 
         vapp_resource = vdc.get_vapp(vapp_name)
         vapp = VApp(client, resource=vapp_resource)
@@ -199,7 +199,7 @@ def detach(ctx, vapp_name, vm_name, disk_name):
         if disk_name.startswith('uuid:'):
             disk_id = disk_name[5:]
             disk_name = None
-        disk = vdc.get_disk(disk_name, disk_id)
+        disk = vdc.get_disk(name=disk_name, disk_id=disk_id)
 
         vapp_resource = vdc.get_vapp(vapp_name)
         vapp = VApp(client, resource=vapp_resource)


### PR DESCRIPTION
(vcd-cli) c:\code\vcd-cli\vcd_cli>vcd disk list
id                                    name    owner      size        size_bytes  status    vms_attached
------------------------------------  ------  ---------  --------  ------------  --------  --------------
bea35db5-7c44-4d52-bbfd-1126162b8b50  disk1   org-admin  20 bytes            20  Resolved
efa4f7ea-62ba-415c-9427-c2a7d96a5ed3  disk1   org-admin  10 bytes            10  Resolved

(vcd-cli) c:\code\vcd-cli\vcd_cli>vcd disk info disk1
Usage: vcd disk info [OPTIONS] <name>

Error: Found multiple disks with name disk1, please identify disk via disk-id.

(vcd-cli) c:\code\vcd-cli\vcd_cli>vcd disk info id:bea35db5-7c44-4d52-bbfd-1126162b8b50
property        value
--------------  ------------------------------------
busSubType      lsilogic
busType         6
description     second disk
id              bea35db5-7c44-4d52-bbfd-1126162b8b50
iops            0
name            disk1
owner           org-admin
size            20 bytes
size_bytes      20
status          1
storageProfile  *

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/158)
<!-- Reviewable:end -->

  