### PR TITLE
[VP-1323]: Provide backward compatibility support for create gateway …

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -18,6 +18,7 @@ from vcd_cli.org import org
 from pyvcloud.vcd.client import GatewayBackingConfigType
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.platform import Platform
+from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
 
 
 class GatewayTest(BaseTestCase):
@@ -56,8 +57,10 @@ class GatewayTest(BaseTestCase):
             namespaces=NSMAP)
         first_ipscope = ip_scopes[0]
         GatewayTest._gateway_ip = first_ipscope.Gateway.text
+        prefix_len = netmask_to_cidr_prefix_len(GatewayTest._gateway_ip,
+                                                first_ipscope.Netmask.text)
         GatewayTest._subnet_addr = GatewayTest._gateway_ip + '/' + str(
-            first_ipscope.SubnetPrefixLength)
+            prefix_len)
 
     def _login(self):
         """Logs in using admin credentials"""
@@ -141,6 +144,8 @@ class GatewayTest(BaseTestCase):
             gateway,
             args=[
                 'create', self._name, '-e', GatewayTest._ext_network_name,
+                '--sub-allocate-ip', GatewayTest._ext_network_name, '--subnet',
+                GatewayTest._subnet_addr, '--ip-range', ip_range,
                 '--sub-allocate-ip', GatewayTest._ext_network_name, '--subnet',
                 GatewayTest._subnet_addr, '--ip-range', ip_range
             ])

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -13,6 +13,7 @@
 #
 
 import click
+from pyvcloud.vcd.client import ApiVersion
 from pyvcloud.vcd.client import GatewayBackingConfigType
 from pyvcloud.vcd.vdc import VDC
 
@@ -221,6 +222,7 @@ def create_gateway(ctx, name, external_networks_name, description,
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
         vdc_href = ctx.obj['profiles'].get('vdc_href')
+        api_version = ctx.obj['profiles'].get('api_version')
         vdc = VDC(client, href=vdc_href)
         is_configured_default_gw = False
         if default_gateway_external_network is not None and len(
@@ -250,14 +252,26 @@ def create_gateway(ctx, name, external_networks_name, description,
                 > 0:
             ext_net_to_rate_limit = tuple_to_dict(configure_rate_limits)
 
-        result = vdc.create_gateway(
-            name, external_networks_name, gateway_config, description,
-            is_configured_default_gw, default_gateway_external_network,
-            default_gw_ip, is_dns_relay, is_ha, is_advanced,
-            is_distributed_routing, is_ip_settings_configured,
-            ext_net_to_participated_subnet_with_ip_settings,
-            is_sub_allocate_ip_pools_enabled, ext_net_to_subnet_with_ip_range,
-            ext_net_to_rate_limit, is_flip_flop)
+        if float(api_version) <= float(ApiVersion.VERSION_30.value):
+            result = vdc.create_gateway_api_version_30(
+                name, external_networks_name, gateway_config, description,
+                is_configured_default_gw, default_gateway_external_network,
+                default_gw_ip, is_dns_relay, is_ha, is_advanced,
+                is_distributed_routing, is_ip_settings_configured,
+                ext_net_to_participated_subnet_with_ip_settings,
+                is_sub_allocate_ip_pools_enabled,
+                ext_net_to_subnet_with_ip_range,
+                ext_net_to_rate_limit)
+        else:
+            result = vdc.create_gateway(
+                name, external_networks_name, gateway_config, description,
+                is_configured_default_gw, default_gateway_external_network,
+                default_gw_ip, is_dns_relay, is_ha, is_advanced,
+                is_distributed_routing, is_ip_settings_configured,
+                ext_net_to_participated_subnet_with_ip_settings,
+                is_sub_allocate_ip_pools_enabled,
+                ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit,
+                is_flip_flop)
         stdout(result.Tasks.Task[0], ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
…workflow

We added switch for the API version and if API version is less than equal to 30 then invoking pysdk function created specifically for API 30 or lower.
Function name is create_gateway_api_version_30.

I tested manually against vCD 9.0 and 9.5.

@shashim22 @pandeys @chaitanya118 
