### PR TITLE
[VP-1147, VP-1148] : Implement commands to create and delete external networks.

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -52,9 +52,9 @@ class Test(BaseTestCase):
         """Load configuration and create a click runner to invoke CLI."""
         self._config = Environment.get_config()
         self._logger = Environment.get_default_logger()
-        self._sys_admin_client = Environment.get_sys_admin_client()
 
         self._runner = CliRunner()
+        self._login()
 
     def tearDown(self):
         """Logout ignoring any errors to ensure test session is gone."""
@@ -89,7 +89,8 @@ class Test(BaseTestCase):
         """
         vc_name = self._config['vc']['vcenter_host_name']
         name_filter = ('vcName', vc_name)
-        query = self._sys_admin_client.get_typed_query(
+        sys_admin_client = Environment.get_sys_admin_client()
+        query = sys_admin_client.get_typed_query(
             ResourceType.PORT_GROUP.value,
             query_result_format=QueryResultFormat.RECORDS,
             equality_filter=name_filter)
@@ -103,7 +104,6 @@ class Test(BaseTestCase):
         self.assertIsNotNone(
             self._port_group, 'None of the port groups are free.')
 
-        self._login()
         result = self._runner.invoke(
             external,
             args=[
@@ -120,6 +120,5 @@ class Test(BaseTestCase):
 
             Invoke the command 'external delete' in network.
         """
-        self._login()
         result = self._runner.invoke(external, args=['delete', self._name])
         self.assertEqual(0, result.exit_code)

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -26,7 +26,7 @@ from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import ResourceType
 
 
-class Test(BaseTestCase):
+class ExtNetTest(BaseTestCase):
     """Test external network related commands
 
     Tests cases in this module do not have ordering dependencies,

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -1,0 +1,121 @@
+# VMware vCloud Director vCD CLI
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid1
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+
+from vcd_cli.login import login, logout
+from vcd_cli.network import external
+
+from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
+
+
+class Test(BaseTestCase):
+    """Test external network related commands
+
+    Tests cases in this module do not have ordering dependencies,
+    so setup is accomplished using Python unittest setUp and tearDown
+    methods.
+
+    Be aware that this test will delete existing vcd-cli sessions.
+    """
+
+    # All tests in this module should run as System Administrator.
+    _sys_admin_client = None
+    _name = 'external_network_' + str(uuid1())
+    _description = 'Description of external_network_' + str(uuid1())
+    _port_group = None
+    _gateway = '10.20.30.1'
+    _netmask = '255.255.255.0'
+    _ip_range = '10.20.30.2-10.20.30.99'
+    _dns1 = '8.8.8.8'
+    _dns2 = '8.8.8.9'
+    _dns_suffix = 'example.com'
+
+    def setUp(self):
+        """Load configuration and create a click runner to invoke CLI."""
+        self._config = Environment.get_config()
+        self._logger = Environment.get_default_logger()
+        self._sys_admin_client = Environment.get_sys_admin_client()
+
+        self._runner = CliRunner()
+
+    def tearDown(self):
+        """Logout ignoring any errors to ensure test session is gone."""
+        self._logout()
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = self._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        self._runner.invoke(logout)
+
+    def test_0010_create(self):
+        """Create an external network as per configuration stated above.
+
+            Invoke the command 'external create' in network.
+        """
+        vc_name = self._config['vc']['vcenter_host_name']
+        name_filter = ('vcName', vc_name)
+        query = self._sys_admin_client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+
+        for record in list(query.execute()):
+            if record.get('networkName') == '--':
+                if not record.get('name').startswith('vxw-'):
+                    self._port_group = record.get('name')
+                    break
+
+        self.assertFalse(self._port_group is None,
+                         'None of the port groups are free.')
+
+        self._login()
+        result = self._runner.invoke(
+            external,
+            args=[
+                'create', self._name, vc_name, '--port-group',
+                self._port_group, '--gateway', self._gateway, '--netmask',
+                self._netmask, '--ip-range', self._ip_range, '--description',
+                self._description, '--dns1', self._dns1, '--dns2', self._dns2,
+                '--dns-suffix', self._dns_suffix
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0010_delete(self):
+        """Delete the external network created.
+
+            Invoke the command 'external delete' in network.
+        """
+        self._login()
+        result = self._runner.invoke(external, args=['delete', self._name])
+        self.assertEqual(0, result.exit_code)

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -81,7 +81,11 @@ class Test(BaseTestCase):
     def test_0010_create(self):
         """Create an external network as per configuration stated above.
 
