### PR TITLE
[VCDA-709] CVE-2017-18342 : Replace yaml.load() with yaml.safe_load()

### DIFF
--- a/vcd_cli/profiles.py
+++ b/vcd_cli/profiles.py
@@ -36,7 +36,7 @@ class Profiles(object):
             p = Profiles()
             p.data = {'active': None}
             with open(profile_path, 'r') as f:
-                p.data = yaml.load(f)
+                p.data = yaml.safe_load(f)
         except Exception:
             LOGGER.warning(
                 'Warning: the profiles file \'%s\''


### PR DESCRIPTION
Fix for CVE-2017-18342 http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18342

vcd-cli derives it's dependency on PyYAML from pyvcloud so no explicit action is required in vcd-cli to restrict PyYAML version.
Replaced instances of yaml.load() to yaml.safe_load().

Tried out vcd login command and it worked correctly, thus confirming that yaml.safe_load() hasn't caused any regressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/233)
<!-- Reviewable:end -->
