### PR TITLE
VP 1267: [VCD-CLI] List gateway IP sub-allocation

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -280,6 +280,15 @@ class ExtNetTest(BaseTestCase):
             external, args=['list-allocated-ip', self._name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0070_list_sub_allocated_ip(self):
+        """List sub allocated ip.
+
+        Invoke the command 'external list-sub-allocated-ip' in network.
+        """
+        result = self._runner.invoke(
+            external, args=['list-sub-allocated-ip', self._name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0100_delete(self):
         """Delete the external network created.
 

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -130,14 +130,14 @@ def external(ctx):
        List associated gateways
 
 \b
-        vcd network external list-allocated-ip ExtNw --filter name==gateway*
+       vcd network external list-allocated-ip ExtNw --filter name==gateway*
 
        List allocated ip
 
 \b
-        vcd network external list-sub-allocated-ip ExtNw --filter name==gateway*
+       vcd network external list-sub-allocated-ip ExtNw --filter name==gateway*
 
-       List allocated ip
+       List sub allocated ip
 
     """
     pass

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -134,6 +134,11 @@ def external(ctx):
 
        List allocated ip
 
+\b
+        vcd network external list-sub-allocated-ip ExtNw --filter name==gateway*
+
+       List allocated ip
+
     """
     pass
 
@@ -1134,6 +1139,26 @@ def list_allocated_ip(ctx, name, filter):
         ext_net_obj = ExternalNetwork(client, resource=ext_net)
         allocated_ip = ext_net_obj.list_allocated_ip_address(filter)
         stdout(allocated_ip, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@external.command('list-sub-allocated-ip', short_help='list sub allocated ip.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '--filter',
+    'filter',
+    default=None,
+    metavar='<name==gateway*>',
+    help='filter for gateway')
+def list_sub_allocated_ip(ctx, name, filter):
+    try:
+        platform = _get_platform(ctx)
+        client = ctx.obj['client']
+        ext_net = platform.get_external_network(name)
+        ext_net_obj = ExternalNetwork(client, resource=ext_net)
+        sub_allocated_ip = ext_net_obj.list_gateway_ip_suballocation(filter)
+        stdout(sub_allocated_ip, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
[VCD-CLI] List gateway IP sub-allocation

This CLN contains functionality of listing gateway IP sun allocation
with given external network.

User can call this command as:
vcd network external list-sub-allocated-ip <ext_net_name>
vcd network external list-sub-allocated-ip <ext_net_name> --filter
name==<gateway_name>

Testing done:
Test case for list gateways sun allocated ip   is added to a test class,
extnet_tests.py
All tests in extnet_tests passed.

To help us process your pull request efficiently, please include:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/302)
<!-- Reviewable:end -->
