### PR TITLE
VP-1258: Attach port groups to an external network

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -65,6 +65,12 @@ vc:
   vcenter_admin_username: 'administrator@vsphere.local'
   vcenter_admin_password: '<vc root password>'
 
+vc2:
+  vcenter_host_name: 'vc2'
+  vcenter_host_ip: '<vc2 ip>'
+  vcenter_admin_username: 'administrator@vsphere.local'
+  vcenter_admin_password: '<vc root password>'
+
 nsx:
   nsx_hostname: 'nsx1'
   nsx_host_ip: '<nsx ip>'

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -24,6 +24,7 @@ from vcd_cli.network import external
 
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.platform import Platform
 
 
 class ExtNetTest(BaseTestCase):
@@ -50,6 +51,7 @@ class ExtNetTest(BaseTestCase):
     _gateway1 = '10.10.30.1'
     _ip_range1 = '10.10.30.2-10.10.30.99'
     _ip_range2 = '10.10.30.30-10.10.30.60'
+    _portgroupType = "DV_PORTGROUP"
 
     def setUp(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -167,6 +169,23 @@ class ExtNetTest(BaseTestCase):
             args=[
                 'modify-ip-range', self._name, '--gateway-ip', self._gateway1,
                 '--ip-range', self._ip_range1,'--new-ip-range', self._ip_range2
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0032_attach_port_group(self):
+        """Attach a portgroup to an external network.
+
+        Invoke the command 'external attach-pg' in network.
+        """
+        vc_name = self._config['vc2']['vcenter_host_name']
+        self.client = Environment.get_sys_admin_client()
+        platform = Platform(self.client)
+        pgroup_name = platform.get_pgroup_name(vc_name,
+            ExtNetTest._portgroupType)
+        result = self._runner.invoke(
+            external,
+            args=[
+                'attach-pg', self._name, vc_name, '--port-group', pgroup_name
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -90,6 +90,10 @@ def external(ctx):
                --gateway-ip 192.168.1.1
                --ip-range 192.168.1.2-192.168.1.20
                --new-ip-range 192.168.1.25-192.168.1.50
+
+\b
+       vcd network external attach-pg external-net1 vc1
+               --port-group 'pg1'
     """
     pass
 
@@ -674,5 +678,31 @@ def modify_ip_range_external_network(ctx, name, gateway_ip, ip_range,
                                         new_ip_range=new_ip_range)
         stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
         stdout('Ip Range of a subnet modified successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@external.command(
+    'attach-pg',
+    short_help='Attaches a port group to an external network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('vc_name', metavar='<vc-name>', required=True)
+@click.option(
+    '-p',
+    '--port-group',
+    'port_group',
+    required=True,
+    metavar='<name>',
+    help='name of the port group present in vCenter')
+
+def attach_port_group_external_network(ctx, name, vc_name, port_group):
+    try:
+        extnet_obj = _get_ext_net_obj(ctx, name)
+
+        ext_net = extnet_obj.attach_port_group(
+                                        vim_server_name=vc_name,
+                                        port_group_name=port_group)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+        stdout('Port group attached to external network successfully.', ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Attach a port group to an external network using vcd-cli.

Testing done:
system-tests: passed
(vcd-cli) C:\dev2-python-dnd\vcd-cli\system_tests>python -m unittest extnet_tests.py
----------------------------------------------------------------------
Ran 6 tests in 108.696s
OK

vcd-cli passed:
(vcd-cli) C:\dev2-python-dnd\vcd-cli>vcd network external attach-pg  xternal vc2 -p dvPortGroup
networkUpdateNetwork: Updating Network xternal(ca049378-5aa0-4b8d-b1fe-3f009a956a3a)
task: 16dd2784-0f68-4502-9880-3cbec803e8f8, Updated Network xternal(ca049378-5aa0-4b8d-b1fe-3f009a956a3a), result: success
Port group attached to external network successfully.

(vcd-cli) C:\dev2-python-dnd\vcd-cli>vcd network external attach-pg  xternal vc3 -p dvPortGroup
networkUpdateNetwork: Updating Network xternal(ca049378-5aa0-4b8d-b1fe-3f009a956a3a)
task: 9d7b6109-c813-4eb4-bebc-83b70d09736d, Updated Network xternal(ca049378-5aa0-4b8d-b1fe-3f009a956a3a), result: success
Port group attached to external network successfully.
