### PR TITLE
VCDA-417: commands to manage extension commands

### DIFF
--- a/vcd_cli/plugin.py
+++ b/vcd_cli/plugin.py
@@ -12,11 +12,27 @@
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
 
+import click
+
 from vcd_cli.profiles import Profiles
 
 
 def load_user_plugins():
     profiles = Profiles.load()
-    if 'extensions' in profiles.data and len(profiles.data) > 0:
+    if 'extensions' in profiles.data and \
+            profiles.data['extensions'] is not None:
         for extension in profiles.data['extensions']:
-            __import__(extension)
+            try:
+                __import__(extension)
+            except ImportError:
+                click.secho(
+                    'Warning: the extension module \'%s\''
+                    ' could not be imported.' % extension,
+                    fg='yellow',
+                    err=True)
+            except Exception:
+                click.secho(
+                    'Warning: the extension module \'%s\''
+                    ' could not be loaded.' % extension,
+                    fg='yellow',
+                    err=True)

--- a/vcd_cli/profile.py
+++ b/vcd_cli/profile.py
@@ -19,17 +19,112 @@ from vcd_cli.profiles import Profiles
 from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
+from vcd_cli.vcd import abort_if_false
 from vcd_cli.vcd import vcd
 
 
-@vcd.command(short_help='manage profiles')
+@vcd.group(short_help='manage profiles')
 @click.pass_context
 def profile(ctx):
     """Manage user profiles
 
     """
-    profiles = Profiles.load()
-    click.echo(yaml.dump(profiles.data, default_flow_style=False))
+    pass
+
+
+@profile.command('info', short_help='show details of current profile')
+@click.pass_context
+def info(ctx):
+    try:
+        profiles = Profiles.load()
+        click.echo(yaml.dump(profiles.data, default_flow_style=False))
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@profile.group(short_help='work with vcd-cli extensions')
+@click.pass_context
+def extension(ctx):
+    """Manage vcd-cli extensions.
+
+\b
+    Description
+        Manages commands added to vcd-cli.
+\b
+        New commands can be added to vcd-cli as Python modules. The module
+        containing the commands implementation needs to be present in the
+        Python path.
+\b
+    Examples
+        vcd profile extension list
+            List the extension modules currently registered with vcd-cli.
+\b
+        vcd profile extension add container_service_extension.client.cse
+            Add to vcd-cli the commands to work with CSE, located in the
+            specified Python module.
+\b
+        vcd profile extension delete container_service_extension.client.cse
+            Removes the CSE commands from vcd-cli.
+\b
+    Files
+        ~/.vcd-cli/profiles.yaml (macOS and Linux)
+        %userprofile%/.vcd-cli/profiles.yaml (Windows)
+            The extension modules are registered in the profiles file.
+
+    """
+    pass
+
+
+@extension.command('list', short_help='list vcd-cli extensions')
+@click.pass_context
+def list_extensions(ctx):
+    try:
+        profiles = Profiles.load()
+        if 'extensions' in profiles.data and \
+                profiles.data['extensions'] is not None:
+            for extension in profiles.data['extensions']:
+                click.echo(extension)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@extension.command(short_help='add a vcd-cli extension')
+@click.pass_context
+@click.argument('module')
+def add(ctx, module):
+    try:
+        profiles = Profiles.load()
+        if 'extensions' not in profiles.data or \
+                profiles.data['extensions'] is None:
+            profiles.data['extensions'] = []
+        if module not in profiles.data['extensions']:
+            profiles.data['extensions'].append(module)
+            profiles.save()
+            click.secho('Extension added from module \'%s\'.' % module)
+        else:
+            raise Exception('module already in the profile')
+    except Exception as e:
+        stderr('Could not add extension from module \'%s\'' % module, ctx)
+
+
+@extension.command(short_help='delete a vcd-cli extension')
+@click.pass_context
+@click.argument('module')
+@click.option(
+    '-y',
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to delete the extension?')
+def delete(ctx, module):
+    try:
+        profiles = Profiles.load()
+        profiles.data['extensions'].remove(module)
+        profiles.save()
+        click.secho('Extension from module \'%s\' deleted.' % module)
+    except Exception as e:
+        stderr('Could not delete extension from module \'%s\'' % module, ctx)
 
 
 @vcd.command(short_help='current resources in use')

--- a/vcd_cli/profiles.py
+++ b/vcd_cli/profiles.py
@@ -12,9 +12,13 @@
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
 
+import logging
 import os
 
 import yaml
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.FileHandler('vcd.log'))
 
 VCD_CLI_USER_PATH = '~/.vcd-cli'
 PROFILE_PATH = VCD_CLI_USER_PATH + '/profiles.yaml'
@@ -34,7 +38,9 @@ class Profiles(object):
             with open(profile_path, 'r') as f:
                 p.data = yaml.load(f)
         except Exception:
-            pass
+            LOGGER.warning(
+                'Warning: the profiles file \'%s\''
+                ' could not be open. Using default values.' % PROFILE_PATH)
         p.path = profile_path
         return p
 

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -175,8 +175,8 @@ def info(ctx, name):
         vapp = VApp(client, resource=vapp_resource)
         md = vapp.get_metadata()
         access_control_settings = vapp.get_access_settings()
-        result = vapp_to_dict(vapp_resource, md, access_settings_to_dict(
-            access_control_settings))
+        result = vapp_to_dict(vapp_resource, md,
+                              access_settings_to_dict(access_control_settings))
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
- added list/add/remove extension commands, under the profile sub-command
- added warning when a module with extension commands can't be loaded
- added profile info command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/187)
<!-- Reviewable:end -->
