### PR TITLE
VCDA-436: avoid unnecessary session restoration

### DIFF
--- a/vcd_cli/amqp.py
+++ b/vcd_cli/amqp.py
@@ -44,18 +44,14 @@ def amqp(ctx):
         vcd system amqp set amqp-config.json --password guest
             Set AMQP configuration.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @amqp.command(short_help='show AMQP settings')
 @click.pass_context
 def info(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         amqp = AmqpService(client)
         settings = amqp.get_settings()
@@ -79,6 +75,7 @@ def info(ctx):
     required=True)
 def test(ctx, password, config_file):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         config = json.loads(
             config_file.read(1024).decode(sys.getfilesystemencoding()))
@@ -108,6 +105,7 @@ def test(ctx, password, config_file):
     required=True)
 def set_config(ctx, password, config_file):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         config = json.loads(
             config_file.read(1024).decode(sys.getfilesystemencoding()))

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -88,12 +88,7 @@ def catalog(ctx):
         vcd catalog update my-catalog -n 'new name' -d 'new description'
             Update the name and/or description of a catalog.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @catalog.command(short_help='show catalog or item details')
@@ -103,6 +98,7 @@ def catalog(ctx):
     'item-name', metavar='[item-name]', required=False, default=None)
 def info(ctx, catalog_name, item_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -142,6 +138,7 @@ def info(ctx, catalog_name, item_name):
     metavar='[description]')
 def update(ctx, catalog_name, new_catalog_name, description):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -156,6 +153,7 @@ def update(ctx, catalog_name, new_catalog_name, description):
 @click.argument('catalog-name', metavar='[catalog-name]', required=False)
 def list_catalogs_or_items(ctx, catalog_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if catalog_name is None:
             in_use_org_href = ctx.obj['profiles'].get('org_href')
@@ -176,7 +174,6 @@ def list_catalogs_or_items(ctx, catalog_name):
                 for r in records:
                     result.append(to_dict(r, resource_type=resource_type))
         stdout(result, ctx)
-
     except Exception as e:
         stderr(e, ctx)
 
@@ -188,6 +185,7 @@ def list_catalogs_or_items(ctx, catalog_name):
     '-d', '--description', required=False, default='', metavar='[description]')
 def create(ctx, catalog_name, description):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -210,6 +208,7 @@ def create(ctx, catalog_name, description):
     prompt='Are you sure you want to delete it?')
 def delete_catalog_or_item(ctx, catalog_name, item_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -228,6 +227,7 @@ def delete_catalog_or_item(ctx, catalog_name, item_name):
 @click.argument('catalog-name', metavar='<catalog-name>', required=True)
 def share_catalog(ctx, catalog_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -243,6 +243,7 @@ def share_catalog(ctx, catalog_name):
 @click.argument('catalog-name', metavar='<catalog-name>', required=True)
 def unshare_catalog(ctx, catalog_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -288,6 +289,7 @@ def download_callback(transferred, total):
     help='show progress')
 def upload(ctx, catalog_name, file_name, item_name, progress):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -332,6 +334,7 @@ def upload(ctx, catalog_name, file_name, item_name, progress):
     help='overwrite')
 def download(ctx, catalog_name, item_name, file_name, progress, overwrite):
     try:
+        restore_session(ctx)
         save_as_name = item_name
         if file_name is not None:
             save_as_name = file_name
@@ -359,6 +362,7 @@ def download(ctx, catalog_name, item_name, file_name, progress, overwrite):
 @click.argument('user-name', metavar='<user-name>')
 def change_owner(ctx, catalog_name, user_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -402,11 +406,7 @@ def acl(ctx):
             List acl of a catalog
 
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @acl.command(short_help='add access settings to a particular catalog')
@@ -415,6 +415,7 @@ def acl(ctx):
 @click.argument('access-list', nargs=-1, required=True)
 def add(ctx, catalog_name, access_list):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -447,6 +448,7 @@ def add(ctx, catalog_name, access_list):
     prompt='Are you sure you want to remove access settings?')
 def remove(ctx, catalog_name, access_list, all):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -483,6 +485,7 @@ def remove(ctx, catalog_name, access_list, all):
     ' default')
 def acl_share(ctx, catalog_name, access_level):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -503,6 +506,7 @@ def acl_share(ctx, catalog_name, access_level):
 @click.argument('catalog-name', metavar='<catalog-name>')
 def acl_unshare(ctx, catalog_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -519,6 +523,7 @@ def acl_unshare(ctx, catalog_name):
 @click.argument('catalog-name', metavar='<catalog-name>')
 def list_acl(ctx, catalog_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)

--- a/vcd_cli/extension.py
+++ b/vcd_cli/extension.py
@@ -43,20 +43,15 @@ def extension(ctx):
             Get details of an extension service named 'cse'
             in namespace 'cse-ns'.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-            ctx.obj['ext'] = APIExtension(ctx.obj['client'])
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @extension.command(short_help='list extensions')
 @click.pass_context
 def list(ctx):
     try:
-        ext = ctx.obj['ext']
+        restore_session(ctx)
+        ext = APIExtension(ctx.obj['client'])
         stdout(ext.list_extensions(), ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -68,7 +63,8 @@ def list(ctx):
 @click.argument('namespace', required=False)
 def info(ctx, name, namespace):
     try:
-        ext = ctx.obj['ext']
+        restore_session(ctx)
+        ext = APIExtension(ctx.obj['client'])
         stdout(ext.get_extension_info(name, namespace), ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -83,7 +79,8 @@ def info(ctx, name, namespace):
 @click.argument('patterns', metavar='<patterns>', required=True)
 def create(ctx, name, namespace, routing_key, exchange, patterns):
     try:
-        ext = ctx.obj['ext']
+        restore_session(ctx)
+        ext = APIExtension(ctx.obj['client'])
         ext.add_extension(name, namespace, routing_key, exchange,
                           patterns.split(','))
         stdout('Extension registered.', ctx)
@@ -106,7 +103,8 @@ def create(ctx, name, namespace, routing_key, exchange, patterns):
     prompt='Are you sure you want to unregister it?')
 def delete(ctx, name, namespace):
     try:
-        ext = ctx.obj['ext']
+        restore_session(ctx)
+        ext = APIExtension(ctx.obj['client'])
         ext.delete_extension(name, namespace)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -31,21 +31,14 @@ def gateway(ctx):
         vcd gateway list
             Get list of edge gateways in current virtual datacenter.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-            if not ctx.obj['profiles'].get('vdc_in_use') or \
-               not ctx.obj['profiles'].get('vdc_href'):
-                raise Exception('select a virtual datacenter')
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @gateway.command('list', short_help='list edge gateways')
 @click.pass_context
 def list_gateways(ctx):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)

--- a/vcd_cli/info.py
+++ b/vcd_cli/info.py
@@ -61,7 +61,6 @@ def info(ctx, resource_type, resource_id):
         Several 'vcd' commands provide the id of a resource, including the
         'vcd search' command.
     """
-
     try:
         if resource_type is None or resource_id is None:
             click.secho(ctx.get_help())

--- a/vcd_cli/netpool.py
+++ b/vcd_cli/netpool.py
@@ -31,18 +31,14 @@ def netpool(ctx):
         vcd netpool list
             Get list of network pools.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @netpool.command('list', short_help='list of network pools')
 @click.pass_context
 def list_netpools(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         sys_admin_resource = client.get_admin()
         system = System(client, admin_resource=sys_admin_resource)

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -29,11 +29,7 @@ def network(ctx):
     """Work with networks in vCloud Director.
 
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @network.group(short_help='work with external networks')
@@ -49,11 +45,7 @@ def external(ctx):
         vcd network external list
             List all external networks available in the system
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @network.group(short_help='work with directly connected org vdc networks')
@@ -79,11 +71,7 @@ def direct(ctx):
         vcd network direct delete direct-net1
             Delete directly connected network 'direct-net1' in the selected vdc
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @network.group(short_help='work with isolated org vdc networks')
@@ -112,11 +100,7 @@ def isolated(ctx):
         vcd network isolated delete isolated-net1
             Delete isolated network 'isoalted-net1' in the selected vdc
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @direct.command(
@@ -150,6 +134,7 @@ def isolated(ctx):
 def create_direct_network(ctx, name, parent_network_name, description,
                           is_shared):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)
@@ -253,6 +238,7 @@ def create_isolated_network(ctx, name, gateway_ip, netmask, description,
                             default_lease_time, max_lease_time,
                             dhcp_ip_range_start, dhcp_ip_range_end, is_shared):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)
