### PR TITLE
[VCDA-761] Fix command vcd login session list chrome for Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ colorama >= 0.3.9
 keyring >= 10.6.0, <= 12.0.0
 # Pycryptodome 3.5.0 does not compile on Mac OS X.
 pycryptodome >= 3.4.7,<3.5
-pypiwin32 >= 223
+pypiwin32 >= 223;platform_system=="Windows"
 pyvcloud >= 19.3.0
 tabulate >= 0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ colorama >= 0.3.9
 keyring >= 10.6.0, <= 12.0.0
 # Pycryptodome 3.5.0 does not compile on Mac OS X.
 pycryptodome >= 3.4.7,<3.5
+pypiwin32 >= 223
 pyvcloud >= 19.3.0
 tabulate >= 0.7.5

--- a/vcd_cli/browsercookie/__init__.py
+++ b/vcd_cli/browsercookie/__init__.py
@@ -136,7 +136,7 @@ class Chrome(BrowserCookieLoader):
                     host, path, secure, expires, name = item[:5]
                     try:
                         # Any error around creating the cookie oject or
-                        # decrypting it's value will cause the exception
+                        # decrypting its value will cause the exception
                         # error message to be printed out on the console.
                         # However the exception shouldn't halt the whole
                         # process, and we should continue processing rest of

--- a/vcd_cli/browsercookie/__init__.py
+++ b/vcd_cli/browsercookie/__init__.py
@@ -1,36 +1,28 @@
 # -*- coding: utf-8 -*-
 __doc__ = 'Load browser cookies into a cookiejar'
 
+import configparser
+from contextlib import contextmanager
+import glob
+import http.cookiejar as cookielib
+import json
 import os
 import sys
-import time
-import glob
-try:
-    import cookielib
-except ImportError:
-    import http.cookiejar as cookielib
-from contextlib import contextmanager
 import tempfile
-try:
-    import json
-except ImportError:
-    import simplejson as json
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+import time
 
 try:
     # should use pysqlite2 to read the cookies.sqlite on Windows
-    # otherwise will raise the "sqlite3.DatabaseError: file is encrypted or is not a database" exception
+    # otherwise will raise the "sqlite3.DatabaseError: file is encrypted or  is
+    # not a database" exception
     from pysqlite2 import dbapi2 as sqlite3
 except ImportError:
     import sqlite3
 
-import keyring
-from keyring import backend
-from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Cipher import AES
+from Crypto.Protocol.KDF import PBKDF2
+from keyring import backend
+
 
 class BrowserCookieError(Exception):
     pass
@@ -38,9 +30,16 @@ class BrowserCookieError(Exception):
 
 @contextmanager
 def create_local_copy(cookie_file):
