### PR TITLE
VP-1355]List routed vdc networks

### DIFF
--- a/system_tests/vdc_network_tests.py
+++ b/system_tests/vdc_network_tests.py
@@ -68,7 +68,7 @@ class VdcNetworkTests(BaseTestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_0020_list_all_routed_nw(self):
-
+        """List available vdc routed networks in vdc."""
         result = self._runner.invoke(
             network, args=['routed', 'list'])
         self.assertEqual(0, result.exit_code)

--- a/system_tests/vdc_network_tests.py
+++ b/system_tests/vdc_network_tests.py
@@ -67,6 +67,12 @@ class VdcNetworkTests(BaseTestCase):
                            '--ip-range', VdcNetworkTests.__ip_range2])
         self.assertEqual(0, result.exit_code)
 
+    def test_0020_list_all_routed_nw(self):
+
+        result = self._runner.invoke(
+            network, args=['routed', 'list'])
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(
             network, args=['routed', 'delete', VdcNetworkTests._name])

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -888,6 +888,10 @@ def routed(ctx):
         vcd network routed add-ip-ranges vdc_routed_nw
             --ip-range  2.2.3.1-2.2.3.2
             --ip-range 2.2.4.1-2.2.4.2
+
+\b
+        vcd network routed list
+            List all routed org vdc networks in the selected vdc
     """
     pass
 
@@ -1098,5 +1102,20 @@ def add_ip_ranges_of_routed_vdc_network(ctx, name, ip_ranges):
         stdout(task, ctx)
         stdout('Add of ip ranges for routed org vdc network is successfull.',
                ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@routed.command(
+    'list',
+    short_help='list all routed org vdc networks in the selected vdc')
+@click.pass_context
+def list_routed_networks(ctx):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        routed_nets = vdc.list_orgvdc_routed_networks()
+        result = []
+        for routed_net in routed_nets:
+            result.append({'name': routed_net.get('name')})
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
User can list all the available org prov vdc routed network present in vdc.

Command: vcd network routed list

Testing Done: New tese case has been added and executed the complete test class successfully.

@shashim22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/295)
<!-- Reviewable:end -->
