### PR TITLE
[VP-1154] Update name and description of external network in VCD CLI

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -115,7 +115,31 @@ class ExtNetTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
-    def test_0010_delete(self):
+    def test_0020_update(self):
+        """Update name and description of the external network created.
+
+        Invoke the command 'external update' in network.
+        """
+        new_name = "updated_" + self._name
+        new_description = "Updated " + self._name
+        result = self._runner.invoke(
+            external,
+            args=[
+                'update', self._name, '--name', new_name, '--description',
+                new_description
+            ])
+        self.assertEqual(0, result.exit_code)
+
+        # Update name and description back to original
+        result = self._runner.invoke(
+            external,
+            args=[
+                'update', new_name, '--name', self._name, '--description',
+                self._description
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0100_delete(self):
         """Delete the external network created.
 
             Invoke the command 'external delete' in network.

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -71,7 +71,7 @@ def external(ctx):
         vcd network external update external-net1
                 --name 'new-external-net1'
                 --description 'New external network'
-            Update an external network.
+            Update name and description of an external network.
     """
     pass
 
@@ -520,7 +520,9 @@ def delete_external_network(ctx, name):
             stderr(e, ctx)
 
 
-@external.command('update', short_help='update an external network')
+@external.command(
+    'update',
+    short_help='update name and description of an external network')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.option(

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -66,6 +66,12 @@ def external(ctx):
 \b
         vcd network external delete external-net1
             Delete an external network.
+
+\b
+        vcd network external update external-net1
+                --name 'new-external-net1'
+                --description 'New external network'
+            Update an external network.
     """
     pass
 
@@ -510,5 +516,39 @@ def delete_external_network(ctx, name):
 
             stdout(task, ctx)
             stdout('External network deleted successfully.', ctx)
+        except Exception as e:
+            stderr(e, ctx)
+
+
+@external.command('update', short_help='update an external network')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-n',
+    '--name',
+    'new_name',
+    metavar='<name>',
+    required=False,
+    help='New name of the external network')
+@click.option(
+    '-d',
+    '--description',
+    'new_description',
+    metavar='<description>',
+    required=False,
+    help='New description of the external network')
+def update_external_network(ctx, name, new_name, new_description):
+        try:
+            restore_session(ctx)
+            client = ctx.obj['client']
+
+            platform = Platform(client)
+            ext_net = platform.update_external_network(
+                name=name,
+                new_name=new_name,
+                new_description=new_description)
+
+            stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+            stdout('External network updated successfully.', ctx)
         except Exception as e:
             stderr(e, ctx)


### PR DESCRIPTION
Implementation of update external network command.

Adding 'update' command to 'external' group. This command can be used to update name or description or both. Command to update is: 'vcd network external update --name --description '

Testing done:
Added a test case for update in extnet_tests. All tests in extnet_tests passes.

@rajeshk2013 @rocknes