### PR TITLE
Handle fallout of replacing flufl.enum with standard enum in pycloud.

### DIFF
--- a/vcd_cli/task.py
+++ b/vcd_cli/task.py
@@ -65,8 +65,8 @@ def info(ctx, task_id):
 @click.pass_context
 @click.argument(
     'status',
-    type=click.Choice(TaskStatus._enums.keys()),
-    metavar=as_metavar(TaskStatus._enums.keys()),
+    type=click.Choice(list(TaskStatus.__members__.keys())),
+    metavar=as_metavar(list(TaskStatus.__members__.keys())),
     required=False,
     nargs=-1)
 def list_tasks(ctx, status):
@@ -106,8 +106,8 @@ def wait(ctx, task_id):
 @click.pass_context
 @click.argument(
     'status',
-    type=click.Choice(TaskStatus._enums.keys()),
-    metavar=as_metavar(TaskStatus._enums.keys()),
+    type=click.Choice(list(TaskStatus.__members__.keys())),
+    metavar=as_metavar(list(TaskStatus.__members__.keys())),
     required=True)
 @click.argument('task_id', metavar='<id>', required=True)
 def update(ctx, status, task_id):


### PR DESCRIPTION
With PR 348 on pyvcloud, flufl.enum has been replaced with standard python enum.

As a fallout in vcd-cli, code pieces that were using flufl.enum constructs like _enum had to be replaced with their enum counterparts.

Testing done:
Without the current change all commands fail in vcd-cli

With the change in : 
checked manually that the following commands that are affected by the change succeed
vcd task list -h
vcd task update -h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/300)
<!-- Reviewable:end -->
