### PR TITLE
VP-1490:Edit gateway for Configure Rate Limits

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -457,6 +457,19 @@ class GatewayTest(BaseTestCase):
                 self._name, ext_name, gateway_sub_allocated_ip_range))
         self.assertEqual(0, result.exit_code)
 
+    def test_0020_update_rate_limit(self):
+        """Updates existing rate limit of gateway.
+         It will trigger the cli command configure-rate-limits update
+        """
+        self._config = Environment.get_config()
+        config = self._config['external_network']
+        ext_name = config['name']
+        result = self._runner.invoke(
+            gateway,
+            args=[
+                'configure-rate-limits', 'update', self._name, '-e',
+                [(ext_name, '101.0', '101.0')]])
+
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(
             gateway, args=['delete', 'test_gateway1'])

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -467,7 +467,7 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway,
             args=[
-                'configure-rate-limits', 'update', self._name, '-e',
+                'configure-rate-limits', 'update', self._name, '-r',
                 [(ext_name, '101.0', '101.0')]])
 
     def test_0098_tearDown(self):

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -697,3 +697,43 @@ def remove_sub_allocated_ip_pools(ctx, name, external_network_name, ip_range):
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@gateway.group('configure-rate-limits', short_help='configures rate limits of'
+                                                   ' gateway')
+@click.pass_context
+def configure_rate_limits(ctx):
+    """Configures rate limit of gateway in vCloud Director.
+
+\b
+    Examples
+        vcd gateway configure-rate-limits update gateway1
+            --e extNw1 101.0 101.0
+            updates the rate limit of gateway.
+    """
+    pass
+
+
+@configure_rate_limits.command('update', short_help='updates rate limit of '
+                                                    'gateway.')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '-e',
+    'rate_limit_config',
+    nargs=3,
+    type=click.Tuple([str, str, str]),
+    multiple=True,
+    default=None,
+    metavar='<external network> <rate limit start> <rate limit end>',
+    help='Updates existing rate limits')
+def update_configure_rate_limits(ctx, name, rate_limit_config):
+    try:
+        rate_limit_conf = dict()
+        for config in rate_limit_config:
+            rate_limit_conf[config[0]] = [config[1], config[2]]
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.edit_rate_limits(rate_limit_conf)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -719,12 +719,13 @@ def configure_rate_limits(ctx):
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
-    '-e',
+    '-r',
     'rate_limit_config',
     nargs=3,
     type=click.Tuple([str, str, str]),
     multiple=True,
     default=None,
+    required=True,
     metavar='<external network> <rate limit start> <rate limit end>',
     help='Updates existing rate limits')
 def update_configure_rate_limits(ctx, name, rate_limit_config):


### PR DESCRIPTION
VP-1490:Edit gateway for Configure Rate Limits

Updates gateway for Configure Rate Limits of gateway

Using this user would be able to update the Configure Rate Limits of gateway through command line:
e.g: vcd gateway configure-rate-limits update gateway1 --e extNw1 101.0 101.0

Testing done: Test cases passed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/293)
<!-- Reviewable:end -->
