### PR TITLE
VP-1299:Remove suballocate ip pool of the gateway

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -452,7 +452,7 @@ class GatewayTest(BaseTestCase):
                 ext_name, '-i', gateway_sub_allocated_ip_range])
 
         GatewayTest._logger.debug(
-            "vcd gateway 'sub-allocate-ip remove {0}"
+            "vcd gateway sub-allocate-ip remove {0}"
             "-e {1} -i {2}".format(
                 self._name, ext_name, gateway_sub_allocated_ip_range))
         self.assertEqual(0, result.exit_code)

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -377,12 +377,12 @@ class GatewayTest(BaseTestCase):
         """
         result = self._runner.invoke(
             gateway,
-            args=['update', self._name, '--name', 'gateway2'])
+            args=['update', self._name, '-n', 'gateway2'])
         self.assertEqual(0, result.exit_code)
         """ resetting back to original name"""
         result = self._runner.invoke(
             gateway,
-            args=['update', 'gateway2', '--name', self._name])
+            args=['update', 'gateway2', '-n', self._name])
         self.assertEqual(0, result.exit_code)
 
     def test_0016_edit_config_ip_settings(self):
@@ -434,6 +434,27 @@ class GatewayTest(BaseTestCase):
                 'sub-allocate-ip', 'update', 'test_gateway1', '-e',
                 ext_name, '-o', gateway_sub_allocated_ip_range,
                 '-n', gateway_sub_allocated_ip_range1])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0019_remove_sub_allocated_ip_pools(self):
+        """Removes the given IP ranges from existing IP ranges.
+         It will trigger the cli command sub-allocate-ip remove
+        """
+        self._config = Environment.get_config()
+        config = self._config['external_network']
+        gateway_sub_allocated_ip_range = \
+            config['new_gateway_sub_allocated_ip_range']
+        ext_name = config['name']
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'sub-allocate-ip', 'remove', self._name, '-e',
+                ext_name, '-i', gateway_sub_allocated_ip_range])
+
+        GatewayTest._logger.debug(
+            "vcd gateway 'sub-allocate-ip remove {0}"
+            "-e {1} -i {2}".format(
+                self._name, ext_name, gateway_sub_allocated_ip_range))
         self.assertEqual(0, result.exit_code)
 
     def test_0098_tearDown(self):

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -589,6 +589,10 @@ def sub_allocate_ip(ctx):
             --old-ip-range 10.10.10.20-10.10.10.30
             --new-ip-range 10.10.10.40-10.10.10.50
             Updates sub allocate ip pools of the edge gateway.
+\b
+        vcd gateway sub-allocate-ip remove gateway1
+            -e extNetwork -i 10.10.10.40-10.10.10.50
+            Removes the provided IP range
     """
     pass
 
@@ -658,6 +662,36 @@ def edit_sub_allocated_ip_pools(ctx, name, external_network_name, old_ip_range,
         gateway_resource = _get_gateway(ctx, name)
         task = gateway_resource.edit_sub_allocated_ip_pools(
             external_network_name, old_ip_range, new_ip_range)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@sub_allocate_ip.command(
+    'remove', short_help='Removes the given IP ranges from existing IP ranges')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=False,
+    required=True,
+    help='external network connected to the gateway.')
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    metavar='<old-ip-range>',
+    multiple=False,
+    required=True,
+    help='IP ranges that needs to be removed.')
+def remove_sub_allocated_ip_pools(ctx, name, external_network_name, ip_range):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.remove_sub_allocated_ip_pools(
+            external_network_name, [ip_range])
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1299:Remove sub allocate ip pool of the gateway

Removes the given IP ranges from the sub allocated pool, with these changes user would be able to delete the list of ip ranges from sub allocate ip pool of the gateway.
for example:
vcd gateway sub-allocate-ip remove gateway -e extNetwork -i 10.10.10.40-10.10.10.50

Implemented remove_sub_allocated_ip_pools in gateway.py to achieve the functionalities.

Test case is passed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/287)
<!-- Reviewable:end -->
