### PR TITLE
[VCDA-603] Fixed 'vcd catalog info' when user can't access ACL settings of the catalog.

### DIFF
--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -105,13 +105,18 @@ def info(ctx, catalog_name, item_name):
         if item_name is None:
             catalog = org.get_catalog(catalog_name)
             result = to_dict(catalog)
+            # We don't have a way to know in advance if a user has access to a
+            # catalog's ACL or not. So we try to retrieve it always. If the
+            # call fails due to permission issues, we silently eat the
+            # exception and exclude ACL settings from the output of the current
+            # command. Users who has access to ACL of the catalog will remain
+            # unaffected. Also any other errors/exceptions will bubble up as
+            # usual.
             try:
                 access_control_settings = access_settings_to_dict(
                     org.get_catalog_access_settings(catalog_name))
                 result.update(access_control_settings)
             except AccessForbiddenException as e:
-                # Users who don't have admin privilege or aren't the owner of
-                # the catalog can't access its ACL settings.
                 pass
         else:
             catalog_item = org.get_catalog_item(catalog_name, item_name)

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -14,6 +14,7 @@ import os
 
 import click
 from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import access_settings_to_dict
 from pyvcloud.vcd.utils import to_dict
@@ -104,9 +105,14 @@ def info(ctx, catalog_name, item_name):
         if item_name is None:
             catalog = org.get_catalog(catalog_name)
             result = to_dict(catalog)
-            access_control_settings = access_settings_to_dict(
-                org.get_catalog_access_settings(catalog_name))
-            result.update(access_control_settings)
+            try:
+                access_control_settings = access_settings_to_dict(
+                    org.get_catalog_access_settings(catalog_name))
+                result.update(access_control_settings)
+            except AccessForbiddenException as e:
+                # Users who don't have admin privilege or aren't the owner of
+                # the catalog can't access it's ACL settings.
+                pass
         else:
             catalog_item = org.get_catalog_item(catalog_name, item_name)
             result = to_dict(catalog_item)

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -111,7 +111,7 @@ def info(ctx, catalog_name, item_name):
                 result.update(access_control_settings)
             except AccessForbiddenException as e:
                 # Users who don't have admin privilege or aren't the owner of
-                # the catalog can't access it's ACL settings.
+                # the catalog can't access its ACL settings.
                 pass
         else:
             catalog_item = org.get_catalog_item(catalog_name, item_name)

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -109,7 +109,7 @@ def info(ctx, catalog_name, item_name):
             # catalog's ACL or not. So we try to retrieve it always. If the
             # call fails due to permission issues, we silently eat the
             # exception and exclude ACL settings from the output of the current
-            # command. Users who has access to ACL of the catalog will remain
+            # command. Users who have access to ACL of the catalog will remain
             # unaffected. Also any other errors/exceptions will bubble up as
             # usual.
             try:


### PR DESCRIPTION
Non admin users who are not owner of a catalog but has viewing rights, can't access the ACL of the catalog.  The command *vcd catalog info* disregards this limitation and tries to retreive the ACL of catalog for all users. This leads to an exception being raised, and such users can never use the command.

As a fix we omit catalog ACL details for users who can't access them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/225)
<!-- Reviewable:end -->