@@ -284,6 +270,7 @@ def create_isolated_network(ctx, name, gateway_ip, netmask, description,
 @click.pass_context
 def list_external_networks(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
 
         platform = Platform(client)
@@ -304,6 +291,7 @@ def list_external_networks(ctx):
 @click.pass_context
 def list_direct_networks(ctx):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)
@@ -324,6 +312,7 @@ def list_direct_networks(ctx):
 @click.pass_context
 def list_isolated_networks(ctx):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)
@@ -359,6 +348,7 @@ def list_isolated_networks(ctx):
     prompt='Are you sure you want to delete the OrgVdc Network?')
 def delete_direct_networks(ctx, name, force):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)
@@ -390,6 +380,7 @@ def delete_direct_networks(ctx, name, force):
     prompt='Are you sure you want to delete the OrgVdc Network?')
 def delete_isolated_networks(ctx, name, force):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)

--- a/vcd_cli/org.py
+++ b/vcd_cli/org.py
@@ -51,12 +51,7 @@ def org(ctx):
         vcd org update my-org-name --enable
             Update organization 'my-org-name', e.g. enable the organization
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @org.command(short_help='show org details')
@@ -64,6 +59,7 @@ def org(ctx):
 @click.argument('name', metavar='<name>', required=True)
 def info(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         logged_in_org_name = ctx.obj['profiles'].get('org')
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
@@ -82,6 +78,7 @@ def info(ctx, name):
 @click.pass_context
 def list_orgs(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         logged_in_org_name = ctx.obj['profiles'].get('org')
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
@@ -106,6 +103,7 @@ def list_orgs(ctx):
 @click.argument('name', metavar='<name>', required=True)
 def use(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         org = client.get_org_by_name(name)
         resource = client.get_resource(org.get('href'))
@@ -148,6 +146,7 @@ def use(ctx, name):
     help='Enable org')
 def create(ctx, name, full_name, enabled):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         sys_admin_resource = client.get_admin()
         system = System(client, admin_resource=sys_admin_resource)
@@ -181,6 +180,7 @@ def create(ctx, name, full_name, enabled):
     prompt='Are you sure you want to delete the Org?')
 def delete(ctx, name, recursive, force):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         system = System(client)
         if force and recursive:
@@ -207,6 +207,7 @@ def delete(ctx, name, recursive, force):
     help='enable/disable the org')
 def update(ctx, name, is_enabled):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         org = Org(client, href=client.get_org_by_name(name).get('href'))
         result = org.update_org(is_enabled=is_enabled)

