### PR TITLE
VCDA-441 list available storage profiles

### DIFF
--- a/tests/tenant-onboard.sh
+++ b/tests/tenant-onboard.sh
@@ -22,5 +22,10 @@ vcd org use $ORG
 vcd role list
 vcd user create $USR $VCD_PASSWORD 'Organization Administrator' --enabled
 vcd pvdc list
+PVDC="$(vcd pvdc list |  sed -n 3p)"
+if [ ! -z "$PVDC" ]; then vcd pvdc info ${PVDC}; fi
 vcd netpool list
-vcd vdc create $VDC -p pvdc-2017-11-28-14-47-16.712 -n pvdc-2017-11-28-14-47-16.712-VXLAN-NP -s \*
+VNET="$(vcd netpool list |  sed -n 3p)"
+if [ ! -z "$PVDC" ] && [ ! -z "$VNET" ]; then
+    vcd vdc create $VDC -p $PVDC -n $VNET -s \*
+fi;

--- a/vcd_cli/pvdc.py
+++ b/vcd_cli/pvdc.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").
@@ -13,8 +13,9 @@
 #
 
 import click
+from pyvcloud.vcd.pvdc import PVDC
 from pyvcloud.vcd.system import System
-
+from pyvcloud.vcd.utils import pvdc_to_dict
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
@@ -30,6 +31,9 @@ def pvdc(ctx):
     Examples
         vcd pvdc list
             Get list of provider virtual datacenters.
+\b
+        vcd pvdc info name
+            Display provider virtual data center details.
     """
 
     if ctx.invoked_subcommand is not None:
@@ -49,6 +53,26 @@ def list_pvdc(ctx):
         result = []
         for pvdc in system.list_provider_vdcs():
             result.append({'name': pvdc.get('name')})
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@pvdc.command('info', short_help='show pvdc details')
+@click.pass_context
+@click.argument('name', metavar='<name>')
+def info_pvdc(ctx, name):
+    try:
+        client = ctx.obj['client']
+        sys_admin_resource = client.get_admin()
+        system = System(client, admin_resource=sys_admin_resource)
+        pvdc_reference = system.get_provider_vdc(name)
+        pvdc = PVDC(
+            client,
+            href=pvdc_reference.get('href'))
+        refs = pvdc.get_vdc_references()
+        md = pvdc.get_metadata()
+        result = pvdc_to_dict(pvdc.get_resource(), refs, md)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
- Implemented list storage profiles by implementing vcd-cli command 'pvdc info name'

- Tested by tenant-onboard.sh 

property          value
----------------  -------------------------------------
cpu_capacity     units: MHz
                           total: 11024
                           allocation: 0
                           used: 0
                           overhead: 0
description        Generated Provider vDC
id                        1d9c86f4-7ca6-42f0-9f76-ffbb9441f62a
is_enabled          True
mem_capacity    units: MB
                            total: 6565
                            allocation: 0
                            used: 0
                            overhead: 0
name                   pvdc-2018-01-16-15-02-24.676
network_pools    pvdc-2018-01-16-15-02-24.676-VXLAN-NP
storage_profiles  Development
                  *
supported_hw      vmx-04
                             vmx-07
                             vmx-08
                             vmx-09
                             vmx-10
                             vmx-11
vdc_refs               acmevdc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/174)
<!-- Reviewable:end -->
