### PR TITLE
VP-1295:Add sub-allocate ip pools to gateway

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -23,10 +23,10 @@ logging:
 vcd:
 # Fill in the vCloud Dirctor host, sysadmin credentials and other related
 # information here. These will be required for the tests to run.
-  host: '<vcd ip>'
+  host: 'sc-rdops-vm03-dhcp-74-13.eng.vmware.com'
   api_version: '30.0'
-  sys_admin_username: 'administrator'
-  sys_admin_pass: '<root-password>'
+  sys_admin_username: 'root'
+  sys_admin_pass: 'ca$hc0w'
   sys_org_name: 'System'
 
 # The following params defines the org, pvdc, ovdc, etc. that the tests will
@@ -89,3 +89,5 @@ external_network:
     - subnet: '<gateway-ip/prefix_len>'
       ip_ranges:
         - '<start-ip>-<end-ip>'
+  gateway_sub_allocated_ip_range: '<ip-range>'
+  new_gateway_sub_allocated_ip_range: '<ip-range>'

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -23,10 +23,10 @@ logging:
 vcd:
 # Fill in the vCloud Dirctor host, sysadmin credentials and other related
 # information here. These will be required for the tests to run.
-  host: 'sc-rdops-vm03-dhcp-74-13.eng.vmware.com'
+  host: '<vcd ip>'
   api_version: '30.0'
-  sys_admin_username: 'root'
-  sys_admin_pass: 'ca$hc0w'
+  sys_admin_username: 'administrator'
+  sys_admin_pass: '<root-password>'
   sys_org_name: 'System'
 
 # The following params defines the org, pvdc, ovdc, etc. that the tests will

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -33,9 +33,9 @@ class GatewayTest(BaseTestCase):
     _runner = None
     _name = 'test_gateway1'
     _external_network_name = 'external_network_' + str(uuid1())
-    _subnet_addr = '10.10.30.1/24'
-    _ext_network_name = 'extNetwork'
-    _gateway_ip = '10.10.30.10'
+    _subnet_addr = None
+    _ext_network_name = None
+    _gateway_ip = None
     _logger = None
 
     def test_0000_setup(self):
@@ -394,15 +394,11 @@ class GatewayTest(BaseTestCase):
             gateway,
             args=[
                 'configure-ip-settings', self._name, '-e',
-                'extNetwork', '-s', self._subnet_addr, True,
+                self._ext_network_name, '-s', self._subnet_addr, True,
                 self._gateway_ip
             ])
-        args = [
-            'configure-ip-settings', self._name, '-e',
-            'extNetwork', '-s', self._subnet_addr, True,
-            self._gateway_ip
-        ]
-        GatewayTest._logger.debug("args :{0}".format(args))
+
+        GatewayTest._logger.debug("result :{0}".format(result))
         self.assertEqual(0, result.exit_code)
 
     def test_0017_add_sub_allocated_ip_pools(self):

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -570,4 +570,55 @@ def edit_gateway_config_ip_settings(ctx, name, external_networks_name,
     except Exception as e:
         stderr(e, ctx)
 
+@gateway.group(short_help='configures Sub allocate ip pools of gateway')
+@click.pass_context
+def sub_allocate_ip(ctx):
+    """Configures sub-allocate ip pools of gateway in vCloud Director.
+
+\b
+    Examples
+        vcd gateway sub-allocate-ip add gateway1
+            --external_network extNw1
+            --ip-range  10.10.10.20-10.10.10.30
+            Adds sub allocate ip pools to the edge gateway.
+
+\b
+        vcd gateway sub-allocate-ip update gateway1
+            -e extNw1
+            --old-ip-range 10.10.10.20-10.10.10.30
+            --new-ip-range 10.10.10.40-10.10.10.50
+            Updates sub allocate ip pools of the edge gateway.
+    """
+    pass
+
+
+@sub_allocate_ip.command(
+    'add', short_help='Adds sub allocate ip pools to the edge gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=False,
+    required=True,
+    help='external network to connected to the gateway.')
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    metavar='<ip range>',
+    multiple=True,
+    required=True,
+    help='ip ranges used for static pool allocation in the network.')
+def add_sub_allocated_ip_pools(ctx, name, external_network_name,
+                               ip_range):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.add_sub_allocated_ip_pools(
+            external_network_name, list(ip_range))
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
 

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -578,7 +578,7 @@ def sub_allocate_ip(ctx):
 \b
     Examples
         vcd gateway sub-allocate-ip add gateway1
-            --external_network extNw1
+            --external-network extNw1
             --ip-range  10.10.10.20-10.10.10.30
             Adds sub allocate ip pools to the edge gateway.
 
@@ -603,7 +603,7 @@ def sub_allocate_ip(ctx):
     metavar='<external network>',
     multiple=False,
     required=True,
-    help='external network to connected to the gateway.')
+    help='external network connected to the gateway.')
 @click.option(
     '-i',
     '--ip-range',


### PR DESCRIPTION
VP-1295:Add sub-allocate ip pools to gateway

Adds new ip range present to the sub allocate pool of gateway.

Examples
        vcd gateway sub-allocate-ip add gateway1
            --external_network extNw1
            --ip-range  10.10.10.20-10.10.10.30
            Adds sub allocate ip pools to the edge gateway

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/283)
<!-- Reviewable:end -->
