### PR TITLE
VP-1253, VP-1254: configure external network for gateways.

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -81,3 +81,11 @@ nsxt:
 pvdc:
   pvdc_name: '<pvdc-name>'
   resource_pool_names: ['resource-pool-name-1', 'resource-pool-name-2', ...]
+
+external_network:
+  name: '<ext-net-name>'
+  port_group_name: '<pg-name>'
+  ip_scopes:
+    - subnet: '<gateway-ip/prefix_len>'
+      ip_ranges:
+        - '<start-ip>-<end-ip>'

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -7,16 +7,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from uuid import uuid1
 from click.testing import CliRunner
 
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import Environment
 from vcd_cli.login import login, logout
+from vcd_cli.network import external
 from vcd_cli.network import network
 from vcd_cli.gateway import gateway
 from vcd_cli.org import org
 from pyvcloud.vcd.client import GatewayBackingConfigType
 from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.platform import Platform
 
 
@@ -27,6 +31,7 @@ class GatewayTest(BaseTestCase):
         """
     _runner = None
     _name = 'test_gateway1'
+    _external_network_name = 'external_network_' + str(uuid1())
     _subnet_addr = None
     _ext_network_name = None
     _gateway_ip = None
@@ -87,9 +92,9 @@ class GatewayTest(BaseTestCase):
         GatewayTest._logger.debug("vcd network external list: {0}".format(
             network_result.output))
         ext_netws = network_result.output
-        ext_nets_name = ext_netws.split('------')
-        ext_netws_arr = ext_nets_name[1].split('\n')
-        return ext_netws_arr[1]
+        ext_nets_name = ext_netws.split('\n')
+        GatewayTest._logger.debug(ext_nets_name)
+        return ext_nets_name[2]
 
     def test_0001_create_gateway_with_mandatory_option(self):
         """Admin user can create gateway
@@ -258,6 +263,85 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway, args=['sync-syslog-settings', 'test_gateway1'])
         self.assertEqual(0, result.exit_code)
+
+    def _create_external_network(self):
+        """Create an external network as per configuration stated above.
+
+        Choose first unused port group which is not a VxLAN. Unused port groups
+        have network names set to '--'. VxLAN port groups have name starting
+        with 'vxw-'.
+
+        Invoke the command 'external create' in network.
+        """
+        _config = Environment.get_config()
+        vc_name = _config['vc']['vcenter_host_name']
+        name_filter = ('vcName', vc_name)
+        sys_admin_client = Environment.get_sys_admin_client()
+        query = sys_admin_client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+
+        _port_group = None
+        for record in list(query.execute()):
+            if record.get('networkName') == '--':
+                if not record.get('name').startswith('vxw-'):
+                    _port_group = record.get('name')
+                    break
+
+        self.assertIsNotNone(_port_group, 'None of the port groups are free.')
+
+        result = self._runner.invoke(
+            external,
+            args=[
+                'create', self._external_network_name, vc_name, '--port-group',
+                _port_group, '--gateway', '10.10.30.1', '--netmask',
+                '255.255.255.0', '--ip-range', '10.10.30.101-10.10.30.150',
+                '--description', self._external_network_name, '--dns1',
+                '8.8.8.8', '--dns2', '8.8.8.9', '--dns-suffix', 'example.com'
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def _delete_external_network(self):
+        """Delete the external network created.
+
+            Invoke the command 'external delete' in network.
+        """
+        result = self._runner.invoke(
+            external, args=['delete', self._external_network_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0013_add_external_network(self):
+        """Adds external network to the gateway.
+         It will trigger the cli command configure-external-network add
+        """
+        self._create_external_network()
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'configure-external-network', 'add', 'test_gateway1', '-e',
+                self._external_network_name, '--configure-ip-setting',
+                '10.10.30.1/24', '10.10.30.110'
+            ])
+        GatewayTest._logger.debug(
+            "vcd gateway configure-external-network add "
+            "-e {0} --configure-ip-setting {1}\n{2}".format(
+                self._external_network_name, '10.10.30.1/24 10.10.30.110',
+                result.output))
+        self.assertEqual(0, result.exit_code)
+
+    def test_0014_remove_external_network(self):
+        """Removes external network from the gateway.
+         It will trigger the cli command configure-external-network remove
+        """
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'configure-external-network', 'remove', 'test_gateway1', '-e',
+                self._external_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+        self._delete_external_network()
 
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -413,7 +413,7 @@ def configure_external_network(ctx):
 \b
         vcd gateway configure-external-network remove gateway1
             -e extNw1
-            Removes an external network to the edge gateway.
+            Removes an external network from the edge gateway.
     """
     pass
 
@@ -438,7 +438,7 @@ def configure_external_network(ctx):
     multiple=True,
     default=None,
     metavar='<subnet> <configured IP>',
-    help='configuring multiple ip settings')
+    help='configuring multiple IP settings')
 def add_external_network(ctx, name, external_network_name,
                          configure_ip_settings):
     try:
@@ -451,7 +451,7 @@ def add_external_network(ctx, name, external_network_name,
 
 
 @configure_external_network.command(
-    'remove', short_help='removes an external network to the edge gateway')
+    'remove', short_help='removes an external network from the edge gateway')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.option(

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -395,3 +395,77 @@ def sync_syslog_settings(ctx, name):
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@gateway.group(short_help='configures external networks of an edge gateway')
+@click.pass_context
+def configure_external_network(ctx):
+    """Configures external networks of edge gateways in vCloud Director.
+
+\b
+    Examples
+        vcd gateway configure-external-network add gateway1
+            --external_network extNw1
+            --configure-ip-setting 10.10.10.1/28 10.10.10.9
+            --configure-ip-setting 10.10.20.1/24 Auto
+            Adds an external network to the edge gateway.
+
+\b
+        vcd gateway configure-external-network remove gateway1
+            -e extNw1
+            Removes an external network to the edge gateway.
+    """
+    pass
+
+
+@configure_external_network.command(
+    'add', short_help='adds an external network to the edge gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=False,
+    required=True,
+    help='external network to which the gateway can connect.')
+@click.option(
+    '--configure-ip-setting',
+    'configure_ip_settings',
+    nargs=2,
+    type=click.Tuple([str, str]),
+    multiple=True,
+    default=None,
+    metavar='<subnet> <configured IP>',
+    help='configuring multiple ip settings')
+def add_external_network(ctx, name, external_network_name,
+                         configure_ip_settings):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.add_external_network(external_network_name,
+                                                     configure_ip_settings)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@configure_external_network.command(
+    'remove', short_help='removes an external network to the edge gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=False,
+    required=True,
+    help='external network that needs to be removed from the gateway.')
+def remove_external_network(ctx, name, external_network_name):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.remove_external_network(external_network_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION
Added two commands in configure-external-network command group.
1. Add: adds an external network with the specified subnet and ip address.
2. Remove: removes an existing external network from the gateway.

Added corresponding test cases.

Testing done: ran gateway_tests succesfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/276)
<!-- Reviewable:end -->
