### PR TITLE
VP-1244: Modify an IP range of a subnet in external network

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -49,6 +49,7 @@ class ExtNetTest(BaseTestCase):
     _dns_suffix = 'example.com'
     _gateway1 = '10.10.30.1'
     _ip_range1 = '10.10.30.2-10.10.30.99'
+    _ip_range2 = '10.10.30.30-10.10.30.60'
 
     def setUp(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -153,6 +154,19 @@ class ExtNetTest(BaseTestCase):
                 '--netmask', self._netmask, '--ip-range', self._ip_range1,
                 '--dns1', self._dns1, '--dns2', self._dns2, '--dns-suffix',
                 self._dns_suffix
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0031_modify_ip_range(self):
+        """Modify an IP range of a subnet in an external network.
+
+        Invoke the command 'external modify-ip-range' in network.
+        """
+        result = self._runner.invoke(
+            external,
+            args=[
+                'modify-ip-range', self._name, '--gateway-ip', self._gateway1,
+                '--ip-range', self._ip_range1,'--new-ip-range', self._ip_range2
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -84,6 +84,12 @@ def external(ctx):
                 --dns-suffix example.com
             Add subnet to external network.
             ip-range can have multiple entries.
+
+\b
+       vcd network external modify-ip-range external-net1
+               --gateway-ip 192.168.1.1
+               --ip-range 192.168.1.2-192.168.1.20
+               --new-ip-range 192.168.1.25-192.168.1.50
     """
     pass
 
@@ -629,3 +635,44 @@ def _get_platform(ctx):
     restore_session(ctx)
     client = ctx.obj['client']
     return Platform(client)
+
+@external.command(
+    'modify-ip-range',
+    short_help='Modifies an IP range of a subnet in an external network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-g',
+    '--gateway-ip',
+    'gateway_ip',
+    required=True,
+    metavar='<ip>',
+    help='gateway ip of the subnet')
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    required=True,
+    metavar='<ip>',
+    help='ip range in StartAddress-EndAddress format')
+@click.option(
+    '-n',
+    '--new-ip-range',
+    'new_ip_range',
+    required=True,
+    metavar='<ip>',
+    help='ip range in StartAddress-EndAddress format')
+
+def modify_ip_range_external_network(ctx, name, gateway_ip, ip_range,
+                                new_ip_range):
+    try:
+        extnet_obj = _get_ext_net_obj(ctx, name)
+
+        ext_net = extnet_obj.modify_ip_range(
+                                        gateway_ip=gateway_ip,
+                                        old_ip_range=ip_range,
+                                        new_ip_range=new_ip_range)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+        stdout('Ip Range of a subnet modified successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION

Modifies an IP range of a subnet in an external network.

This will modify the exiting Ip Range of a subnet with the new IP Range.

Testing done: 
vcd-cli command : passed
-------------------------------
(vcd-cli) C:\dev-python-dnd\vcd-cli>vcd network external modify-ip-range ext -g 192.168.1.1 -i 192.168.1.12-192.168.1.22 -n 192.168.1.5-192.168.1.10
networkUpdateNetwork: Updating Network ext(02409fa5-6362-4d29-a500-8df1a0bdbefa)
task: 551e6bb8-76b7-4151-b7ed-1e34c4b0b28f, Updated Network ext(02409fa5-6362-4d29-a500-8df1a0bdbefa), result: success
Ip Range of a subnet modified successfully.

system-tests : passed
