### PR TITLE
Delete ip range

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -203,7 +203,6 @@ class ExtNetTest(BaseTestCase):
         Invoke the command 'external detach-port-group' in network.
         """
         ExtNetTest._client = Environment.get_sys_admin_client()
-        #       platform = Platform(self.client)
         port_group_helper = PortgroupHelper(ExtNetTest._client)
         vc_name = self._config['vc2']['vcenter_host_name']
         pg_name = port_group_helper. \

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -161,20 +161,7 @@ class ExtNetTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
-    def test_0031_modify_ip_range(self):
-        """Modify an IP range of a subnet in an external network.
-
-        Invoke the command 'external modify-ip-range' in network.
-        """
-        result = self._runner.invoke(
-            external,
-            args=[
-                'modify-ip-range', self._name, '--gateway-ip', self._gateway1,
-                '--ip-range', self._ip_range1, '--new-ip-range', self._ip_range2
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0032_enable_subnet(self):
+    def test_0031_enable_subnet(self):
         """Enable/Disable subnet of an external network.
 
         Invoke the command 'external enable-subnet' in network.
@@ -194,18 +181,6 @@ class ExtNetTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
-    def test_0033_add_ip_range(self):
-        """Add an IP range to a subnet in an external network.
-
-        Invoke the command 'external add-ip-range' in network.
-        """
-        result = self._runner.invoke(
-            external,
-            args=[
-                'add-ip-range', self._name, '--gateway-ip', self._gateway1,
-                '--ip-range', self._ip_range3])
-        self.assertEqual(0, result.exit_code)
-
     def test_0040_attach_port_group(self):
         """Attach a portgroup to an external network.
         Invoke the command 'external attach-port-group' in network.
@@ -223,22 +198,61 @@ class ExtNetTest(BaseTestCase):
                 '--port-group', pg_name])
         self.assertEqual(0, result.exit_code)
 
-        def test_0041_detach_port_group(self):
-            """Detach port group from an external network.
-            Invoke the command 'external detach-port-group' in network.
-            """
-            ExtNetTest._client = Environment.get_sys_admin_client()
-            #       platform = Platform(self.client)
-            port_group_helper = PortgroupHelper(ExtNetTest._client)
-            vc_name = self._config['vc2']['vcenter_host_name']
-            pg_name = port_group_helper. \
-                get_ext_net_used_portgroup_name(vc_name, self._name)
-            result = self._runner.invoke(
-                external,
-                args=[
-                    'detach-port-group', self._name, '--vc-name', vc_name,
-                    '--port-group', pg_name])
-            self.assertEqual(0, result.exit_code)
+    def test_0041_detach_port_group(self):
+        """Detach port group from an external network.
+        Invoke the command 'external detach-port-group' in network.
+        """
+        ExtNetTest._client = Environment.get_sys_admin_client()
+        #       platform = Platform(self.client)
+        port_group_helper = PortgroupHelper(ExtNetTest._client)
+        vc_name = self._config['vc2']['vcenter_host_name']
+        pg_name = port_group_helper. \
+            get_ext_net_used_portgroup_name(vc_name, self._name)
+        result = self._runner.invoke(
+            external,
+            args=[
+                'detach-port-group', self._name, '--vc-name', vc_name,
+                '--port-group', pg_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0050_add_ip_range(self):
+        """Add an IP range to a subnet in an external network.
+
+        Invoke the command 'external add-ip-range' in network.
+        """
+        result = self._runner.invoke(
+            external,
+            args=[
+                'add-ip-range', self._name, '--gateway-ip', self._gateway1,
+                '--ip-range', self._ip_range3])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0051_modify_ip_range(self):
+        """Modify an IP range of a subnet in an external network.
+
+        Invoke the command 'external modify-ip-range' in network.
+        """
+        result = self._runner.invoke(
+            external,
+            args=[
+                'modify-ip-range', self._name, '--gateway-ip', self._gateway1,
+                '--ip-range', self._ip_range1, '--new-ip-range',
+                self._ip_range2
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0052_remove_ip_range(self):
+        """Remove an IP range of a subnet in an external network.
+
+        Invoke the command 'external remove-ip-range' in network.
+        """
+        result = self._runner.invoke(
+            external,
+            args=[
+                'remove-ip-range', self._name, '--gateway-ip', self._gateway1,
+                '--ip-range', self._ip_range2
+            ])
+        self.assertEqual(0, result.exit_code)
 
     def test_0100_delete(self):
         """Delete the external network created.

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -50,6 +50,7 @@ class ExtNetTest(BaseTestCase):
     _gateway1 = '10.10.30.1'
     _ip_range1 = '10.10.30.2-10.10.30.99'
     _ip_range2 = '10.10.30.30-10.10.30.60'
