### PR TITLE
Same as pyvcloud PR - fix venv activation command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -123,7 +123,7 @@ Display the version installed:
 It is also possible to install `vcd-cli` in a [virtualenv](https://docs.python.org/3/library/venv.html).  Quick commands to do so:
 ``` shell
     $ python3 -m venv $HOME/my_venv
-    $ . $HOME/my_venv
+    $ . $HOME/my_venv/bin/activate
     (my_venv) $ pip3 install vcd-cli
 ```
 To terminate the virtual environment use the `deactivate` command. In


### PR DESCRIPTION
Same error + fix as my pyvcloud install.md PR today. Fixes the venv activation command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/202)
<!-- Reviewable:end -->
