### PR TITLE
[VP-1184, VP-1201] Provided command line support for convert to advanced gateway and enable distributed routing

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -220,7 +220,7 @@ class GatewayTest(BaseTestCase):
                                                       args=[
                                                 'enable-distributed-routing',
                                                 'test_gateway1',
-                                            '--distributed-routing-enabled'])
+                                                '--enable'])
         self.assertEqual(0, result_advanced_gateway.exit_code)
 
 

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -20,7 +20,7 @@ from pyvcloud.vcd.platform import Platform
 
 
 class GatewayTest(BaseTestCase):
-    """Test gateway related commandsl
+    """Test gateway related commands
 
         Be aware that this test will delete existing vcd-cli sessions.
         """
@@ -224,7 +224,7 @@ class GatewayTest(BaseTestCase):
         self.assertEqual(0, result_advanced_gateway.exit_code)
 
 
-    def test_0008_tearDown(self):
+    def test_0098_tearDown(self):
         result_delete = self._runner.invoke(gateway, args=['delete',
                                                            'test_gateway1'])
         self.assertEqual(0, result_delete.exit_code)

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -20,7 +20,7 @@ from pyvcloud.vcd.platform import Platform
 
 
 class GatewayTest(BaseTestCase):
-    """Test gateway related commands
+    """Test gateway related commandsl
 
         Be aware that this test will delete existing vcd-cli sessions.
         """
@@ -152,27 +152,7 @@ class GatewayTest(BaseTestCase):
         self.assertEqual(0, result_create3.exit_code)
         self._delete_gateway()
 
