### PR TITLE
VCDA-496: Fix org case insensitive issue

### DIFF
--- a/vcd_cli/vdc.py
+++ b/vcd_cli/vdc.py
@@ -100,12 +100,12 @@ def list_vdc(ctx):
         orgs = client.get_org_list()
         result = []
         for org in [o for o in orgs.Org if hasattr(orgs, 'Org')]:
-            if org.get('name') == in_use_org_name:
+            if org.get('name').lower() == in_use_org_name.lower():
                 resource = client.get_resource(org.get('href'))
                 for v in get_links(resource, media_type=EntityType.VDC.value):
                     result.append({
                         'name': v.name,
-                        'org': in_use_org_name,
+                        'org': org.get('name'),
                         'in_use': in_use_vdc == v.name
                     })
                 break
@@ -124,7 +124,7 @@ def use(ctx, name):
         in_use_org_name = ctx.obj['profiles'].get('org_in_use')
         orgs = client.get_org_list()
         for org in [o for o in orgs.Org if hasattr(orgs, 'Org')]:
-            if org.get('name') == in_use_org_name:
+            if org.get('name').lower() == in_use_org_name.lower():
                 resource = client.get_resource(org.get('href'))
                 for v in get_links(resource, media_type=EntityType.VDC.value):
                     if v.name == name:
@@ -145,7 +145,7 @@ def use(ctx, name):
                             'vapp': vapp_in_use
                         }, ctx, message)
                         return
-        raise Exception('not found')
+        raise Exception('Org \'%s\' not found' % in_use_org_name)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
Some commands like vcd vdc list/use were failing because we don't do case-insensitive org name comparison.
This can happen when we create an Org with uppercase, say ORG1,
login in vcd-cli using lower case( org1) and then try to list the vdc in ORG1.
Since the org_name from the api does not match with the in_use_org we store in the profiles file, we get in the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/192)
<!-- Reviewable:end -->
