### PR TITLE
VP-1241 List external network IP allocations.

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -155,7 +155,7 @@ class GatewayTest(BaseTestCase):
 
     def test_0004_create_gateway_with_default_gateway_and_dns_relay_enabled(
             self):
-        """Create gateway with options --default-gateway --default-gw-ip
+        """Create gateway with options --default-gateway --default-gateway-ip
         --dns-relay-enabled --advanced-enabled.
 
         It will delete the gateway after creation.
@@ -165,15 +165,15 @@ class GatewayTest(BaseTestCase):
             args=[
                 'create', self._name, '-e', GatewayTest._ext_network_name,
                 '--default-gateway', GatewayTest._ext_network_name,
-                '--default-gw-ip', GatewayTest._gateway_ip,
+                '--default-gateway-ip', GatewayTest._gateway_ip,
                 '--dns-relay-enabled', '--advanced-enabled'
             ])
-        GatewayTest._logger.debug("vcd gateway create <name> -e <ext nw> "
-                                  "--defalut-gateway <ext_nw>"
-                                  "--default-gw-ip {0} --dns-relay-enabled "
-                                  "--advanced-enabled : {"
-                                  "1}".format(GatewayTest._gateway_ip,
-                                              result_create5.output))
+        GatewayTest._logger.debug(
+            "vcd gateway create <name> -e <ext nw> "
+            "--defalut-gateway <ext_nw>"
+            "--default-gateway-ip {0} --dns-relay-enabled "
+            "--advanced-enabled : {"
+            "1}".format(GatewayTest._gateway_ip, result_create5.output))
         self.assertEqual(0, result_create5.exit_code)
         self._delete_gateway()
 
@@ -225,9 +225,12 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with option modify-form-factor
         """
-        result = self._runner.invoke(gateway,
-                    args=['modify-form-factor', 'test_gateway1',
-                          GatewayBackingConfigType.FULL.value])
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'modify-form-factor', 'test_gateway1',
+                GatewayBackingConfigType.FULL.value
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0009_get_info(self):
@@ -236,8 +239,7 @@ class GatewayTest(BaseTestCase):
         It will trigger the cli command with command 'info'
         """
         result_advanced_gateway = self._runner.invoke(
-            gateway,
-            args=['info', 'test_gateway1'])
+            gateway, args=['info', 'test_gateway1'])
         self.assertEqual(0, result_advanced_gateway.exit_code)
 
     def test_0098_tearDown(self):

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -205,10 +205,8 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with option convert-to-advanced
         """
-        result_advanced_gateway = self._runner.invoke(gateway,
-                                                      args=[
-                                                        'convert-to-advanced',
-                                                        'test_gateway1'])
+        result_advanced_gateway = self._runner.invoke(
+            gateway, args=['convert-to-advanced', 'test_gateway1'])
         self.assertEqual(0, result_advanced_gateway.exit_code)
 
     def test_0007_enable_distributed_routing(self):
@@ -216,17 +214,24 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with option enable-distributed-routing
         """
-        result_advanced_gateway = self._runner.invoke(gateway,
-                                                      args=[
-                                                'enable-distributed-routing',
-                                                'test_gateway1',
-                                                '--enable'])
+        result_advanced_gateway = self._runner.invoke(
+            gateway,
+            args=['enable-distributed-routing', 'test_gateway1', '--enable'])
         self.assertEqual(0, result_advanced_gateway.exit_code)
 
+    def test_0008_get_info(self):
+        """Get information of the gateway.
+
+        It will trigger the cli command with command 'info'
+        """
+        result_advanced_gateway = self._runner.invoke(
+            gateway,
+            args=['info', 'test_gateway1'])
+        self.assertEqual(0, result_advanced_gateway.exit_code)
 
     def test_0098_tearDown(self):
-        result_delete = self._runner.invoke(gateway, args=['delete',
-                                                           'test_gateway1'])
+        result_delete = self._runner.invoke(
+            gateway, args=['delete', 'test_gateway1'])
         self.assertEqual(0, result_delete.exit_code)
         """Logout ignoring any errors to ensure test session is gone."""
         self._logout()

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -39,20 +39,20 @@ def gateway(ctx):
             Display gateway details.
 
 \b
