### PR TITLE
Under-score changed to Hyphen in windows resulting in gateway_tests failure in unix

### DIFF
--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -438,7 +438,8 @@ def list_config_ip_settings(ctx, name):
     except Exception as e:
         stderr(e, ctx)
 
-@gateway.group(short_help='configures external networks of an edge gateway')
+@gateway.group('configure-external-network',
+            short_help='configures external networks of an edge gateway')
 @click.pass_context
 def configure_external_network(ctx):
     """Configures external networks of edge gateways in vCloud Director.
@@ -571,7 +572,8 @@ def edit_gateway_config_ip_settings(ctx, name, external_networks_name,
         stderr(e, ctx)
 
 
-@gateway.group(short_help='configures Sub allocate ip pools of gateway')
+@gateway.group('sub-allocate-ip', short_help='configures Sub allocate ip '
+                                            'pools of gateway')
 @click.pass_context
 def sub_allocate_ip(ctx):
     """Configures sub-allocate ip pools of gateway in vCloud Director.


### PR DESCRIPTION
Before the fix, output for command vcd gateway -h shows configure_external_network in unix but configure-external-network in windows. Because of this, test cases which are posting command with '-' were succeeding in windows but failing in unix.

Same issue was with sub-allocate-ip sub-group.

After this fix, both group mentioned above will work with '-' and also show in 'vcd gateway -h' output.

Testing Done: Run the command where '-' is shown as the output and also executed the command without any error.
vcd gateway configure-external network -h

@guptaankit52 @chaitanya118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/288)
<!-- Reviewable:end -->
