### PR TITLE
[VCDA-762] Fix confusing error message when non admin users invoke vcd system extension commands

### DIFF
--- a/vcd_cli/extension.py
+++ b/vcd_cli/extension.py
@@ -14,6 +14,7 @@
 
 import click
 from pyvcloud.vcd.api_extension import APIExtension
+from pyvcloud.vcd.exceptions import OperationNotSupportedException
 
 from vcd_cli.system import system
 from vcd_cli.utils import restore_session
@@ -53,6 +54,8 @@ def list(ctx):
         restore_session(ctx)
         ext = APIExtension(ctx.obj['client'])
         stdout(ext.list_extensions(), ctx)
+    except OperationNotSupportedException as e:
+        stderr('User doesn\'t have permission to view extensions.', ctx)
     except Exception as e:
         stderr(e, ctx)
 
@@ -66,6 +69,8 @@ def info(ctx, name, namespace):
         restore_session(ctx)
         ext = APIExtension(ctx.obj['client'])
         stdout(ext.get_extension_info(name, namespace), ctx)
+    except OperationNotSupportedException as e:
+        stderr('User doesn\'t have permission to view extensions.', ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/extension.py
+++ b/vcd_cli/extension.py
@@ -14,7 +14,6 @@
 
 import click
 from pyvcloud.vcd.api_extension import APIExtension
-from pyvcloud.vcd.exceptions import OperationNotSupportedException
 
 from vcd_cli.system import system
 from vcd_cli.utils import restore_session
@@ -54,8 +53,6 @@ def list(ctx):
         restore_session(ctx)
         ext = APIExtension(ctx.obj['client'])
         stdout(ext.list_extensions(), ctx)
-    except OperationNotSupportedException as e:
-        stderr('User doesn\'t have permission to view extensions.', ctx)
     except Exception as e:
         stderr(e, ctx)
 
@@ -69,8 +66,6 @@ def info(ctx, name, namespace):
         restore_session(ctx)
         ext = APIExtension(ctx.obj['client'])
         stdout(ext.get_extension_info(name, namespace), ctx)
-    except OperationNotSupportedException as e:
-        stderr('User doesn\'t have permission to view extensions.', ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -30,7 +30,6 @@ from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import AccessForbiddenException
-from pyvcloud.vcd.exceptions import MissingRecordException
 from pyvcloud.vcd.exceptions import RequestTimeoutException
 from pyvcloud.vcd.exceptions import UnauthorizedException
 from pyvcloud.vcd.utils import extract_id
@@ -257,8 +256,6 @@ def stderr(exception, ctx=None):
     elif type(exception) == RequestTimeoutException:
         message = 'The server timed out waiting for the request, ' \
                   'please check your connection.'
-    elif type(exception) == MissingRecordException:
-        message = 'Record not found.'
     elif hasattr(exception, 'message'):
         message = exception.message
     else:


### PR DESCRIPTION
The real fix has been made in pyvcloud https://github.com/vmware/pyvcloud/pull/288 .
Removing some exception handling while writing message to click.echo() to let the real exception message bubble up.

Tested the vcd-cli commands 
vcd system extension list
vcd system extension info <bogus service>
and verified that after the change, proper error messages are displayed for both sys admin and non sys admin users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/243)
<!-- Reviewable:end -->