-        vcd gateway create gateway1 \\
-            --external_network extnw1 \\
-            --external_network extnw2 \\
-            --default-gateway extnw1 \\
-            --default-gw-ip 10.10.20.1 \\
-            --dns-relay-enabled \\
-            --gateway-config full \\
-            --ha-disabled \\
-            --advanced-enabled \\
-            --distributed-routing-enabled \\
-            --configure-ip-setting extnw1 10.10.20.1/24 10.10.20.3 \\
-            --sub-allocate-ip extnw1 \\
-            --subnet 10.10.20.1/28 --ip-range 10.10.20.5-10.10.20.10 \\
-            --configure-rate-limit extnw1 100 200 \\
+        vcd gateway create gateway1
+            --external_network extnw1
+            --external_network extnw2
+            --default-gateway extnw1
+            --default-gw-ip 10.10.20.1
+            --dns-relay-enabled
+            --gateway-config full
+            --ha-disabled
+            --advanced-enabled
+            --distributed-routing-enabled
+            --configure-ip-setting extnw1 10.10.20.1/24 10.10.20.3
+            --sub-allocate-ip extnw1
+            --subnet 10.10.20.1/28 --ip-range 10.10.20.5-10.10.20.10
+            --configure-rate-limit extnw1 100 200
             --flips-mode-disabled
             Create gateway.
                 Parameter --external-network is a required parameter and
@@ -360,12 +360,7 @@ def _get_gateway(ctx, name):
 @click.argument('name', metavar='<name>', required=True)
 def info(ctx, name):
     try:
-        restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        gateway = vdc.get_gateway(name)
-        gateway_resource = Gateway(client, href=gateway.get('href'))
+        gateway_resource = _get_gateway(ctx, name)
         ip_allocs = gateway_resource.list_external_network_ip_allocations()
         output = {}
         output['external_network_ip_allocations'] = ip_allocs

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -33,6 +33,10 @@ def gateway(ctx):
     Examples
         vcd gateway list
             Get list of edge gateways in current virtual datacenter.
+
+\b
+        vcd gateway info name
+            Display gateway details.
     """
     pass
 
@@ -173,6 +177,7 @@ def create_gateway(ctx, name, external_networks_name, description,
                    sub_allocated_subnet, ip_ranges, configure_rate_limits,
                    is_flip_flop, gateway_config):
     """Create a gateway.
+
     \b
         Note
             System Administrators can create gateway.
@@ -379,16 +384,20 @@ def enable_distributed_routing(ctx, name, is_enabled=False):
         stderr(e, ctx)
 
 
-@gateway.command('modify-form-factor',
-                 short_help='modify form factor for gateway')
+@gateway.command(
+    'modify-form-factor', short_help='modify form factor for gateway')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
-@click.argument('gateway_configuration', metavar='<gateway configuration>',
-                required=True, type=click.Choice([
+@click.argument(
+    'gateway_configuration',
+    metavar='<gateway configuration>',
+    required=True,
+    type=click.Choice([
         GatewayBackingConfigType.COMPACT.value,
         GatewayBackingConfigType.FULL.value,
         GatewayBackingConfigType.FULL4.value,
-        GatewayBackingConfigType.XLARGE.value]))
+        GatewayBackingConfigType.XLARGE.value
+    ]))
 def modify_form_factor(ctx, name, gateway_configuration):
     """Modify form factor for gateway.
 
@@ -409,6 +418,7 @@ def modify_form_factor(ctx, name, gateway_configuration):
     except Exception as e:
         stderr(e, ctx)
 
+
 def _get_gateway(ctx, name):
     """Get the sdk's gateway resource.
 
@@ -423,17 +433,11 @@ def _get_gateway(ctx, name):
     gateway_resource = Gateway(client, href=gateway.get('href'))
     return gateway_resource
 
-  
+
 @gateway.command('info', short_help='show gateway information.')
 @click.pass_context
