### PR TITLE
VP-1297:Edit gateway for Sub-Allocate IP Pools

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -375,6 +375,7 @@ class GatewayTest(BaseTestCase):
         """Edits the gateway name.
          It will trigger the cli command update
         """
+        GatewayTest._logger.debug("self._name{0}".format(self._name))
         result = self._runner.invoke(
             gateway,
             args=['update', self._name, '--name', 'gateway2'])
@@ -415,6 +416,25 @@ class GatewayTest(BaseTestCase):
             args=[
                 'sub-allocate-ip', 'add', 'test_gateway1', '-e',
                 ext_name, '--ip-range', gateway_sub_allocated_ip_range])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0018_edit_sub_allocated_ip_pools(self):
+        """Edits existing ip range present in the sub allocate pool of gateway.
+         It will trigger the cli command sub-allocate-ip update
+        """
+        self._config = Environment.get_config()
+        config = self._config['external_network']
+        gateway_sub_allocated_ip_range = \
+            config['gateway_sub_allocated_ip_range']
+        gateway_sub_allocated_ip_range1 = \
+            config['new_gateway_sub_allocated_ip_range']
+        ext_name = config['name']
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'sub-allocate-ip', 'update', 'test_gateway1', '-e',
+                ext_name, '-o', gateway_sub_allocated_ip_range,
+                '-n', gateway_sub_allocated_ip_range1])
         self.assertEqual(0, result.exit_code)
 
     def test_0098_tearDown(self):

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -375,7 +375,6 @@ class GatewayTest(BaseTestCase):
         """Edits the gateway name.
          It will trigger the cli command update
         """
-        GatewayTest._logger.debug("self._name{0}".format(self._name))
         result = self._runner.invoke(
             gateway,
             args=['update', self._name, '--name', 'gateway2'])

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -570,6 +570,7 @@ def edit_gateway_config_ip_settings(ctx, name, external_networks_name,
     except Exception as e:
         stderr(e, ctx)
 
+
 @gateway.group(short_help='configures Sub allocate ip pools of gateway')
 @click.pass_context
 def sub_allocate_ip(ctx):
@@ -622,3 +623,41 @@ def add_sub_allocated_ip_pools(ctx, name, external_network_name,
     except Exception as e:
         stderr(e, ctx)
 
+
+@sub_allocate_ip.command(
+    'update', short_help='Edits sub allocate IP pools to the edge gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=False,
+    required=True,
+    help='external network connected to the gateway.')
+@click.option(
+    '-o',
+    '--old-ip-range',
+    'old_ip_range',
+    metavar='<old-ip-range>',
+    multiple=False,
+    required=True,
+    help='existing IP ranges used for static pool allocation in the network.')
+@click.option(
+    '-n',
+    '--new-ip-range',
+    'new_ip_range',
+    metavar='<new-ip-range>',
+    multiple=False,
+    required=True,
+    help='new IP range to replace the existing IP range.')
+def edit_sub_allocated_ip_pools(ctx, name, external_network_name, old_ip_range,
+                                new_ip_range):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.edit_sub_allocated_ip_pools(
+            external_network_name, old_ip_range, new_ip_range)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION
Edit gateway for Sub-Allocate IP Pools

User can edit the existing ip range present in the sub allocate pool of gateway.
For example :
vcd gateway sub-allocate-ip update gateway1
            -e extNw1
            --old-ip-range 10.10.10.20-10.10.10.30
            --new-ip-range 10.10.10.40-10.10.10.50

Made changes to gateway.py and gateway_tests.py file and implemented edit_sub_allocated_ip_pools method in gateway.py file to achieve the functionality

Test cases are passing