-    """Make a local copy of the sqlite cookie database and return the new filename.
-    This is necessary in case this database is still being written to while the user browses
-    to avoid sqlite locking errors.
+    """Make a local copy of the sqlite cookie database.
+
+    This is necessary in case this database is still being written to while the
+    user browses to avoid sqlite locking errors.
+
+    :return: the copied database
+
+    :rtpe: object (is always a file-like object)
+
+    :raises: BrowserCookieError: if the cookie file can't be located.
     """
     # check if cookie file exists
     if os.path.exists(cookie_file):
@@ -60,15 +59,18 @@ class BrowserCookieLoader(object):
         self.cookie_files = list(cookie_files)
 
     def find_cookie_files(self):
-        '''Return a list of cookie file locations valid for this loader'''
+        """Return a list of cookie file locations valid for this loader."""
         raise NotImplementedError
 
     def get_cookies(self):
-        '''Return all cookies (May include duplicates from different sources)'''
+        """Return all cookies.
+
+        May include duplicates from different sources.
+        """
         raise NotImplementedError
 
     def load(self):
-        '''Load cookies into a cookiejar'''
+        """Load cookies into a cookiejar."""
         cookie_jar = cookielib.CookieJar()
         for cookie in self.get_cookies():
             cookie_jar.set_cookie(cookie)
@@ -81,12 +83,14 @@ class Chrome(BrowserCookieLoader):
 
     def find_cookie_files(self):
         for pattern in [
-            os.path.expanduser('~/Library/Application Support/Google/Chrome/Default/Cookies'),
+            os.path.expanduser('~/Library/Application Support/Google/Chrome/'
+                               'Default/Cookies'),
             os.path.expanduser('~/.config/chromium/Default/Cookies'),
             os.path.expanduser('~/.config/chromium/Profile */Cookies'),
             os.path.expanduser('~/.config/google-chrome/Default/Cookies'),
             os.path.expanduser('~/.config/google-chrome/Profile */Cookies'),
-            os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Default\Cookies'),
+            os.path.join(os.getenv('APPDATA', ''),
+                         r'..\Local\Google\Chrome\User Data\Default\Cookies'),
         ]:
             for result in glob.glob(pattern):
                 yield result
@@ -105,7 +109,7 @@ class Chrome(BrowserCookieLoader):
                         iterations = 1003
                         key = PBKDF2(my_pass, salt, length, iterations)
                         break
-                except:
+                except Exception as e:
                     pass
 
         elif sys.platform.startswith('linux'):
@@ -117,25 +121,27 @@ class Chrome(BrowserCookieLoader):
         elif sys.platform == 'win32':
             key = None
         else:
-            raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
+            raise BrowserCookieError('Unsupported operating system: ' +
+                                     sys.platform)
 
         for cookie_file in self.cookie_files:
             with create_local_copy(cookie_file) as tmp_cookie_file:
                 con = sqlite3.connect(tmp_cookie_file)
                 cur = con.cursor()
-                cur.execute('SELECT host_key, path, secure, expires_utc, name, value, encrypted_value FROM cookies;')
+                cur.execute('SELECT host_key, path, is_secure, expires_utc, '
+                            'name, value, encrypted_value FROM cookies;')
                 for item in cur.fetchall():
                     host, path, secure, expires, name = item[:5]
                     try:
                         value = self._decrypt(item[5], item[6], key=key)
-                        yield create_cookie(host, path, secure, expires, name, value)
-                    except:
-                        pass
+                        yield create_cookie(host, path, secure, expires, name,
+                                            value)
+                    except Exception as e:
+                        print(e)
                 con.close()
 
     def _decrypt(self, value, encrypted_value, key):
-        """Decrypt encoded cookies
-        """
+        """Decrypt encoded cookies."""
         if (sys.platform == 'darwin') or sys.platform.startswith('linux'):
             if value or (encrypted_value[:3] != b'v10'):
                 return value
@@ -158,12 +164,14 @@ class Chrome(BrowserCookieLoader):
             decrypted = cipher.decrypt(encrypted_value)
             return clean(decrypted)
         else:
-            #Must be win32 (on win32, all chrome cookies are encrypted)
+            # Must be win32 (on win32, all chrome cookies are encrypted)
             try:
                 import win32crypt
             except ImportError:
-                raise BrowserCookieError('win32crypt must be available to decrypt Chrome cookie on Windows')
-            return win32crypt.CryptUnprotectData(encrypted_value, None, None, None, 0)[1].decode("utf-8")
+                raise BrowserCookieError('win32crypt must be available to '
+                                         'decrypt Chrome cookie on Windows')
+            return win32crypt.CryptUnprotectData(encrypted_value, None, None,
+                                                 None, 0)[1].decode("utf-8")
 
 
 class Firefox(BrowserCookieLoader):
@@ -177,7 +185,8 @@ class Firefox(BrowserCookieLoader):
             if cp.has_option(section, 'Default'):
                 try:
                     if cp.getboolean(section, 'IsRelative'):
-                        path = os.path.dirname(profile) + '/' + cp.get(section, 'Path')
+                        path = os.path.dirname(profile) + '/' +\
+                            cp.get(section, 'Path')
                     else:
                         path = cp.get(section, 'Path')
                     return os.path.abspath(os.path.expanduser(path))
@@ -187,13 +196,17 @@ class Firefox(BrowserCookieLoader):
 
     def find_default_profile(self):
         if sys.platform == 'darwin':
-            return glob.glob(os.path.expanduser('~/Library/Application Support/Firefox/profiles.ini'))
+            return glob.glob(os.path.expanduser('~/Library/Application Support'
+                                                '/Firefox/profiles.ini'))
         elif sys.platform.startswith('linux'):
-            return glob.glob(os.path.expanduser('~/.mozilla/firefox/profiles.ini'))
+            return glob.glob(os.path.expanduser('~/.mozilla/firefox/profiles'
+                                                '.ini'))
         elif sys.platform == 'win32':
-            return glob.glob(os.path.join(os.getenv('APPDATA', ''), 'Mozilla/Firefox/profiles.ini'))
+            return glob.glob(os.path.join(os.getenv('APPDATA', ''),
+                             'Mozilla/Firefox/profiles.ini'))
         else:
-            raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
+            raise BrowserCookieError('Unsupported operating system: ' +
+                                     sys.platform)
 
     def find_cookie_files(self):
         profile = self.find_default_profile()
@@ -201,7 +214,8 @@ class Firefox(BrowserCookieLoader):
             raise BrowserCookieError('Could not find default Firefox profile')
         path = self.parse_profile(profile[0])
         if not path:
-            raise BrowserCookieError('Could not find path to default Firefox profile')
+            raise BrowserCookieError('Could not find path to default Firefox'
+                                     'profile')
         cookie_files = glob.glob(os.path.expanduser(path + '/cookies.sqlite'))
         if cookie_files:
             return cookie_files
@@ -213,48 +227,56 @@ class Firefox(BrowserCookieLoader):
             with create_local_copy(cookie_file) as tmp_cookie_file:
                 con = sqlite3.connect(tmp_cookie_file)
                 cur = con.cursor()
-                cur.execute('select host, path, isSecure, expiry, name, value from moz_cookies')
+                cur.execute('select host, path, isSecure, expiry, name, value '
+                            'from moz_cookies')
 
                 for item in cur.fetchall():
                     yield create_cookie(*item)
                 con.close()
 
                 # current sessions are saved in sessionstore.js
-                session_file = os.path.join(os.path.dirname(cookie_file), 'sessionstore.js')
+                session_file = os.path.join(os.path.dirname(cookie_file),
+                                            'sessionstore.js')
                 if os.path.exists(session_file):
                     try:
-                        json_data = json.loads(open(session_file, 'rb').read().decode('utf-8'))
+                        json_data = json.loads(
+                            open(session_file, 'rb').read().decode('utf-8'))
                     except ValueError as e:
                         print('Error parsing firefox session JSON:', str(e))
                     else:
                         expires = str(int(time.time()) + 3600 * 24 * 7)
                         for window in json_data.get('windows', []):
                             for cookie in window.get('cookies', []):
-                                yield create_cookie(cookie.get('host', ''), cookie.get('path', ''), False, expires, cookie.get('name', ''), cookie.get('value', ''))
+                                yield create_cookie(cookie.get('host', ''),
+                                                    cookie.get('path', ''),
+                                                    False,
+                                                    expires,
+                                                    cookie.get('name', ''),
+                                                    cookie.get('value', ''))
                 else:
-                    print('Firefox session filename does not exist:', session_file)
+                    print('Firefox session filename does not exist:',
+                          session_file)
 
 
 def create_cookie(host, path, secure, expires, name, value):
-    """Shortcut function to create a cookie
-    """
-    return cookielib.Cookie(0, name, value, None, False, host, host.startswith('.'), host.startswith('.'), path, True, secure, expires, False, None, None, {})
+    """Shortcut function to create a cookie."""
+    return cookielib.Cookie(0, name, value, None, False, host,
+                            host.startswith('.'), host.startswith('.'),
+                            path, True, secure, expires, False, None, None, {})
 
 
 def chrome(cookie_file=None):
-    """Returns a cookiejar of the cookies used by Chrome
-    """
+    """Returns a cookiejar of the cookies used by Chrome."""
     return Chrome(cookie_file).load()
 
 
 def firefox(cookie_file=None):
-    """Returns a cookiejar of the cookies and sessions used by Firefox
-    """
+    """Returns a cookiejar of the cookies and sessions used by Firefox."""
     return Firefox(cookie_file).load()
 
 
 def _get_cookies():
-    '''Return all cookies from all browsers'''
+    """Return all cookies from all browsers."""
     for klass in [Chrome, Firefox]:
         try:
             for cookie in klass().get_cookies():
@@ -264,7 +286,11 @@ def _get_cookies():
 
 
 def load():
-    """Try to load cookies from all supported browsers and return combined cookiejar
+    """Try to load cookies from all supported browsers.
+
+    :return: combined cookiejar
+
+    :rtype: cookielib.CookieJar
     """
     cookie_jar = cookielib.CookieJar()
 


### PR DESCRIPTION
The command was broken because 
1. one of the internal queries to the cookie sqllite file was using a wrong filed name viz secure while it should have been is_secure.
2. the module win32crypt required to decrypt cookie values on Windows was missing from our requirements list.

As a fix, the correct column name has been used in the query and a dependency on pywin32 (provides win32crypt module) has been added only for windows installations. the module doesn't exist for OSX or linux.

Also fixed flake8 errors in the file browsercookie\__init__.py

Testing done : On Windows and Mac, we installed a fresh copy of vcd-cli with the fix and made sure
1. the installation succeeded without any issue 
2. we were able to run the affected command without any errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/246)
<!-- Reviewable:end -->
