### PR TITLE
VP-1250, VP-1291: Edit edge gateway name and gateway config ip settings

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -358,7 +358,7 @@ class GatewayTest(BaseTestCase):
         self._delete_external_network()
 
     def test_0015_edit_gateway_name(self):
-        """Removes external network from the gateway.
+        """Edits the gateway name.
          It will trigger the cli command update
         """
         result = self._runner.invoke(

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -357,6 +357,35 @@ class GatewayTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
         self._delete_external_network()
 
+    def test_0015_edit_gateway_name(self):
+        """Removes external network from the gateway.
+         It will trigger the cli command update
+        """
+        result = self._runner.invoke(
+            gateway,
+            args=['update', self._name, '--name', 'gateway2'])
+        self.assertEqual(0, result.exit_code)
+        """ resetting back to original name"""
+        result = self._runner.invoke(
+            gateway,
+            args=['update', 'gateway2', '--name', self._name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0016_edit_config_ip_settings(self):
+        """Edits the gateway config ip settings.
+
+        It will trigger the cli command with option config-ip-settings
+        """
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'configure-ip-settings', self._name, '-e',
+                self._ext_network_name, '-s', self._subnet_addr, True,
+                self._gateway_ip
+            ])
+        GatewayTest._logger.debug("result :{0}".format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(
             gateway, args=['delete', 'test_gateway1'])

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -83,6 +83,7 @@ def gateway(ctx):
 \b
         vcd gateway sync-syslog-settings gateway1
              Synchronizes syslog settings of the gateway with given name
+
 \b
         vcd gateway list-config-ip-settings gateway1
              lists the config ip settings of the gateway with given name
@@ -551,7 +552,8 @@ def edit_gateway_name(ctx, name, new_name):
     required=True,
     metavar='<subnet> <enable> <ip>',
     help='set the subnet settings')
-def edit_gateway_config_ip(ctx, name, external_networks_name, subnet_settings):
+def edit_gateway_config_ip_settings(ctx, name, external_networks_name,
+                                    subnet_settings):
     try:
         gateway_resource = _get_gateway(ctx, name)
         ext_network = dict()

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -95,7 +95,7 @@ def gateway(ctx):
             extNetwork --subnet-available 10.20.30.1/24 True 10.20.30.3
 
              edits the config ip settings of the gateway with given name
-             Parameter --subnet-available is a required parameter and
+             --subnet-available is a required parameter and
                 can have multiple entries
     """
     pass
@@ -530,7 +530,8 @@ def edit_gateway_name(ctx, name, new_name):
         stderr(e, ctx)
 
 
-@gateway.command('configure-ip-settings', short_help='update gateway name.')
+@gateway.command('configure-ip-settings', short_help='edit config ip settings.'
+                 )
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -86,6 +86,17 @@ def gateway(ctx):
 \b
         vcd gateway list-config-ip-settings gateway1
              lists the config ip settings of the gateway with given name
+\b
+        vcd gateway edit_gateway_name gateway1 --n gateway2
+             edits the gateway name
+
+\b
+        vcd gateway configure-ip-settings gateway1 --external-network
+            extNetwork --subnet-available 10.20.30.1/24 True 10.20.30.3
+
+             edits the config ip settings of the gateway with given name
+             Parameter --subnet-available is a required parameter and
+                can have multiple entries
     """
     pass
 
@@ -498,3 +509,62 @@ def remove_external_network(ctx, name, external_network_name):
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@gateway.command('update', short_help='update gateway name.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-n',
+    '--new-name',
+    'new_name',
+    required=True,
+    metavar='<new-name>',
+    help='new name of the gateway')
+def edit_gateway_name(ctx, name, new_name):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.edit_gateway_name(new_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@gateway.command('configure-ip-settings', short_help='update gateway name.')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_networks_name',
+    metavar='<external network>',
+    required=True,
+    help='external networks to which the new gateway can connect.')
+@click.option(
+    '-s',
+    '--subnet-available',
+    'subnet_settings',
+    nargs=3,
+    type=click.Tuple([str, bool, str]),
+    multiple=True,
+    required=True,
+    metavar='<subnet> <enable> <ip>',
+    help='set the subnet settings')
+def edit_gateway_config_ip(ctx, name, external_networks_name, subnet_settings):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        ext_network = dict()
+        subnet_participation = dict()
+        for setting in subnet_settings:
+            subnet_participation_settings = dict()
+            subnet_participation_settings['enable'] = setting[1]
+            subnet_participation_settings['ip_address'] = setting[2]
+            subnet_participation[setting[0]] = subnet_participation_settings
+
+        ext_network[external_networks_name] = subnet_participation
+        task = gateway_resource.edit_config_ip_settings(ext_network)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+


### PR DESCRIPTION
VP-1250, VP-1291: Edit edge gateway name and gateway config ip settings

VP-1250: Edit edge gateway name
User can edit the gateway name eg : vcd gateway edit_gateway_name gateway1 --n gateway2

VP-1292: Edit gateway config ip settings
User can change the Config ip settings, enable/disable subnet participation 
eg: vcd gateway configure-ip-settings gateway1 --external-network
            extNetwork --subnet-available 10.20.30.1/24 True 10.20.30.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/279)
<!-- Reviewable:end -->
