### PR TITLE
[VP-1360]Edit routed network for Static IP pool under Network Specification (Add)

### DIFF
--- a/system_tests/vdc_network_tests.py
+++ b/system_tests/vdc_network_tests.py
@@ -24,6 +24,9 @@ class VdcNetworkTests(BaseTestCase):
     """
     _runner = None
     _name = 'test_routed_Nw'+ str(uuid1())
+    __subnet = '6.6.5.1/20'
+    __ip_range1 = '6.6.5.2-6.6.5.20'
+    __ip_range2 = '6.6.6.2-6.6.6.20'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -35,11 +38,10 @@ class VdcNetworkTests(BaseTestCase):
         self._login()
         VdcNetworkTests._runner.invoke(org, ['use', default_org])
         result_create1 = VdcNetworkTests._runner.invoke(network, ['routed',
-                                                                  'create',
-                                                 VdcNetworkTests._name,
-                                                 '-g', GatewayConstants.name,
-                                                 '--subnet', '6.6.5.1/20'
-                                                 ])
+                        'create', VdcNetworkTests._name,
+                        '-g', GatewayConstants.name, '--subnet',
+                        VdcNetworkTests.__subnet
+                        ])
 
         self.assertEqual(0, result_create1.exit_code)
 
@@ -55,6 +57,14 @@ class VdcNetworkTests(BaseTestCase):
         result = self._runner.invoke(
             network, args=['routed', 'edit', _new_name,
                            '-n', VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0010_add_ip_ranges_of_routed_nw(self):
+
+        result = self._runner.invoke(
+            network, args=['routed', 'add-ip-ranges', VdcNetworkTests._name,
+                           '--ip-range', VdcNetworkTests.__ip_range1,
+                           '--ip-range', VdcNetworkTests.__ip_range2])
         self.assertEqual(0, result.exit_code)
 
     def test_0098_tearDown(self):

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -123,6 +123,7 @@ def external(ctx):
        vcd network external list-pvdc ExtNw --filter name==pvdc*
 
         List available provider vdcs
+
     """
     pass
 
@@ -882,6 +883,11 @@ def routed(ctx):
             --description new_description
             --shared-enabled/--shared-disabled
         Edit name, description and shared state of org vdc network
+
+\b
+        vcd network routed add-ip-ranges vdc_routed_nw
+            --ip-range  2.2.3.1-2.2.3.2
+            --ip-range 2.2.4.1-2.2.4.2
     """
     pass
 
@@ -1067,5 +1073,30 @@ def list_available_pvdcs(ctx, name, filter):
         result = []
         result.append({'Provider Vdcs':assoc_prov_vdc_name})
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@routed.command('add-ip-ranges', short_help='add IP range of '
+                                                 'routed org vdc network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_ranges',
+    required=True,
+    multiple=True,
+    metavar='<ip>',
+    help='ip range in StartAddress-EndAddress format')
+def add_ip_ranges_of_routed_vdc_network(ctx, name, ip_ranges):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        client = ctx.obj['client']
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        vdcNetwork = VdcNetwork(client, resource=routed_network)
+        task = vdcNetwork.add_static_ip_pool(ip_ranges)
+        stdout(task, ctx)
+        stdout('Add of ip ranges for routed org vdc network is successfull.',
+               ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
User can add ip range for org vdc routed network. It has support for adding multiple ip range simultaneously.
Command: vcd network routed add-ip-ranges vdc_routed_nw --ip-range 6.6.2.1-6.6.2.10 --ip-range 6.6.3.1-6.6.3.10

Testing Done: Added test case for this functionality and executed them successfully.

@shashim22 @guptaankit52 