### PR TITLE
VCDA-525: vcd catalog acl list returns columns in random order

### DIFF
--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -531,7 +531,6 @@ def list_acl(ctx, catalog_name):
         stdout(
             access_settings_to_list(acl,
                                     ctx.obj['profiles'].get('org_in_use')),
-            ctx,
-            sort_headers=False)
+            ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -1070,7 +1070,6 @@ def list_acl(ctx, vapp_name):
         stdout(
             access_settings_to_list(acl,
                                     ctx.obj['profiles'].get('org_in_use')),
-            ctx,
-            sort_headers=False)
+            ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vdc.py
+++ b/vcd_cli/vdc.py
@@ -462,7 +462,6 @@ def list_acl(ctx, vdc_name):
         stdout(
             access_settings_to_list(acl,
                                     ctx.obj['profiles'].get('org_in_use')),
-            ctx,
-            sort_headers=False)
+            ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Not passing sort_headers in the stdout method to avoid the random ordering on headers.