### PR TITLE
VCDA-470: Fixing help text for command vcd info

### DIFF
--- a/vcd_cli/info.py
+++ b/vcd_cli/info.py
@@ -46,13 +46,13 @@ def info(ctx, resource_type, resource_id):
         vcd info vapp c48a4e1a-7bd9-4177-9c67-4c330016b99f
             Get details of vApp by id.
 \b
-        vcd catalog list my-catalog
-            List items in a catalog.
         vcd catalog info my-catalog my-item
             Get details of an item listed in the previous command.
+\b
         vcd info catalogitem f653b137-0d14-4ea9-8f14-dcd2b7914110
             Get details of the catalog item based on the 'id' listed in the
             previous command.
+\b
         vcd info vapptemplate 53b83b27-1f2b-488e-9020-a27aee8cb640
             Get details of the vApp tepmlate based on the 'template-id' listed
             in the previous command.


### PR DESCRIPTION
* Got rid of spurious help item related to catalog list
* Added line breaks between individual examples

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/177)
<!-- Reviewable:end -->
