### PR TITLE
VCDA-532: Fix requirements.txt to avoid Mac OS X pycryptodome bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click >= 6.7
 colorama >= 0.3.9
 keyring >= 10.6.0
-pycryptodome >= 3.4.7
+# Pycryptodome 3.5.0 does not compile on Mac OS X.
+pycryptodome >= 3.4.7,<3.5
 pyvcloud >= 19.1.1
 tabulate >= 0.7.5


### PR DESCRIPTION
Adjusted requirements.txt to force pycryptodome to be version 3.4.x, as
3.5.0 does not compile on Mac OS X.

Reviewers: @sompa, @sahithi, @rocknes, @anusuyar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/197)
<!-- Reviewable:end -->
