### PR TITLE
VCDA-454: Updated copyrights for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
-# VMware vCloud Director CLI 10
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# vCloud CLI
+#
+# Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+#
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").
 # You may not use this product except in compliance with the License.
+#
 # This product may include a number of subcomponents with
 # separate copyright notices and license terms. Your use of the source
 # code for the these subcomponents is subject to the terms and
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
-
 from setuptools import setup
 
 setup(

--- a/vcd_cli/amqp.py
+++ b/vcd_cli/amqp.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/disk.py
+++ b/vcd_cli/disk.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/extension.py
+++ b/vcd_cli/extension.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/info.py
+++ b/vcd_cli/info.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/login.py
+++ b/vcd_cli/login.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/netpool.py
+++ b/vcd_cli/netpool.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/org.py
+++ b/vcd_cli/org.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/profile.py
+++ b/vcd_cli/profile.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/profiles.py
+++ b/vcd_cli/profiles.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/pvdc.py
+++ b/vcd_cli/pvdc.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/right.py
+++ b/vcd_cli/right.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/role.py
+++ b/vcd_cli/role.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/search.py
+++ b/vcd_cli/search.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/system.py
+++ b/vcd_cli/system.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/task.py
+++ b/vcd_cli/task.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/user.py
+++ b/vcd_cli/user.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/vdc.py
+++ b/vcd_cli/vdc.py
@@ -1,6 +1,6 @@
 # VMware vCloud Director CLI
 #
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -1,6 +1,6 @@
 # vCloud CLI 0.1
 #
-# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").


### PR DESCRIPTION
Updated .py file copyright dates to most recent commit and extended back
in one case to first known commit from git log. Copyright dates follow
earliest-latest date convention.

Reviewers: @sahithi, @anusuyar, @pacogomez, @rdbwebster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/189)
<!-- Reviewable:end -->
