### PR TITLE
VP-1258: Attach port groups to an external network

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -206,7 +206,7 @@ class ExtNetTest(BaseTestCase):
                 '--ip-range', self._ip_range3])
         self.assertEqual(0, result.exit_code)
 
-    def test_0034_attach_port_group(self):
+    def test_0040_attach_port_group(self):
         """Attach a portgroup to an external network.
         Invoke the command 'external attach-port-group' in network.
         """
@@ -223,7 +223,7 @@ class ExtNetTest(BaseTestCase):
                 '--port-group', pg_name])
         self.assertEqual(0, result.exit_code)
 
-        def test_0035_detach_port_group(self):
+        def test_0041_detach_port_group(self):
             """Detach port group from an external network.
             Invoke the command 'external detach-port-group' in network.
             """

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -43,6 +43,7 @@ class ExtNetTest(BaseTestCase):
     _name = 'external_network_' + str(uuid1())
     _description = 'Description of external_network_' + str(uuid1())
     _port_group = None
+    _portgroupType = "DV_PORTGROUP"
     _gateway = '10.20.30.1'
     _netmask = '255.255.255.0'
     _ip_range = '10.20.30.2-10.20.30.99'
@@ -205,7 +206,24 @@ class ExtNetTest(BaseTestCase):
                 '--ip-range', self._ip_range3])
         self.assertEqual(0, result.exit_code)
 
-        def test_0034_detach_port_group(self):
+    def test_0034_attach_port_group(self):
+        """Attach port group from an external network.
+        Invoke the command 'external attach-port-group' in network.
+        """
+        ExtNetTest._client = Environment.get_sys_admin_client()
+
+        port_group_helper = PortgroupHelper(ExtNetTest._client)
+        vc_name = self._config['vc2']['vcenter_host_name']
+        pg_name = port_group_helper. \
+            get_available_portgroup_name(vc_name, ExtNetTest._portgroupType)
+        result = self._runner.invoke(
+            external,
+            args=[
+                'attach-port-group', self._name, '--vc-name', vc_name,
+                '--port-group', pg_name])
+        self.assertEqual(0, result.exit_code)
+
+        def test_0035_detach_port_group(self):
             """Detach port group from an external network.
             Invoke the command 'external detach-port-group' in network.
             """

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -207,7 +207,7 @@ class ExtNetTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_0034_attach_port_group(self):
-        """Attach port group from an external network.
+        """Attach a portgroup to an external network.
         Invoke the command 'external attach-port-group' in network.
         """
         ExtNetTest._client = Environment.get_sys_admin_client()

--- a/system_tests/helpers/portgroup_helper.py
+++ b/system_tests/helpers/portgroup_helper.py
@@ -49,3 +49,33 @@ class PortgroupHelper(object):
             raise EntityNotFoundException('port group not found in'
                                           'vCenter : ' + vim_server_name)
         return pgroup_name
+
+    def get_available_portgroup_name(self, vim_server_name, portgroupType):
+        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
+
+        Query uses vCenter Server name as filter and returns the first available
+        portgroup
+
+        :param str vim_server_name: vCenter server name
+        :param str portgroupType: type of port group
+        :return: name of the portgroup
+        :rtype: str
+        :raises: EntityNotFoundException: if any port group cannot be found.
+        """
+        name_filter = ('vcName', vim_server_name)
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+        pgroup_name = ''
+        for record in list(query.execute()):
+            if record.get('networkName') == '--':
+                if record.get('portgroupType') == portgroupType  \
+                   and not record.get('name').startswith('vxw-'):
+                    pgroup_name = record.get('name')
+                    break
+        if not pgroup_name:
+            raise EntityNotFoundException('port group not found in'
+                                          'vCenter : ' + vim_server_name)
+
+        return pgroup_name

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -794,7 +794,7 @@ def detach_port_group_external_network(ctx, name, vc_name, pg_name):
 
 @external.command(
     'attach-port-group',
-    short_help='Attach port group from an external network.')
+    short_help='Attach a portgroup to an external network.')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.option(

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -104,6 +104,11 @@ def external(ctx):
                --new-ip-range 192.168.1.25-192.168.1.50
 
 \b
+       vcd network external attach-port-group external-net1
+               --vc-name vc1
+               --port-group pg1
+
+\b
        vcd network external detach-port-group external-net1
                --vc-name vc1
                --port-group pg1
@@ -783,6 +788,33 @@ def detach_port_group_external_network(ctx, name, vc_name, pg_name):
                                                port_group_name=pg_name)
         stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
         stdout('Port group detached successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@external.command(
+    'attach-port-group',
+    short_help='Attach port group from an external network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '--vc-name',
+    'vc_name',
+    required=True,
+    help='name of the vcenter')
+@click.option(
+    '--port-group',
+    'pg_name',
+    required=True,
+    help='name of the port group present in vCenter')
+def attach_port_group_external_network(ctx, name, vc_name, pg_name):
+    try:
+        extnet_obj = _get_ext_net_obj(ctx, name)
+
+        ext_net = extnet_obj.attach_port_group(vim_server_name=vc_name,
+                                               port_group_name=pg_name)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+        stdout('Port group attached successfully.', ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
Attaches a port group of same type to an external network using vcd-cli command.

Testing Done:
vcd- cli command:
C:\dev2-python-dnd\vcd-cli>vcd network external attach-port-group ext --vc-name vc2 --port-group DPortGroup
networkUpdateNetwork: Updating Network ext(01483b37-3919-4772-82d9-f9cbf6bea8c9)
task: dfcb4620-7adb-45c3-8d49-1d8df0fb8495, Updated Network ext(01483b37-3919-4772-82d9-f9cbf6bea8c9), result: success
Port group attached successfully.

unittest:
C:\dev2-python-dnd\vcd-cli\system_tests>python -m unittest extnet_tests.py
........
----------------------------------------------------------------------
Ran 8 tests in 151.751s

OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/289)
<!-- Reviewable:end -->