-    def test_0004_create_gateway_with_configure_rate_limit(self):
-        """Create gateway with options --configure-rate-limit.
-
-        It will delete the gateway after creation
-        """
-        result_create4 = GatewayTest._runner.invoke(
-            gateway,
-            args=[
-                'create', self._name, '-e', GatewayTest._ext_network_name,
-                '--configure-rate-limit', GatewayTest._ext_network_name, 100,
-                101
-            ])
-        GatewayTest._logger.debug("vcd gateway create <name> -e <ext nw> "
-                                  "--configure-rate-limit', {0}, 100, "
-                                  "101]: {1}".format(
-                                      GatewayTest._ext_network_name,
-                                      result_create4.output))
-        self.assertEqual(0, result_create4.exit_code)
-        self._delete_gateway()
-
-    def test_0005_create_gateway_with_default_gateway_and_dns_relay_enabled(
+    def test_0004_create_gateway_with_default_gateway_and_dns_relay_enabled(
             self):
         """Create gateway with options --default-gateway --default-gw-ip
         --dns-relay-enabled --advanced-enabled.
@@ -196,11 +176,57 @@ class GatewayTest(BaseTestCase):
         self.assertEqual(0, result_create5.exit_code)
         self._delete_gateway()
 
+    def test_0005_create_gateway_with_configure_rate_limit(self):
+        """Create gateway with options --configure-rate-limit.
+
+        It will delete the gateway after creation
+        """
+        result_create4 = GatewayTest._runner.invoke(
+            gateway,
+            args=[
+                'create', self._name, '-e', GatewayTest._ext_network_name,
+                '--configure-rate-limit', GatewayTest._ext_network_name, 100,
+                101
+            ])
+        GatewayTest._logger.debug("vcd gateway create <name> -e <ext nw> "
+                                  "--configure-rate-limit', {0}, 100, "
+                                  "101]: {1}".format(
+                                      GatewayTest._ext_network_name,
+                                      result_create4.output))
+        self.assertEqual(0, result_create4.exit_code)
+
     def _delete_gateway(self):
         result_delete1 = GatewayTest._runner.invoke(
             gateway, args=['delete', self._name])
         self.assertEqual(0, result_delete1.exit_code)
 
-    def test_0006_tearDown(self):
+    def test_0006_convert_to_advanced_gateway(self):
+        """Convert legacy gateway to advance gateway.
+
+        It will trigger the cli command with option convert-to-advanced
+        """
+        result_advanced_gateway = self._runner.invoke(gateway,
+                                                      args=[
+                                                        'convert-to-advanced',
+                                                        'test_gateway1'])
+        self.assertEqual(0, result_advanced_gateway.exit_code)
+
+    def test_0007_enable_distributed_routing(self):
+        """Enable Distributed routing for advanced gateway.
+
+        It will trigger the cli command with option enable-distributed-routing
+        """
+        result_advanced_gateway = self._runner.invoke(gateway,
+                                                      args=[
+                                                'enable-distributed-routing',
+                                                'test_gateway1',
+                                            '--distributed-routing-enabled'])
+        self.assertEqual(0, result_advanced_gateway.exit_code)
+
+
+    def test_0008_tearDown(self):
+        result_delete = self._runner.invoke(gateway, args=['delete',
+                                                           'test_gateway1'])
+        self.assertEqual(0, result_delete.exit_code)
         """Logout ignoring any errors to ensure test session is gone."""
         self._logout()

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -361,18 +361,18 @@ def convert_to_advanced_gateway(ctx, name):
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
-    '--distributed-routing-enabled/--distributed-routing-disabled',
-    'is_dr',
+    '--enable/--disable',
+    'is_enabled',
     default=False,
     metavar='<is_distributed>',
     help='Enable distributed routing for networks connected to this gateway.')
-def enable_distributed_routing(ctx, name, is_dr=False):
+def enable_distributed_routing(ctx, name, is_enabled=False):
     """Enable Distributed routing for gateway.
 
         \b
             Examples
                 vcd gateway enable-distributed-routing  <gateway-name>
-                --distributed-routing-enabled/--distributed-routing-disabled
+                --enable/--disable
 
                  Enable/Disable Distributed routing for gateway.
     """
@@ -383,7 +383,7 @@ def enable_distributed_routing(ctx, name, is_dr=False):
         vdc = VDC(client, href=vdc_href)
         gateway = vdc.get_gateway(name)
         gateway_resource = Gateway(client, href=gateway.get('href'))
-        task = gateway_resource.enable_distributed_routing(is_dr)
+        task = gateway_resource.enable_distributed_routing(is_enabled)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -20,6 +20,7 @@ from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
 from vcd_cli.vcd import vcd
+from pyvcloud.vcd.gateway import Gateway
 from vcd_cli.utils import tuple_to_dict
 
 
@@ -174,8 +175,7 @@ def create_gateway(ctx, name, external_networks_name, description,
     """Create a gateway.
     \b
         Note
-            Both System Administrators and Organization Administrators can
-            create gateway.
+            System Administrators can create gateway.
 
     \b
         Examples
@@ -311,8 +311,7 @@ def delete_gateway(ctx, name):
     """delete a gateway.
         \b
             Note
-                Both System Administrators and Organization Administrators can
-                delete gateway.
+                System Administrators can delete gateway.
         \b
             Examples
                 vcd gateway delete <gateway-name>
@@ -324,6 +323,67 @@ def delete_gateway(ctx, name):
         vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=vdc_href)
         task = vdc.delete_gateway(name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@gateway.command('convert-to-advanced', short_help='convert to advanced '
+                                                   'gateway')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+def convert_to_advanced_gateway(ctx, name):
+    """Convert to advanced gateway.
+        \b
+            Note
+                System Administrators and Organization Administrator can
+                convert legacy gateway to advanced.
+        \b
+            Examples
+                vcd gateway convert-to-advanced <gateway-name>
+                 Convert gateway to advanced by providing gateway name
+    """
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        gateway = vdc.get_gateway(name)
+        gateway_resource = Gateway(client, href=gateway.get('href'))
+        task = gateway_resource.convert_to_advanced()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@gateway.command('enable-distributed-routing', short_help='enable '
+                                                          'distributed '
+                                                          'routing for '
+                                                          'gateway')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '--distributed-routing-enabled/--distributed-routing-disabled',
+    'is_dr',
+    default=False,
+    metavar='<is_distributed>',
+    help='Enable distributed routing for networks connected to this gateway.')
+def enable_distributed_routing(ctx, name, is_dr=False):
+    """Enable Distributed routing for gateway.
+
+        \b
+            Examples
+                vcd gateway enable-distributed-routing  <gateway-name>
+                --distributed-routing-enabled/--distributed-routing-disabled
+
+                 Enable/Disable Distributed routing for gateway.
+    """
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        gateway = vdc.get_gateway(name)
+        gateway_resource = Gateway(client, href=gateway.get('href'))
+        task = gateway_resource.enable_distributed_routing(is_dr)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
[VP-1184, VP-1201] Provided command line support for convert to advanced gateway and enable distributed routing.

This will enable the command line support for:
1: Convert legacy gateway to advanced gateway
	vcd gateway convert-to-advanced <name>
2: Enable distributed routing
	vcd gateway enable-distributed-routing <gw_name> --enable/--disable

Testing Done: Added test case for both the use cases

@shashim22 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/260)
<!-- Reviewable:end -->
