### PR TITLE
List allocated ip

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -271,6 +271,15 @@ class ExtNetTest(BaseTestCase):
             external, args=['list-gateway', self._name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0065_list_allocated_ip(self):
+        """List allocated ip.
+
+        Invoke the command 'external list-allocated-ip' in network.
+        """
+        result = self._runner.invoke(
+            external, args=['list-allocated-ip', self._name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0100_delete(self):
         """Delete the external network created.
 

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -50,6 +50,7 @@ class ExtNetTest(BaseTestCase):
     _gateway1 = '10.10.30.1'
     _ip_range1 = '10.10.30.2-10.10.30.99'
     _ip_range2 = '10.10.30.30-10.10.30.60'
+    _ip_range3 = '10.10.30.101-10.10.30.110'
 
     def setUp(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -188,6 +189,18 @@ class ExtNetTest(BaseTestCase):
                 'enable-subnet', self._name, '--gateway', self._gateway1,
                 '--disable'
             ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0033_add_ip_range(self):
+        """Add an IP range of a subnet in an external network.
+
+        Invoke the command 'external add-ip-range' in network.
+        """
+        result = self._runner.invoke(
+            external,
+            args=[
+                'add-ip-range', self._name, '--gateway-ip', self._gateway1,
+                '--ip-range', self._ip_range3])
         self.assertEqual(0, result.exit_code)
 
     def test_0100_delete(self):

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -93,6 +93,11 @@ def external(ctx):
             Enable/Disable subnet of an external network.
 
 \b
+       vcd network external add-ip-range external-net1
+               --gateway-ip 192.168.1.1
+               --ip-range 192.168.1.2-192.168.1.20
+
+\b
        vcd network external modify-ip-range external-net1
                --gateway-ip 192.168.1.1
                --ip-range 192.168.1.2-192.168.1.20
@@ -674,6 +679,39 @@ def _get_platform(ctx):
     restore_session(ctx)
     client = ctx.obj['client']
     return Platform(client)
+
+
+@external.command(
+    'add-ip-range',
+    short_help='Adds an IP range of a subnet in an external network.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '-g',
+    '--gateway-ip',
+    'gateway_ip',
+    required=True,
+    metavar='<ip>',
+    help='gateway ip of the subnet')
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    required=True,
+    multiple=True,
+    metavar='<ip>',
+    help='ip range in StartAddress-EndAddress format')
+def add_ip_range_external_network(ctx, name, gateway_ip, ip_range):
+    try:
+        extnet_obj = _get_ext_net_obj(ctx, name)
+
+        ext_net = extnet_obj.add_ip_range(
+            gateway_ip=gateway_ip,
+            ip_ranges=ip_range)
+        stdout(ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0], ctx)
+        stdout('Ip Range of a subnet added successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
 
 
 @external.command(

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -129,6 +129,11 @@ def external(ctx):
 
        List associated gateways
 
+\b
+        vcd network external list-allocated-ip ExtNw --filter name==gateway*
+
+       List allocated ip
+
     """
     pass
 
@@ -1109,6 +1114,26 @@ def list_available_gateways(ctx, name, filter):
         result = []
         result.append({'Gateways':assoc_edge_gateways_name})
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@external.command('list-allocated-ip', short_help='list allocated ip.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '--filter',
+    'filter',
+    default=None,
+    metavar='<name==gateway*>',
+    help='filter for gateway')
+def list_allocated_ip(ctx, name, filter):
+    try:
+        platform = _get_platform(ctx)
+        client = ctx.obj['client']
+        ext_net = platform.get_external_network(name)
+        ext_net_obj = ExternalNetwork(client, resource=ext_net)
+        allocated_ip = ext_net_obj.list_allocated_ip_address(filter)
+        stdout(allocated_ip, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP 1265: [VCD-CLI] List allocated IP addresses

    [VCD-CLI] List allocated IP addresses

    This CLN contains cli aommnad for listing allocated ip and gateways name
    associated with given external_network.It also contains related test
    cases.

    User can call this cli command as:
    vcd network external list-allocated-ip <ext_net_name>
    vcd network external list-allocated-ip <ext_net_name> --filter
    name==<gateway_name>

    Testing done:
    Test case for list associated gateways  is added to a test class,
    extnet_tests.py
    All tests in extnet_tests passed.