### PR TITLE
Added additional logic in user creation command to check password length

### DIFF
--- a/vcd_cli/user.py
+++ b/vcd_cli/user.py
@@ -161,6 +161,8 @@ def create(ctx, user_name, password, role_name, full_name, description, email,
            alert_email_prefix, external, default_cached, group_role,
            stored_vm_quota, deployed_vm_quota):
     try:
+        if len(password) < 6:
+            raise Exception('Password must be at least 6 characters long.')
         restore_session(ctx)
         client = ctx.obj['client']
         in_use_org_href = ctx.obj['profiles'].get('org_href')

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -45,7 +45,7 @@ LOGGER.addHandler(logging.FileHandler('vcd.log'))
 
 def is_sysadmin(ctx):
     org_name = ctx.obj['profiles'].get('org')
-    return org_name == 'System'
+    return org_name.lower() == 'system'
 
 
 def as_table(obj_list,


### PR DESCRIPTION
* Added logic in user creation command to throw appropriate exception if password length is not adequate.
* Also fixed a small case related issue in is_sysadmin() function.

Testing done: Ran command manually to see the exception in action.

(vcd-cli) c:\code\vcd-cli\vcd_cli>vcd user create test test "vApp Author"
Usage: vcd user create [OPTIONS] <user_name> <password> <role-name>

Error: Password must be atleast 6 characters long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/217)
<!-- Reviewable:end -->