-@click.argument('name', metavar='<gateway name>', required=True)
+@click.argument('name', metavar='<name>', required=True)
 def info(ctx, name):
-    """Display information of the gateway.
-
-        \b
-            Examples
-                vcd gateway info <gateway-name>
-    """
     try:
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -94,10 +94,12 @@ def list_gateways(ctx):
     '--gateway-config',
     'gateway_config',
     default=GatewayBackingConfigType.COMPACT.value,
-    type=click.Choice([GatewayBackingConfigType.COMPACT.value,
-                       GatewayBackingConfigType.FULL.value,
-                       GatewayBackingConfigType.FULL4.value,
-                       GatewayBackingConfigType.XLARGE.value]),
+    type=click.Choice([
+        GatewayBackingConfigType.COMPACT.value,
+        GatewayBackingConfigType.FULL.value,
+        GatewayBackingConfigType.FULL4.value,
+        GatewayBackingConfigType.XLARGE.value
+    ]),
     metavar='<gateway_config>',
     help='Gateway configuration')
 @click.option(
@@ -133,7 +135,7 @@ def list_gateways(ctx):
     metavar='<External Network>',
     default=None,
     help='Sub-allocate the IP Pools provided by the externally connected'
-         ' interfaces')
+    ' interfaces')
 @click.option(
     '--subnet',
     'sub_allocated_subnet',
@@ -156,7 +158,7 @@ def list_gateways(ctx):
     nargs=3,
     type=click.Tuple([str, float, float]),
     help='specify the inbound and outbound rate limits for each externally'
-         ' connected interface.')
+    ' connected interface.')
 @click.option(
     '--flip-flop-enabled/--flip-flop-disabled',
     'is_flip_flop',
@@ -166,11 +168,9 @@ def list_gateways(ctx):
     help='flip flip mode')
 def create_gateway(ctx, name, external_networks_name, description,
                    default_gateway_external_network, default_gw_ip,
-                   is_dns_relay,
-                   is_ha, is_advanced,
-                   is_distributed_routing, configure_ip_settings,
-                   sub_allocated_ext_net_name, sub_allocated_subnet, ip_ranges,
-                   configure_rate_limits,
+                   is_dns_relay, is_ha, is_advanced, is_distributed_routing,
+                   configure_ip_settings, sub_allocated_ext_net_name,
+                   sub_allocated_subnet, ip_ranges, configure_rate_limits,
                    is_flip_flop, gateway_config):
     """Create a gateway.
     \b
@@ -267,8 +267,8 @@ def create_gateway(ctx, name, external_networks_name, description,
         if configure_ip_settings is not None and len(configure_ip_settings) \
                 > 0:
             is_ip_settings_configured = True
-            ext_net_to_participated_subnet_with_ip_settings = tuple_to_dict \
-                (configure_ip_settings)
+            ext_net_to_participated_subnet_with_ip_settings = tuple_to_dict(
+                configure_ip_settings)
         is_sub_allocate_ip_pools_enabled = False
         ext_net_to_subnet_with_ip_range = {}
         if sub_allocated_ext_net_name is not None and len(
@@ -276,33 +276,28 @@ def create_gateway(ctx, name, external_networks_name, description,
                 not None and len(sub_allocated_subnet) > 0 and ip_ranges is \
                 not None and len(sub_allocated_subnet) > 0:
             is_sub_allocate_ip_pools_enabled = True
-            ext_net_to_subnet_with_ip_range = {sub_allocated_ext_net_name :
-                                                   {sub_allocated_subnet :
-                                                        list(ip_ranges)}}
+            ext_net_to_subnet_with_ip_range = {
+                sub_allocated_ext_net_name: {
+                    sub_allocated_subnet: list(ip_ranges)
+                }
+            }
         ext_net_to_rate_limit = {}
         if configure_rate_limits is not None and len(configure_rate_limits) \
                 > 0:
             ext_net_to_rate_limit = tuple_to_dict(configure_rate_limits)
 
-        result = vdc.create_gateway(name, external_networks_name,
-                    gateway_config,
-                    description,
-                    is_configured_default_gw,
-                    default_gateway_external_network,
-                    default_gw_ip,
-                    is_dns_relay,
-                    is_ha,
-                    is_advanced,
-                    is_distributed_routing,
-                    is_ip_settings_configured,
-                    ext_net_to_participated_subnet_with_ip_settings,
-                    is_sub_allocate_ip_pools_enabled,
-                    ext_net_to_subnet_with_ip_range,
-                    ext_net_to_rate_limit,
-                    is_flip_flop)
+        result = vdc.create_gateway(
+            name, external_networks_name, gateway_config, description,
+            is_configured_default_gw, default_gateway_external_network,
+            default_gw_ip, is_dns_relay, is_ha, is_advanced,
+            is_distributed_routing, is_ip_settings_configured,
+            ext_net_to_participated_subnet_with_ip_settings,
+            is_sub_allocate_ip_pools_enabled, ext_net_to_subnet_with_ip_range,
+            ext_net_to_rate_limit, is_flip_flop)
         stdout(result.Tasks.Task[0], ctx)
     except Exception as e:
         stderr(e, ctx)
+
 
 @gateway.command('delete', short_help='delete edge gateway')
 @click.pass_context
@@ -327,8 +322,10 @@ def delete_gateway(ctx, name):
     except Exception as e:
         stderr(e, ctx)
 
-@gateway.command('convert-to-advanced', short_help='convert to advanced '
-                                                   'gateway')
+
+@gateway.command(
+    'convert-to-advanced', short_help='convert to advanced '
+    'gateway')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 def convert_to_advanced_gateway(ctx, name):
@@ -354,10 +351,13 @@ def convert_to_advanced_gateway(ctx, name):
     except Exception as e:
         stderr(e, ctx)
 
-@gateway.command('enable-distributed-routing', short_help='enable '
-                                                          'distributed '
-                                                          'routing for '
-                                                          'gateway')
+
+@gateway.command(
+    'enable-distributed-routing',
+    short_help='enable '
+    'distributed '
+    'routing for '
+    'gateway')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -385,5 +385,30 @@ def enable_distributed_routing(ctx, name, is_enabled=False):
         gateway_resource = Gateway(client, href=gateway.get('href'))
         task = gateway_resource.enable_distributed_routing(is_enabled)
         stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@gateway.command('info', short_help='show gateway information.')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+def info(ctx, name):
+    """Display information of the gateway.
+
+        \b
+            Examples
+                vcd gateway info <gateway-name>
+    """
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        gateway = vdc.get_gateway(name)
+        gateway_resource = Gateway(client, href=gateway.get('href'))
+        ip_allocs = gateway_resource.list_external_network_ip_allocations()
+        output = {}
+        output['external_network_ip_allocations'] = ip_allocs
+        stdout(output, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -37,6 +37,39 @@ def gateway(ctx):
 \b
         vcd gateway info name
             Display gateway details.
+
+\b
+        vcd gateway create gateway1 \\
+            --external_network extnw1 \\
+            --external_network extnw2 \\
+            --default-gateway extnw1 \\
+            --default-gw-ip 10.10.20.1 \\
+            --dns-relay-enabled \\
+            --gateway-config full \\
+            --ha-disabled \\
+            --advanced-enabled \\
+            --distributed-routing-enabled \\
+            --configure-ip-setting extnw1 10.10.20.1/24 10.10.20.3 \\
+            --sub-allocate-ip extnw1 \\
+            --subnet 10.10.20.1/28 --ip-range 10.10.20.5-10.10.20.10 \\
+            --configure-rate-limit extnw1 100 200 \\
+            --flips-mode-disabled
+            Create gateway.
+                Parameter --external-network is a required parameter and
+                can have multiple entries.
+
+\b
+        vcd gateway delete gateway1
+             Delete gateway by providing gateway name.
+
+\b
+        vcd gateway enable-distributed-routing  gateway1 --disable
+            Enable/Disable Distributed routing for gateway.
+
+\b
+        vcd gateway modify-form-factor  gateway1 full4
+            Possible value for gatewy configuration are
+            compact/full/full4/x-large
     """
     pass
 
