### PR TITLE
Issue 215: Fixed bug in vcd org delete

### DIFF
--- a/vcd_cli/org.py
+++ b/vcd_cli/org.py
@@ -182,7 +182,8 @@ def delete(ctx, name, recursive, force):
     try:
         restore_session(ctx)
         client = ctx.obj['client']
-        system = System(client)
+        sys_admin_resource = client.get_admin()
+        system = System(client, admin_resource=sys_admin_resource)
         if force and recursive:
             click.confirm(
                 'Do you want to force delete \'%s\' and all '


### PR DESCRIPTION
Fixed org.py to instantiate pyvcloud System with required admin_resource
argument.  This appears to have been missed in an earlier pass to clean up
instantiation errors on the System class. 

Reviewers: @anusuyar, @sompa 