+    _ip_range3 = '10.10.30.101-10.10.30.110'
 
     def setUp(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -188,6 +189,18 @@ class ExtNetTest(BaseTestCase):
                 'enable-subnet', self._name, '--gateway', self._gateway1,
                 '--disable'
             ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0033_add_ip_range(self):
+        """Add an IP range of a subnet in an external network.
+
+        Invoke the command 'external add-ip-range' in network.
+        """
+        result = self._runner.invoke(
+            external,
+            args=[
+                'add-ip-range', self._name, '--gateway-ip', self._gateway1,
+                '--ip-range', self._ip_range3])
         self.assertEqual(0, result.exit_code)
 
     def test_0100_delete(self):

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -93,6 +93,11 @@ def external(ctx):
             Enable/Disable subnet of an external network.
 
 \b
+       vcd network external add-ip-range external-net1
+               --gateway-ip 192.168.1.1
+               --ip-range 192.168.1.2-192.168.1.20
+
+\b
        vcd network external modify-ip-range external-net1
                --gateway-ip 192.168.1.1
                --ip-range 192.168.1.2-192.168.1.20
@@ -674,6 +679,39 @@ def _get_platform(ctx):
     restore_session(ctx)
     client = ctx.obj['client']
     return Platform(client)
+
+
+@external.command(
+    'add-ip-range',
+    short_help='Adds an IP range of a subnet in an external network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-g',
+    '--gateway-ip',
+    'gateway_ip',
+    required=True,
+    metavar='<ip>',
+    help='gateway ip of the subnet')
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    required=True,
+    multiple=True,
+    metavar='<ip>',
+    help='ip range in StartAddress-EndAddress format')
+def add_ip_range_external_network(ctx, name, gateway_ip, ip_range):
+    try:
+        extnet_obj = _get_ext_net_obj(ctx, name)
+
+        ext_net = extnet_obj.add_ip_range(
+            gateway_ip=gateway_ip,
+            ip_ranges=ip_range)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+        stdout('Ip Range of a subnet added successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
 
 
 @external.command(

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -787,6 +787,7 @@ def modify_ip_range_external_network(ctx, name, gateway_ip, ip_range,
     '--ip-range',
     'ip_range',
     required=True,
+    multiple=True,
     metavar='<ip>',
     help='ip range in StartAddress-EndAddress format')
 def remove_ip_range_external_network(ctx, name, gateway_ip, ip_range):
@@ -795,7 +796,7 @@ def remove_ip_range_external_network(ctx, name, gateway_ip, ip_range):
 
         ext_net = extnet_obj.delete_ip_range(
             gateway_ip=gateway_ip,
-            ip_range=ip_range)
+            ip_ranges=ip_range)
         stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
         stdout('Ip Range of a subnet removed successfully.', ctx)
     except Exception as e:

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -104,6 +104,11 @@ def external(ctx):
                --new-ip-range 192.168.1.25-192.168.1.50
 
 \b
+       vcd network external remove-ip-range external-net1
+               --gateway-ip 192.168.1.1
+               --ip-range 192.168.1.2-192.168.1.20
+
+\b
        vcd network external attach-port-group external-net1
                --vc-name vc1
                --port-group pg1
@@ -761,6 +766,38 @@ def modify_ip_range_external_network(ctx, name, gateway_ip, ip_range,
             new_ip_range=new_ip_range)
         stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
         stdout('Ip Range of a subnet modified successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@external.command(
+    'remove-ip-range',
+    short_help='Removes an IP range of a subnet in an external network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-g',
+    '--gateway-ip',
+    'gateway_ip',
+    required=True,
+    metavar='<ip>',
+    help='gateway ip of the subnet')
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    required=True,
+    metavar='<ip>',
+    help='ip range in StartAddress-EndAddress format')
+def remove_ip_range_external_network(ctx, name, gateway_ip, ip_range):
+    try:
+        extnet_obj = _get_ext_net_obj(ctx, name)
+
+        ext_net = extnet_obj.delete_ip_range(
+            gateway_ip=gateway_ip,
+            ip_range=ip_range)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+        stdout('Ip Range of a subnet removed successfully.', ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP 1446: [VCD-CLI] Delete an IP range of a subnet in external network

[VCD-CLI] Delete an IP range of a subnet in external network

This CLN contains code fro removing an IP range of a subnet in an
external network and it's test cases.
User can usel this command as:

vcd network external remove-ip-range <external_network_name>
--g <gateway-ip> --ip-range <startaddress-endaddress>

Testing done:
Test case for remove ip range is added to a test class,
extnet_tests.py
All tests in extnet_tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/290)
<!-- Reviewable:end -->
