### PR TITLE
[VCDA-549] Fix query service to handle special characters in filter values

### DIFF
--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -14,6 +14,7 @@ import os
 
 import click
 from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import access_settings_to_dict
@@ -171,8 +172,10 @@ def list_catalogs_or_items(ctx, catalog_name):
             result = org.list_catalogs()
         else:
             result = []
-            resource_type = \
-                'adminCatalogItem' if is_sysadmin(ctx) else 'catalogItem'
+            if is_sysadmin(ctx):
+                resource_type = ResourceType.ADMIN_CATALOG_ITEM.value
+            else:
+                resource_type = ResourceType.CATALOG_ITEM.value
             q = client.get_typed_query(
                 resource_type,
                 query_result_format=QueryResultFormat.ID_RECORDS,

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -176,7 +176,7 @@ def list_catalogs_or_items(ctx, catalog_name):
             q = client.get_typed_query(
                 resource_type,
                 query_result_format=QueryResultFormat.ID_RECORDS,
-                qfilter='catalogName==%s' % catalog_name)
+                equality_filter=('catalogName', catalog_name))
             records = list(q.execute())
             if len(records) == 0:
                 result = 'not found'

--- a/vcd_cli/info.py
+++ b/vcd_cli/info.py
@@ -72,7 +72,7 @@ def info(ctx, resource_type, resource_id):
         q = client.get_typed_query(
             to_camel_case(resource_type, RESOURCE_TYPES),
             query_result_format=QueryResultFormat.REFERENCES,
-            qfilter='id==%s' % resource_id)
+            equality_filter=('id', resource_id))
         records = list(q.execute())
         if len(records) == 0:
             raise Exception('not found')

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -242,11 +242,11 @@ def list_vapps(ctx, name):
         result = []
         if name is None:
             resource_type = 'adminVApp' if is_sysadmin(ctx) else 'vApp'
-            qfilter = None
+            name_filter = None
             attributes = None
         else:
             resource_type = 'adminVm' if is_sysadmin(ctx) else 'vm'
-            qfilter = 'containerName==%s' % name
+            name_filter = ('containerName', name)
             attributes = [
                 'name', 'containerName', 'ipAddress', 'status', 'memoryMB',
                 'numberOfCpus'
@@ -254,7 +254,7 @@ def list_vapps(ctx, name):
         q = client.get_typed_query(
             resource_type,
             query_result_format=QueryResultFormat.ID_RECORDS,
-            qfilter=qfilter)
+            equality_filter=name_filter)
         records = list(q.execute())
         if len(records) == 0:
             result = 'not found'

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -14,6 +14,7 @@
 
 import click
 from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.utils import access_settings_to_dict
 from pyvcloud.vcd.utils import to_dict
@@ -241,11 +242,17 @@ def list_vapps(ctx, name):
         client = ctx.obj['client']
         result = []
         if name is None:
-            resource_type = 'adminVApp' if is_sysadmin(ctx) else 'vApp'
+            if is_sysadmin(ctx):
+                resource_type = ResourceType.ADMIN_VAPP.value
+            else:
+                resource_type = ResourceType.VAPP.value
             name_filter = None
             attributes = None
         else:
-            resource_type = 'adminVm' if is_sysadmin(ctx) else 'vm'
+            if is_sysadmin(ctx):
+                resource_type = ResourceType.ADMIN_VM.value
+            else:
+                resource_type = ResourceType.VM.value
             name_filter = ('containerName', name)
             attributes = [
                 'name', 'containerName', 'ipAddress', 'status', 'memoryMB',
@@ -257,7 +264,10 @@ def list_vapps(ctx, name):
             equality_filter=name_filter)
         records = list(q.execute())
         if len(records) == 0:
-            result = 'not found'
+            if name is None:
+                result = 'No vApps were found.'
+            else:
+                result = 'No vms were found.'
         else:
             for r in records:
                 result.append(


### PR DESCRIPTION
As a fallout of https://github.com/vmware/pyvcloud/pull/282, we need to make sure that we url encode filter values properly in vcd-cli.

Changed qfilter to equality_filter wherever possible, since equality_filter url-encodes the value properly.

Tested the following commands to make sure that no regressions were introduced
vcd catalog list <cat-name>
vcd info adminVApp <vapp-id>
vcd vapp list
vcd vapp list <vapp-name>

Also replaced hard-coded strings to their ResourceType enum counterpart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/239)
<!-- Reviewable:end -->
