### PR TITLE
VCDA-181: Clean up installation instructions for vcd-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 `vcd-cli` is the Command Line Interface for VMware vCloud Director.
 
+## Installation
+
+In general `vcd-cli` can be installed with the following command:
+
+```shell
+$ pip install --user vcd-cli
+```
+Depending on your operating system and distribution you may need 
+additional packages to install successfully.   See [install.md](docs/install.md)
+for full details. 
+
 ## Quick Start
 
 Below is a sample `vcd-cli` interaction with vCloud Director to create a virtual machine and start using it.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,20 +1,29 @@
-`vcd-cli` requires Python 3.
+# Installation 
+
+`vcd-cli` requires Python 3.  See sections below for installation on major
+OS distributions. Examples use `pip3` for installing Python 3 modules to
+ensure correct results in environments with mixed Python versions. Note
+that there are a couple of confusing exceptions related to installing
+`pip` itself. In these cases you **must** use the name `pip`.
+
+Pre-release and source installations are covered at the end of the page,
+so keep reading to experience life on the bleeding edge.
+
+If you find a bug in these procedures please file an issue or submit
+a pull request as described in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Ubuntu
 
-
 Ubuntu 16.04:
-
 ``` shell
-    $ sudo apt-get install python3-pip gcc python3-dev -y
-
+    $ sudo apt-get install python3-pip gcc -y
     $ pip3 install --user vcd-cli
 ```
 
+**Note:** If you encounter wheel errors ensure your pip3 version is up
+to date.  ```pip3 install --upgrade pip``` usually fixes them.
+
 ## CentOS
-
-
-CentOS 7:
 
 ```shell
     $ sudo yum update
@@ -26,34 +35,68 @@ CentOS 7:
     $ pip3 install --user vcd-cli
 ```
 
-## macOS
+## Photon OS 
 
-On macOS, open a Terminal and enter the commands listed below (skip those that refer to a component already installed on your mac):
+Photon OS minimal installs lack standard tools like pip3 and even ping,
+so you need to install a number of packages using tdnf.  There are also
+differences between Photon 1 and 2 distributions, so setup differs.
+
+Photon 1:
+``` shell
+    $ tdnf install -y gcc glibc-devel glibc-lang binutils python3-devel linux-api-headers
+    $ pip3 install --user vcd-cli
+```
+
+Photon 2:
+``` shell
+    $ tdnf install -y build-essential python3-setuptools python3-tools python3-pip python3-devel
+    $ pip3 install --user vcd-cli
+```
+
+## Mac OS X
+
+Open a Terminal and enter the commands listed below.  Skip those that
+refer to a component already installed on your Mac. 
 
 Install `Xcode Command Line Tools`:
-
 ``` shell
     $ xcode-select --install
 ```
-
 Press `Install` and accept the license terms.
 
-Install `pip`:
-
+Install `pip3`:
 ``` shell
     $ sudo easy_install pip
 ```
-
-Install `vcd-cli`
-
+Install `vcd-cli`:
 ``` shell
-    $ pip install --user vcd-cli
+    $ pip3 install --user vcd-cli
 ```
+
+**Note**: Older Mac OS X Python3 versions link with an outdated OpenSSL
+library, which may lead to failures.  If you get SSL errors on login,
+try adding the following libraries, then run pip3 again.
+``` shell
+    $ pip3 install --user urllib3 pyopenssl
+```
+
+## Windows 10
+
+Start by installng Python 3 using the latest Windows installer available from 
+https://www.python.org/downloads/windows/ and ensure that python.exe is in 
+the path.  
+
+Install `vcd-cli` and add to the PATH (needed for local installs):
+``` shell
+    C:\Users\Administrator>pip3 install --user vcd-cli
+    C:\Users\Administrator>set PATH=%PATH%;C:\Users\Administrator\AppData\Roaming\Python\Python36\Scripts
+```
+
+Administrator is just an example.  Other accounts work as well. 
 
 ## Verify Installation
 
 Display the version installed:
-
 ``` shell
     $ vcd version
 
@@ -62,32 +105,65 @@ Display the version installed:
 
 ## Installation with virtualenv
 
-It is also possible to install `vcd-cli` in a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
+It is also possible to install `vcd-cli` in a [virtualenv](https://docs.python.org/3/library/venv.html).  Quick commands to do so:
+``` shell
+    $ python3 -m venv $HOME/my_venv
+    $ . $HOME/my_venv
+    (my_venv) $ pip3 install vcd-cli
+```
+To terminate the virtual environment use the `deactivate` command. In
+this case we don't use the --user option as venv supplies its own location
+for packages.  Adding the --user option may cause odd installation behavior on
+some platforms.
 
 ## Upgrade
 
-To upgrade an existing `vcd-cli` install, just run:
+To upgrade an existing `vcd-cli` install, run:
 
 ``` shell
-    $ pip install --user vcd-cli --upgrade
+    $ pip3 install --user vcd-cli --upgrade
 ```
 
 ## Pre-releases
 
-The commands described above install the current stable version of `vcd-cli`. To install a pre-release version, enter:
+The commands described above install the current stable version of `vcd-cli`. 
+To install a pre-release version, enter:
 
 ``` shell
-    $ pip install --user vcd-cli --pre
+    $ pip3 install --user vcd-cli --pre
 ```
 
 And to upgrade a pre-release:
 
 ``` shell
-    $ pip install vcd-cli --pre --upgrade
+    $ pip3 install --user vcd-cli --pre --upgrade
 ```
+
+## Development and Specific Versions
 
 Installation from the current development version in GitHub:
 
 ``` shell
-    $ pip install --user git+https://github.com/vmware/vcd-cli.git
+    $ pip3 install --user git+https://github.com/vmware/vcd-cli.git
 ```
+
+Install specific Github or published versions:
+
+``` shell
+    $ pip3 install --user git+https://github.com/vmware/vcd-cli.git@20.0.0
+    (or)
+    $ pip3 install --user vcd-cli==20.0.0
+```
+
+## Installation from Local Source Files
+
+This is the standard installation for development.  Clone the code and
+install from source.
+``` shell
+    $ git clone https://github.com/vmware/vcd-cli.git
+    $ cd vcd-cli
+    $ python3 setup.py develop
+```
+The vcd command will automatically pick up current vcd-cli source files
+including any changes you have made.  Use of virtualenv is recommended to 
+avoid polluting your production Python installation. 


### PR DESCRIPTION
Added installation commands for Photon, vetted commands with current vcd-cli
version, cleaned up text, and added install.md reference in README.md.

Reviewers: @pacogomez @anusuyar @sompa @rocknes @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/165)
<!-- Reviewable:end -->
