### PR TITLE
[VCDA-727] Fixed login issue with custom version other than [27.0, 28.0, 29.0, 30.0]

### DIFF
--- a/vcd_cli/login.py
+++ b/vcd_cli/login.py
@@ -50,7 +50,6 @@ from vcd_cli.vcd import vcd
     'api_version',
     required=False,
     metavar=as_metavar(API_CURRENT_VERSIONS),
-    type=click.Choice(API_CURRENT_VERSIONS),
     help='API version')
 @click.option(
     '-s/-i',


### PR DESCRIPTION
We were restricting the values of the flag -V (--version) to the above mentioned values. This stopped the user from specifying a newer api version viz 31.0.

As a fix we have removed the restriction.

Testing done: Tried the following command and it worked fine, the user was logged in
(vcd-cli) C:\code\vcd-cli>vcd login 10.150.200.112 system administrator -i -w -V 31.0
Password:
administrator logged in, org: 'system', vdc: ''

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/237)
<!-- Reviewable:end -->
