### PR TITLE
[VCDA-760] Fix logging of REST calls made on behalf of vcd-cli commands.

### DIFF
--- a/vcd_cli/login.py
+++ b/vcd_cli/login.py
@@ -192,9 +192,9 @@ def login(ctx, user, host, password, api_version, org, verify_ssl_certs,
             vdc=in_use_vdc,
             org_href=org_href,
             vdc_href=vdc_href,
-            log_request=profiles.get('log_request', default=False),
-            log_header=profiles.get('log_header', default=False),
-            log_body=profiles.get('log_body', default=False),
+            log_request=True,
+            log_header=True,
+            log_body=True,
             vapp='',
             vapp_href='')
         alt_text = '%s logged in, org: \'%s\', vdc: \'%s\'' % \


### PR DESCRIPTION
Due to the way we were writing few booleans that control logging of requests to the profiles.yaml file, vcd-cli wasn't logging any backend requests. As a fix we made sure that the correct values are being written to profiles.yaml.

Ran few vcd-cli commands and made sure that all related REST calls were getting logged properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/242)
<!-- Reviewable:end -->