-            Invoke the command 'external create' in network.
+        Choose first unused port group which is not a VxLAN. Unused port groups
+        have network names set to '--'. VxLAN port groups have name starting
+        with 'vxw-'.
+
+        Invoke the command 'external create' in network.
         """
         vc_name = self._config['vc']['vcenter_host_name']
         name_filter = ('vcName', vc_name)
@@ -96,8 +100,8 @@ class Test(BaseTestCase):
                     self._port_group = record.get('name')
                     break
 
-        self.assertFalse(self._port_group is None,
-                         'None of the port groups are free.')
+        self.assertIsNotNone(
+            self._port_group, 'None of the port groups are free.')
 
         self._login()
         result = self._runner.invoke(

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -10,15 +10,15 @@
 # code for the these subcomponents is subject to the terms and
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 
-# Script to run all tests. 
+# Script to run all tests.
 #
 # Usage: ./run_system_tests.sh [test1.py test2.py ...]
 #
 # If you give test names we'll run them.  Otherwise it defaults
-# to the current stable tests. 
+# to the current stable tests.
 #
-# The script requires a vcd_connection file which defaults to 
-# $HOME/vcd_connection.  See vcd_connection.sample for an example. 
+# The script requires a vcd_connection file which defaults to
+# $HOME/vcd_connection.  See vcd_connection.sample for an example.
 # You can also set it in the VCD_CONNECTION environmental variable.
 #
 set -e
@@ -28,8 +28,9 @@ SCRIPT_DIR=`pwd`
 SRCROOT=`cd ..; pwd`
 cd $SRCROOT
 
-# If there are tests to run use those. Otherwise use stable tests. 
+# If there are tests to run use those. Otherwise use stable tests.
 STABLE_TESTS="login_and_vcd_tests.py \
+extnet_tests.py \
 org_tests.py"
 
 if [ $# == 0 ]; then
@@ -39,7 +40,7 @@ else
   TESTS=$*
 fi
 
-# Get connection information.  
+# Get connection information.
 if [ -z "$VCD_CONNECTION" ]; then
   VCD_CONNECTION=$HOME/vcd_connection
 fi
@@ -52,9 +53,9 @@ else
 fi
 . "$VCD_CONNECTION"
 
-# Prepare a test parameter file. We'll use sed to replace values and create 
+# Prepare a test parameter file. We'll use sed to replace values and create
 # a new file.  Note that some environmental variables may not be set in which
-# case the corresponding parameter will end up an empty string. 
+# case the corresponding parameter will end up an empty string.
 auto_base_config=$SRCROOT/auto.base_config.yaml
 sed -e "s/<vcd ip>/${VCD_HOST}/" \
 -e "s/30.0/${VCD_API_VERSION}/" \
@@ -73,7 +74,7 @@ fi
 
 cd system_tests
 
-# Run the tests with the new file. From here on out all commands are logged. 
+# Run the tests with the new file. From here on out all commands are logged.
 set -x
 export VCD_TEST_BASE_CONFIG_FILE=${auto_base_config}
 python3 -m unittest $TESTS -v

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -363,7 +363,7 @@ def create_external_network(ctx, name, vc_name, port_group, gateway_ip,
             secondary_dns_ip=secondary_dns_ip,
             dns_suffix=dns_suffix)
 
-        stdout(ext_net.find('vcloud:Tasks', NSMAP).Task[0], ctx)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
         stdout('External network created successfully.', ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -43,17 +43,17 @@ def external(ctx):
         Only System Administrators can work with external networks.
 
 \b
-        vcd network external create external-net1 vc1 \\
-                --port-group 'pg1' \\
-                --port-group 'pg2' \\
-                --gateway-ip 192.168.1.1 \\
-                --netmask 255.255.255.0 \\
-                --ip-range 192.168.1.2-192.168.1.49 \\
-                --ip-range 192.168.1.100-192.168.1.149 \\
-                --description 'External network' \\
-                --primary-dns-ip 8.8.8.8 \\
-                --secondary-dns-ip 8.8.8.9 \\
-                --dns-suffix example.com \\
+        vcd network external create external-net1 vc1
+                --port-group 'pg1'
+                --port-group 'pg2'
+                --gateway-ip 192.168.1.1
+                --netmask 255.255.255.0
+                --ip-range 192.168.1.2-192.168.1.49
+                --ip-range 192.168.1.100-192.168.1.149
+                --description 'External network'
+                --primary-dns-ip 8.8.8.8
+                --secondary-dns-ip 8.8.8.9
+                --dns-suffix example.com
             Create an external network.
                 Parameters --port-group and --ip-range are both
                 required parameters and each can have multiple entries.


### PR DESCRIPTION
Implementation of create and delete external network commands.

Adding 'create' & 'delete' commands to 'external' group. External network can be created by command: 'vcd network external create [OPTIONS]'. It can be deleted by command: 'vcd network external delete '. 

Testing done:
Test cases for create and delete are added to a new test class, extnet_tests. 
All tests in extnet_tests passed.

@ckolovson @rocknes @rajeshk2013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/257)
<!-- Reviewable:end -->
