### PR TITLE
[VCDA-756] Limit keyring version to 12.0.0 to avoid installation failures on linux.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click >= 6.7
 colorama >= 0.3.9
-keyring >= 10.6.0
+keyring >= 10.6.0, <= 12.0.0
 # Pycryptodome 3.5.0 does not compile on Mac OS X.
 pycryptodome >= 3.4.7,<3.5
 pyvcloud >= 19.3.0


### PR DESCRIPTION
Updated requirements.txt to limit version of keyring module to 12.0.0. Latest version of keyring module is causing installation failure on linux machines.

Tested on Windows, Linux, Mac and made sure that installation + commands work fine on these systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/244)
<!-- Reviewable:end -->