--- a/vcd_cli/profile.py
+++ b/vcd_cli/profile.py
@@ -28,7 +28,6 @@ def profile(ctx):
     """Manage user profiles
 
     """
-
     profiles = Profiles.load()
     click.echo(yaml.dump(profiles.data, default_flow_style=False))
 
@@ -39,7 +38,6 @@ def pwd(ctx):
     """Current resources in use
 
     """
-
     try:
         restore_session(ctx)
         host = ctx.obj['profiles'].get('host')

--- a/vcd_cli/pvdc.py
+++ b/vcd_cli/pvdc.py
@@ -36,18 +36,14 @@ def pvdc(ctx):
         vcd pvdc info name
             Display provider virtual data center details.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @pvdc.command('list', short_help='list of provider virtual datacenters')
 @click.pass_context
 def list_pvdc(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         sys_admin_resource = client.get_admin()
         system = System(client, admin_resource=sys_admin_resource)
@@ -64,6 +60,7 @@ def list_pvdc(ctx):
 @click.argument('name', metavar='<name>')
 def info_pvdc(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         sys_admin_resource = client.get_admin()
         system = System(client, admin_resource=sys_admin_resource)

--- a/vcd_cli/right.py
+++ b/vcd_cli/right.py
@@ -54,12 +54,7 @@ def right(ctx):
         vcd right remove 'vApp: Copy' 'Disk: Create' -o myOrg
             Removes list of rights from the organization
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @right.command(
@@ -81,6 +76,7 @@ def right(ctx):
     help='list all rights available in the System')
 def list_rights(ctx, org_name, all):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -103,6 +99,7 @@ def list_rights(ctx, org_name, all):
 @click.argument('right-name', metavar='<right-name>', required=True)
 def info(ctx, right_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         org = Org(client, href=ctx.obj['profiles'].get('org_href'))
         right_resource = org.get_right_resource(right_name)
@@ -123,6 +120,7 @@ def info(ctx, right_name):
     help='name of the org')
 def add(ctx, rights, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -156,6 +154,7 @@ def add(ctx, rights, org_name):
     'organization?')
 def remove(ctx, rights, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -74,12 +74,7 @@ def role(ctx):
             Removes one or more rights from a given role.
 
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @role.command('list', short_help='list roles')
@@ -94,6 +89,7 @@ def role(ctx):
 )
 def list_roles(ctx, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -121,6 +117,7 @@ def list_roles(ctx, org_name):
 )
 def info(ctx, role_name, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -146,6 +143,7 @@ def info(ctx, role_name, org_name):
     help='name of the org')
 def list_rights(ctx, role_name, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -178,6 +176,7 @@ def list_rights(ctx, role_name, org_name):
 )
 def create(ctx, role_name, description, rights, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -210,6 +209,7 @@ def create(ctx, role_name, description, rights, org_name):
     prompt='Are you sure you want to delete the role?')
 def delete(ctx, role_name, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -235,6 +235,7 @@ def delete(ctx, role_name, org_name):
     help='name of the org')
 def unlink(ctx, role_name, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -263,6 +264,7 @@ def unlink(ctx, role_name, org_name):
     help='name of the org')
 def link(ctx, role_name, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -291,6 +293,7 @@ def link(ctx, role_name, org_name):
     help='name of the org')
 def add_right(ctx, role_name, rights, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')
@@ -327,6 +330,7 @@ def add_right(ctx, role_name, rights, org_name):
     prompt='Are you sure you want to remove rights from the role?')
 def remove_right(ctx, role_name, rights, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')

--- a/vcd_cli/system.py
+++ b/vcd_cli/system.py
@@ -28,18 +28,14 @@ def system(ctx):
     """Manage system settings in vCloud Director.
 
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @system.command(short_help='show system details')
 @click.pass_context
 def info(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         result = client.get_resource(
             client._session_endpoints[_WellKnownEndpoint.ADMIN])

--- a/vcd_cli/task.py
+++ b/vcd_cli/task.py
@@ -45,12 +45,7 @@ def task(ctx):
         vcd task update aborted 4a115aa5-9657-4d97-a8c2-3faf43fb45dd
             Abort task by id, requires login as 'system administrator'.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @task.command(short_help='show task details')
@@ -58,6 +53,7 @@ def task(ctx):
 @click.argument('task_id', metavar='<id>', required=True)
 def info(ctx, task_id):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         result = client.get_resource('%s/task/%s' % (client._uri, task_id))
         stdout(task_to_dict(result), ctx, show_id=True)
@@ -75,6 +71,7 @@ def info(ctx, task_id):
     nargs=-1)
 def list_tasks(ctx, status):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         task_obj = Task(client)
         records = task_obj.list_tasks(filter_status_list=status)
@@ -97,6 +94,7 @@ def list_tasks(ctx, status):
 @click.argument('task_id', metavar='<id>', required=True)
 def wait(ctx, task_id):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         task = client.get_resource('%s/task/%s' % (client._uri, task_id))
         stdout(task, ctx)
@@ -114,13 +112,12 @@ def wait(ctx, task_id):
 @click.argument('task_id', metavar='<id>', required=True)
 def update(ctx, status, task_id):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         task = client.get_resource('%s/task/%s' % (client._uri, task_id))
         task.set('status', status)
         result = client.put_linked_resource(task, RelationType.EDIT,
                                             EntityType.TASK.value, task)
-        print(result)
+        stdout(result, ctx)
     except Exception as e:
-        import traceback
-        traceback.print_exc()
         stderr(e, ctx)

--- a/vcd_cli/user.py
+++ b/vcd_cli/user.py
@@ -50,12 +50,7 @@ def user(ctx):
             Get list of users in the current organization.
 
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @user.command(short_help='create user in current organization')
@@ -166,6 +161,7 @@ def create(ctx, user_name, password, role_name, full_name, description, email,
            alert_email_prefix, external, default_cached, group_role,
            stored_vm_quota, deployed_vm_quota):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -209,6 +205,7 @@ def create(ctx, user_name, password, role_name, full_name, description, email,
     ' Are you sure you want to delete the user?')
 def delete(ctx, user_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -228,6 +225,7 @@ def delete(ctx, user_name):
     help='enable/disable the user')
 def update(ctx, user_name, is_enabled):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -250,6 +248,7 @@ def update(ctx, user_name, is_enabled):
 )
 def list_users(ctx, org_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         if org_name is not None:
             org_href = client.get_org_by_name(org_name).get('href')

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -90,7 +90,11 @@ def as_metavar(values):
     return result
 
 
-def restore_session(ctx):
+def restore_session(ctx, vdc_required=False):
+    if type(
+            ctx.obj
+    ) is dict and 'client' in ctx.obj and ctx.obj['client'] is not None:
+        return
     profiles = Profiles.load()
     token = profiles.get('token')
     if token is None or len(token) == 0:
@@ -119,6 +123,10 @@ def restore_session(ctx):
     ctx.obj = {}
     ctx.obj['client'] = client
     ctx.obj['profiles'] = profiles
+    if vdc_required:
+        if not ctx.obj['profiles'].get('vdc_in_use') or \
+           not ctx.obj['profiles'].get('vdc_href'):
+            raise Exception('select a virtual datacenter')
 
 
 def spinning_cursor():

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -158,15 +158,7 @@ def vapp(ctx):
         vdc vapp disconnect vapp1 org-vdc-network1
             Disconnects the network org-vdc-network1 from vapp1.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-            if not ctx.obj['profiles'].get('vdc_in_use') or \
-               not ctx.obj['profiles'].get('vdc_href'):
-                raise Exception('select a virtual datacenter')
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @vapp.command(short_help='show vApp details')
@@ -174,6 +166,7 @@ def vapp(ctx):
 @click.argument('name', metavar='<name>', required=True)
 def info(ctx, name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -194,6 +187,7 @@ def info(ctx, name):
 @click.argument('disk-name', metavar='<disk-name>', required=True)
 def attach(ctx, vapp_name, vm_name, disk_name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -218,6 +212,7 @@ def attach(ctx, vapp_name, vm_name, disk_name):
 @click.argument('disk-name', metavar='<disk-name>', required=True)
 def detach(ctx, vapp_name, vm_name, disk_name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -240,6 +235,7 @@ def detach(ctx, vapp_name, vm_name, disk_name):
 @click.argument('name', metavar='[name]', required=False)
 def list_vapps(ctx, name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         result = []
         if name is None:
@@ -347,6 +343,7 @@ def create(ctx, name, description, catalog, template, network, memory, cpu,
            disk_size, ip_allocation_mode, vm_name, hostname, storage_profile,
            accept_all_eulas):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -396,6 +393,7 @@ def create(ctx, name, description, catalog, template, network, memory, cpu,
     help='Force delete running VM(s). Only applies to vApp delete.')
 def delete(ctx, name, vm_names, force):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -417,6 +415,7 @@ def delete(ctx, name, vm_names, force):
 @click.argument('storage-seconds', metavar='[storage-seconds]', required=False)
 def update_lease(ctx, name, runtime_seconds, storage_seconds):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -436,6 +435,7 @@ def update_lease(ctx, name, runtime_seconds, storage_seconds):
 @click.argument('user-name', metavar='<user-name>', required=True)
 def change_owner(ctx, vapp_name, user_name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -463,6 +463,7 @@ def change_owner(ctx, vapp_name, user_name):
     prompt='Are you sure you want to reboot the vApp or VM(s)?')
 def reboot(ctx, name, vm_names):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -494,6 +495,7 @@ def reboot(ctx, name, vm_names):
     prompt='Are you sure you want to power off the vApp?')
 def power_off(ctx, name, vm_names):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -524,6 +526,7 @@ def power_off(ctx, name, vm_names):
     prompt='Are you sure you want to reset the vApp or VM(s)?')
 def reset(ctx, name, vm_names):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -557,6 +560,7 @@ def reset(ctx, name, vm_names):
     'if not specified, default is False')
 def deploy(ctx, name, vm_names, power_on, force_customization):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -599,6 +603,7 @@ def deploy(ctx, name, vm_names, power_on, force_customization):
     help='Undeploy power action')
 def undeploy(ctx, name, vm_names, action):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -623,6 +628,7 @@ def undeploy(ctx, name, vm_names, action):
 @click.argument('vm-names', nargs=-1)
 def power_on(ctx, name, vm_names):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -654,6 +660,7 @@ def power_on(ctx, name, vm_names):
     prompt='Are you sure you want to shutdown the vApp or VM(s)?')
 def shutdown(ctx, name, vm_names):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -689,6 +696,7 @@ def shutdown(ctx, name, vm_names):
     help="True if this orgvdc network has been deployed. False by default")
 def connect(ctx, name, network, retain_ip, is_deployed):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -716,6 +724,7 @@ def connect(ctx, name, network, retain_ip, is_deployed):
     prompt='Are you sure you want to disconnect the network?')
 def disconnect(ctx, name, network):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -747,6 +756,7 @@ def disconnect(ctx, name, network):
     help='Make copy customizable during instantiation')
 def capture(ctx, name, catalog, template, customizable):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -782,6 +792,7 @@ def capture(ctx, name, catalog, template, customizable):
     help='Name of the storage profile for the new disk')
 def add_disk(ctx, name, vm_name, size, storage_profile):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -798,6 +809,7 @@ def add_disk(ctx, name, vm_name, size, storage_profile):
 @click.argument('name', metavar='<name>', required=True)
 def use(ctx, name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
         in_use_vdc_name = ctx.obj['profiles'].get('vdc_in_use')
@@ -864,6 +876,7 @@ def add_vm(ctx, name, source_vapp, source_vm, catalog, target_vm, hostname,
            network, ip_allocation_mode, storage_profile, password_auto,
            accept_all_eulas):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -932,11 +945,7 @@ def acl(ctx):
 
 
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @acl.command(short_help='add access settings to a particular vapp')
@@ -945,6 +954,7 @@ def acl(ctx):
 @click.argument('access-list', nargs=-1, required=True)
 def add(ctx, vapp_name, access_list):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -982,7 +992,7 @@ def remove(ctx, vapp_name, access_list, all):
                 'Do you want to remove all access settings from the vapp '
                 '\'%s\'' % vapp_name,
                 abort=True)
-
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -1011,6 +1021,7 @@ def remove(ctx, vapp_name, access_list, all):
     ' default')
 def share(ctx, vapp_name, access_level):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -1029,6 +1040,7 @@ def share(ctx, vapp_name, access_level):
 @click.argument('vapp-name', metavar='<vapp-name>')
 def unshare(ctx, vapp_name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -1046,6 +1058,7 @@ def unshare(ctx, vapp_name):
 @click.argument('vapp-name', metavar='<vapp-name>')
 def list_acl(ctx, vapp_name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)

--- a/vcd_cli/vc.py
+++ b/vcd_cli/vc.py
@@ -34,18 +34,14 @@ def vc(ctx):
         vcd vc info vc1
             Get details of the vCenter Server 'vc1' attached to the vCD system.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @vc.command('list', short_help='list vCenter Servers')
 @click.pass_context
 def list_vcenters(ctx):
     try:
+        restore_session(ctx)
         platform = Platform(ctx.obj['client'])
         stdout(platform.list_vcenters(), ctx)
     except Exception as e:
@@ -57,6 +53,7 @@ def list_vcenters(ctx):
 @click.argument('name')
 def info(ctx, name):
     try:
+        restore_session(ctx)
         platform = Platform(ctx.obj['client'])
         stdout(platform.get_vcenter(name), ctx)
     except Exception as e:

--- a/vcd_cli/vdc.py
+++ b/vcd_cli/vdc.py
@@ -59,12 +59,7 @@ def vdc(ctx):
         vcd vdc delete -y dev-vdc
             Delete virtual datacenter.
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @vdc.command(short_help='show virtual datacenter details')
@@ -72,6 +67,7 @@ def vdc(ctx):
 @click.argument('name', metavar='<name>', required=True)
 def info(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
         in_use_vdc = ctx.obj['profiles'].get('vdc_in_use')
@@ -97,6 +93,7 @@ def info(ctx, name):
 @click.pass_context
 def list_vdc(ctx):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
         in_use_vdc = ctx.obj['profiles'].get('vdc_in_use')
@@ -122,6 +119,7 @@ def list_vdc(ctx):
 @click.argument('name', metavar='<name>', required=True)
 def use(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
         orgs = client.get_org_list()
@@ -217,6 +215,7 @@ def use(ctx, name):
 def create(ctx, name, pvdc_name, network_pool_name, allocation_model, sp_name,
            sp_limit, description, cpu_allocated, cpu_limit):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -255,6 +254,7 @@ def create(ctx, name, pvdc_name, network_pool_name, allocation_model, sp_name,
     prompt='Are you sure you want to delete the VDC?')
 def delete(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         in_use_vdc = ctx.obj['profiles'].get('vdc_in_use')
@@ -277,6 +277,7 @@ def delete(ctx, name):
 @click.argument('name', metavar='<name>', required=True)
 def enable(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -292,6 +293,7 @@ def enable(ctx, name):
 @click.argument('name', metavar='<name>', required=True)
 def disable(ctx, name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -339,11 +341,7 @@ def acl(ctx):
 
 
     """
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @acl.command(short_help='add access settings to a particular vdc')
@@ -352,6 +350,7 @@ def acl(ctx):
 @click.argument('access-list', nargs=-1, required=True)
 def add(ctx, vdc_name, access_list):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -385,6 +384,7 @@ def add(ctx, vdc_name, access_list):
     prompt='Are you sure you want to remove access settings?')
 def remove(ctx, vdc_name, access_list, all):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
 
@@ -412,6 +412,7 @@ def remove(ctx, vdc_name, access_list, all):
 @click.argument('vdc-name', metavar='<vdc-name>')
 def share(ctx, vdc_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -431,6 +432,7 @@ def share(ctx, vdc_name):
 @click.argument('vdc-name', metavar='<vdc-name>')
 def unshare(ctx, vdc_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)
@@ -449,6 +451,7 @@ def unshare(ctx, vdc_name):
 @click.argument('vdc-name', metavar='<vdc-name>')
 def list_acl(ctx, vdc_name):
     try:
+        restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')
         org = Org(client, in_use_org_href)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -48,15 +48,7 @@ def vm(ctx):
             Modifies the VM 'vm1' in vApp 'vapp1' to be configured
             with 2 cpu and the specified memory .
     """
-
-    if ctx.invoked_subcommand is not None:
-        try:
-            restore_session(ctx)
-            if not ctx.obj['profiles'].get('vdc_in_use') or \
-               not ctx.obj['profiles'].get('vdc_href'):
-                raise Exception('select a virtual datacenter')
-        except Exception as e:
-            stderr(e, ctx)
+    pass
 
 
 @vm.command('list', short_help='list VMs')
@@ -74,6 +66,7 @@ def list_vms(ctx):
 @click.argument('vm-name', metavar='<vm-name>', required=True)
 def info(ctx, vapp_name, vm_name):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -86,8 +79,7 @@ def info(ctx, vapp_name, vm_name):
         stderr(e, ctx)
 
 
-@vm.command('update',
-            short_help='Update the VM properties and configurations')
+@vm.command('update', short_help='Update the VM properties and configurations')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
 @click.argument('vm-name', metavar='<vm-name>', required=True)
@@ -113,9 +105,9 @@ def info(ctx, vapp_name, vm_name):
     metavar='<memory>',
     type=click.INT,
     help='Memory to configure the VM.')
-
 def update(ctx, vapp_name, vm_name, cpu, cores, memory):
     try:
+        restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
@@ -123,7 +115,7 @@ def update(ctx, vapp_name, vm_name, cpu, cores, memory):
         vapp = VApp(client, resource=vapp_resource)
         vm_resource = vapp.get_vm(vm_name)
         vm = VM(client, resource=vm_resource)
-        if cpu is not None :
+        if cpu is not None:
             task_cpu_update = vm.modify_cpu(cpu, cores)
             stdout("Updating cpu (and core(s) if specified) for the VM")
             stdout(task_cpu_update, ctx)


### PR DESCRIPTION
- restore session is now called just one time when needed
- added parameter to load vdc in use
- in the network commands, it validates that a vdc is selected
- fixes VCDA-286 to display any command help with no login required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/185)
<!-- Reviewable:end -->
