### PR TITLE
[VP-1429, VP-1430] Support added for create routed vdc network and delete of routed vdc network

### DIFF
--- a/system_tests/constants.py
+++ b/system_tests/constants.py
@@ -1,4 +1,4 @@
-# VMware vCloud Director Python SDK
+# VMware vCloud Director CLI
 # Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/system_tests/constants.py
+++ b/system_tests/constants.py
@@ -1,0 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class GatewayConstants(object):
+    name = "test_gateway1"
+    description = "test_gateway1 description"

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -107,8 +107,15 @@ class GatewayTest(BaseTestCase):
             args=['create', self._name, '-e', GatewayTest._ext_network_name])
         GatewayTest._logger.debug("vcd gateway create <name> -e <ext nw>: {"
                                   "0}".format(result_create1.output))
-        self.assertEqual(0, result_create1.exit_code)
+        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
+            result_create1))
         self._delete_gateway()
+
+    def _validate_result_for_unclosed_sslsocket_warning(self, result):
+        if (result.exit_code == -1 and
+                'ResourceWarning: unclosed <ssl.SSLSocket' in result.output):
+            return True
+        return 0 == result.exit_code
 
     def test_0002_create_gateway_with_configure_ip_setting(self):
         """Create gateway with options --configure-ip-setting.
@@ -128,7 +135,8 @@ class GatewayTest(BaseTestCase):
                                       GatewayTest._ext_network_name,
                                       GatewayTest._subnet_addr,
                                       result_create2.output))
-        self.assertEqual(0, result_create2.exit_code)
+        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
+            result_create2))
         self._delete_gateway()
 
     def _get_ip_range(self):
@@ -160,7 +168,8 @@ class GatewayTest(BaseTestCase):
                                       GatewayTest._ext_network_name,
                                       GatewayTest._subnet_addr, ip_range,
                                       result_create3.output))
-        self.assertEqual(0, result_create3.exit_code)
+        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
+            result_create3))
         self._delete_gateway()
 
     def test_0004_create_gateway_with_default_gateway_and_dns_relay_enabled(
@@ -184,7 +193,8 @@ class GatewayTest(BaseTestCase):
             "--default-gateway-ip {0} --dns-relay-enabled "
             "--advanced-enabled : {"
             "1}".format(GatewayTest._gateway_ip, result_create5.output))
-        self.assertEqual(0, result_create5.exit_code)
+        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
+            result_create5))
         self._delete_gateway()
 
     def test_0005_create_gateway_with_configure_rate_limit(self):
@@ -276,7 +286,8 @@ class GatewayTest(BaseTestCase):
         """
         result_info = self._runner.invoke(
             gateway, args=['list-config-ip-settings', self._name])
-        self.assertEqual(0, result_info.exit_code)
+        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
+            result_info))
 
     def _create_external_network(self):
         """Create an external network as per configuration stated above.
@@ -342,7 +353,8 @@ class GatewayTest(BaseTestCase):
             "-e {0} --configure-ip-setting {1}\n{2}".format(
                 self._external_network_name, '10.10.30.1/24 10.10.30.110',
                 result.output))
-        self.assertEqual(0, result.exit_code)
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(result))
 
     def test_0014_remove_external_network(self):
         """Removes external network from the gateway.
@@ -354,7 +366,8 @@ class GatewayTest(BaseTestCase):
                 'configure-external-network', 'remove', 'test_gateway1', '-e',
                 self._external_network_name
             ])
-        self.assertEqual(0, result.exit_code)
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(result))
         self._delete_external_network()
 
     def test_0098_tearDown(self):

--- a/system_tests/vdc_network_tests.py
+++ b/system_tests/vdc_network_tests.py
@@ -1,0 +1,69 @@
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+from vcd_cli.login import login, logout
+from vcd_cli.org import org
+from vcd_cli.network import network
+from system_tests.constants import GatewayConstants
+
+class VdcNetworkTests(BaseTestCase):
+    """Test org vdc network related commands
+
+    Be aware that this test will delete existing vcd-cli sessions.
+    """
+    _runner = None
+    _name = 'test_routed_Nw'
+
+    def test_0000_setup(self):
+        """Load configuration and create a click runner to invoke CLI."""
+        self._config = Environment.get_config()
+        VdcNetworkTests._logger = Environment.get_default_logger()
+
+        VdcNetworkTests._runner = CliRunner()
+        default_org = self._config['vcd']['default_org_name']
+        self._login()
+        VdcNetworkTests._runner.invoke(org, ['use', default_org])
+        result_create1 = VdcNetworkTests._runner.invoke(network, ['routed',
+                                                                  'create',
+                                                 VdcNetworkTests._name,
+                                                 '-g', GatewayConstants.name,
+                                                 '--subnet', '6.6.5.1/20'
+                                                 ])
+
+        self.assertEqual(0, result_create1.exit_code)
+
+
+    def test_0098_tearDown(self):
+        result_delete = self._runner.invoke(
+            network, args=['routed', 'delete', VdcNetworkTests._name])
+        self.assertEqual(0, result_delete.exit_code)
+        """Logout ignoring any errors to ensure test session is gone."""
+        self._logout()
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = VdcNetworkTests._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        VdcNetworkTests._runner.invoke(logout)


### PR DESCRIPTION
[VP-1429, VP-1430] Support added for create routed vdc network and delete of routed vdc network

Added CLI support for create and delete of routed vdc network
vcd network routed create <name> -g <gateway_name> --subnet 2.2.2.3/20
vcd network routed delete <name>

Testing Done: Added test case in vdc_routed_network.tests and executed them successfully

@chaitanya118 @pandeys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/278)
<!-- Reviewable:end -->