@@ -59,10 +92,10 @@ def list_gateways(ctx):
 
 @gateway.command('create', short_help='create edge gateway')
 @click.pass_context
-@click.argument('name', metavar='<new gateway name>', required=True)
+@click.argument('name', metavar='<name>', required=True)
 @click.option(
     '-e',
-    '--external-nw',
+    '--external-network',
     'external_networks_name',
     metavar='<external network>',
     multiple=True,
@@ -79,13 +112,13 @@ def list_gateways(ctx):
     'default_gateway_external_network',
     default=None,
     metavar='<external_network>',
-    help='Name of external network for Default gateway configuration')
+    help='name of external network for default gateway configuration')
 @click.option(
-    '--default-gw-ip',
+    '--default-gateway-ip',
     'default_gw_ip',
     default=None,
     metavar='<default gateway IP>',
-    help='Name of external network for Default gateway configuration')
+    help='IP from the external network for the default gateway')
 @click.option(
     '--dns-relay-enabled/--dns-relay-disabled',
     'is_dns_relay',
@@ -105,7 +138,7 @@ def list_gateways(ctx):
         GatewayBackingConfigType.XLARGE.value
     ]),
     metavar='<gateway_config>',
-    help='Gateway configuration')
+    help='gateway configuration')
 @click.option(
     '--ha-enabled/--ha-disabled',
     'is_ha',
@@ -117,13 +150,13 @@ def list_gateways(ctx):
     'is_advanced',
     default=False,
     metavar='<is_advanced>',
-    help='Advanced gateway')
+    help='advanced gateway')
 @click.option(
     '--distributed-routing-enabled/--distributed-routing-disabled',
     'is_distributed_routing',
     default=False,
     metavar='<is_distributed>',
-    help='Enable distributed routing for networks connected to this gateway.')
+    help='enable distributed routing for networks connected to this gateway.')
 @click.option(
     '--configure-ip-setting',
     'configure_ip_settings',
@@ -131,32 +164,32 @@ def list_gateways(ctx):
     type=click.Tuple([str, str, str]),
     multiple=True,
     default=None,
-    metavar='<External Network> <subnet> <configured IP>',
-    help='Configuring multiple ip settings')
+    metavar='<external network> <subnet> <configured IP>',
+    help='configuring multiple ip settings')
 @click.option(
     '--sub-allocate-ip',
     'sub_allocated_ext_net_name',
-    metavar='<External Network>',
+    metavar='<external network>',
     default=None,
-    help='Sub-allocate the IP Pools provided by the externally connected'
+    help='sub-allocate the IP Pools provided by the externally connected'
     ' interfaces')
 @click.option(
     '--subnet',
     'sub_allocated_subnet',
     default=None,
-    metavar='<External Network Subnet>',
-    help='Subnet for the selected external network for IP sub allocation')
+    metavar='<external network subnet>',
+    help='subnet for the selected external network for IP sub allocation')
 @click.option(
     '--ip-range',
     'ip_ranges',
-    metavar='<IP Ranges>',
+    metavar='<IP ranges>',
     multiple=True,
     default=None,
-    help='IP Ranges pertaining to External networks IP Pool')
+    help='IP ranges pertaining to external network\'s IP Pool')
 @click.option(
     '--configure-rate-limit',
     'configure_rate_limits',
-    metavar='<External Network> <incoming rate limit> <outgoing rate limit>',
+    metavar='<external network> <incoming rate limit> <outgoing rate limit>',
     multiple=True,
     default=None,
     nargs=3,
@@ -176,88 +209,6 @@ def create_gateway(ctx, name, external_networks_name, description,
                    configure_ip_settings, sub_allocated_ext_net_name,
                    sub_allocated_subnet, ip_ranges, configure_rate_limits,
                    is_flip_flop, gateway_config):
-    """Create a gateway.
-
-    \b
-        Note
-            System Administrators can create gateway.
-
-    \b
-        Examples
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-             Create gateway by providing new gateway name, external networks.
-             It will create Compact by default without Default gateway
-             configuration
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-             -e <External-Network-Name1>
-            Create gateway by providing multiple external networks
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --default-gateway <External Network> --default-gw-ip <default
-            gateway IP> --dns-relay-enabled/--dns-relay-disabled
-            Create gateway by providing Default gateway configuration
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --c <compact/full/full4/x-large>
-            Create gateway by providing gateway config.
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --ha-enabled/--ha-disabled
-            Create gateway with HA enabled
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --advanced-enabled/--advanced-disabled
-            Create advanced gateway
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --distributed-routing-enabled/--distributed-routing-disabled
-            Create gateway with enable distributed routing for networks
-            connected to this gateway
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --distributed-routing-enabled/--distributed-routing-disabled
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --configure-ip-setting <External Network Name1> <subnet1>
-            <IP>
-            --configure-ip-setting <External Network Name2> <subnet1>
-            <IP> ...(One or more ip settings)
-            For ex: --configure-ip-setting ext_net 10.3.2.1/24 Auto or
-                    --configure-ip-setting ext_net 10.3.2.1/24 10.3.2.3
-            Create gateway with Configure IP settings
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --sub-allocate-ip <External Network Name> --subnet
-            <subnet> --ip-range <IP Range>
-            --ip-range <IP Range> ...(one or more IP Ranges)
-            For ex: --sub-allocate-ip <External Network Name>
-            --subnet 10.3.2.1/20 --ip-range 10.3.2.3-10.3.2.4
-
-    \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --configure-rate-limit <External_Network_Name1>
-             <incoming rate limit> <outgoing rate limit>
-            --configure-rate-limit  <External_Network_Name2>
-             <incoming rate limit> <outgoing rate limit> ... (One or more
-             rate limits)
-             Create gateway with Rate Limits Configured
-
-    \b
-            \b
-            vcd gateway create <gateway-name> -e <External-Network-Name1>
-            --flips-mode-enabled/--flips-mode-disabled
-            flips flop mode
-        """
     try:
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
@@ -308,15 +259,6 @@ def create_gateway(ctx, name, external_networks_name, description,
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 def delete_gateway(ctx, name):
-    """delete a gateway.
-        \b
-            Note
-                System Administrators can delete gateway.
-        \b
-            Examples
-                vcd gateway delete <gateway-name>
-                 Delete gateway by providing gateway name
-    """
     try:
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
@@ -367,15 +309,6 @@ def convert_to_advanced_gateway(ctx, name):
     metavar='<is_distributed>',
     help='Enable distributed routing for networks connected to this gateway.')
 def enable_distributed_routing(ctx, name, is_enabled=False):
-    """Enable Distributed routing for gateway.
-
-        \b
-            Examples
-                vcd gateway enable-distributed-routing  <gateway-name>
-                --enable/--disable
-
-                 Enable/Disable Distributed routing for gateway.
-    """
     try:
         gateway_resource = _get_gateway(ctx, name)
         task = gateway_resource.enable_distributed_routing(is_enabled)
@@ -399,18 +332,6 @@ def enable_distributed_routing(ctx, name, is_enabled=False):
         GatewayBackingConfigType.XLARGE.value
     ]))
 def modify_form_factor(ctx, name, gateway_configuration):
-    """Modify form factor for gateway.
-
-        \b
-            Examples
-                vcd gateway modify-form-factor  <gateway-name>
-                <gateway_configuration>
-
-                Possible value for gatewy configuration are
-                compact/full/full4/x-large
-
-                Modify form factor for gateway.
-    """
     try:
         gateway_resource = _get_gateway(ctx, name)
         task = gateway_resource.modify_form_factor(gateway_configuration)


### PR DESCRIPTION
Added a new command 'info' as per the CLI design document.
IP allocations are displayed as one of the property of the gateway.
Example output:
(vcd-cli) C:\development\vcd-cli>vcd gateway info edge2
property                         value
external_network_ip_allocations  extnw3: ['10.10.10.2']

Testing done: ran gateway_tests successfully.
Output:
(vcd-cli) C:\development\vcd-cli\system_tests>python -m unittest gateway_tests.py
..........
Ran 10 tests in 262.436s

OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/267)
<!-- Reviewable:end -->
