### PR TITLE
VCDA-421 & VCDA-422: Implementing SDK methods and cli commands to connect/disconnect ovdc_network to/from vapp.

### DIFF
--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -150,6 +150,13 @@ def vapp(ctx):
             Add a VM to a vApp. Instantiate the source VM \'vm1\' that is in
             the \'template1.ova\' template in the \'catalog1\' catalog and
             place the new VM inside \'vapp1\' vApp.
+\b
+        vdc vapp connect vapp1 org-vdc-network1
+            Connects the network org-vdc-network1 to vapp1.
+
+\b
+        vdc vapp disconnect vapp1 org-vdc-network1
+            Disconnects the network org-vdc-network1 from vapp1.
     """
 
     if ctx.invoked_subcommand is not None:
@@ -666,6 +673,69 @@ def shutdown(ctx, name, vm_names):
                 vm.reload()
                 task = vm.shutdown()
                 stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('connect', short_help='connect an ovdc network')
+@click.pass_context
+@click.argument('name',
+                required=True,
+                metavar='<vapp-name>')
+@click.argument('network',
+                required=True,
+                metavar='<orgvdc-network-name>')
+@click.option(
+    '--retain-ip',
+    is_flag=True,
+    default=False,
+    help="True if the network resources such as IP/MAC of router will be "
+         "retained across deployments. False by default")
+@click.option(
+    '--is-deployed',
+    is_flag=True,
+    default=False,
+    help="True if this orgvdc network has been deployed. False by default")
+def connect(ctx, name, network, retain_ip, is_deployed):
+    try:
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        vapp_resource = vdc.get_vapp(name)
+        vapp = VApp(client, resource=vapp_resource)
+        vapp.connect_org_vdc_network(network, retain_ip=retain_ip,
+                                     is_deployed=is_deployed)
+        stdout("Successfully connected ovdc network \'%s\' to vapp \'%s\'"
+               % (network, name))
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('disconnect', short_help='disconnect an ovdc network')
+@click.pass_context
+@click.argument('name',
+                required=True,
+                metavar='<vapp-name>')
+@click.argument('network',
+                required=True,
+                metavar='<orgvdc-network-name>')
+@click.option(
+    '-y',
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to disconnect the network?')
+def disconnect(ctx, name, network):
+    try:
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        vapp_resource = vdc.get_vapp(name)
+        vapp = VApp(client, resource=vapp_resource)
+        vapp.disconnect_org_vdc_network(network)
+        stdout("Successfully disconnected ovdc network \'%s\' from vapp \'%s\'"
+               %(network, name))
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
```

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp disconnect v1 ovdcnet
Are you sure you want to disconnect the network? [y/N]: y
Successfully disconnected ovdc network 'ovdcnet' from vapp 'v1'

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp disconnect v1 ovdcneter
Are you sure you want to disconnect the network? [y/N]: y
Usage: vcd vapp disconnect [OPTIONS] <vapp-name> <orgvdc-network-name>

Error: Orgvdc network 'ovdcneter' is not attached to the vapp

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp connect v1 ovdcneter
Usage: vcd vapp connect [OPTIONS] <vapp-name> <orgvdc-network-name>

Error: Orgvdc network 'ovdcneter' does not exist in vdc 'vdc1'

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp connect v1 ovdcnet
Successfully connected ovdc network 'ovdcnet' to vapp 'v1'

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp connect v1 ovdcnet
Usage: vcd vapp connect [OPTIONS] <vapp-name> <orgvdc-network-name>

Error: Orgvdc network 'ovdcnet' is already connected to vapp.

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name

```