### PR TITLE
VP-1246:List associated direct org vDC networks in external network

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -289,6 +289,15 @@ class ExtNetTest(BaseTestCase):
             external, args=['list-sub-allocated-ip', self._name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0075_list_associated_direct_org_vdc_networks(self):
+        """List associated direct org vDC networks.
+
+        Invoke the command 'external list-direct-org-vdc-network' in network.
+        """
+        result = self._runner.invoke(
+            external, args=['list-direct-org-vdc-network', self._name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0100_delete(self):
         """Delete the external network created.
 

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -138,6 +138,11 @@ def external(ctx):
        vcd network external list-sub-allocated-ip ExtNw --filter name==gateway*
 
        List sub allocated ip
+\b
+       vcd network external list-direct-org-vdc-network ExtNw
+               --filter connectedTo==Ext*
+
+       List associated direct org vDC networks
 
     """
     pass
@@ -1159,6 +1164,30 @@ def list_sub_allocated_ip(ctx, name, filter):
         ext_net_obj = ExternalNetwork(client, resource=ext_net)
         sub_allocated_ip = ext_net_obj.list_gateway_ip_suballocation(filter)
         stdout(sub_allocated_ip, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@external.command(
+    'list-direct-org-vdc-network',
+	short_help='list associated direct org vDC networks.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '--filter',
+    'filter',
+    default=None,
+    metavar='<connectedTo==Ext*>',
+    help='filter for org vDC network')
+def list_direct_org_vdc_networks(ctx, name, filter):
+    try:
+        platform = _get_platform(ctx)
+        client = ctx.obj['client']
+        ext_net = platform.get_external_network(name)
+        ext_net_obj = ExternalNetwork(client, resource=ext_net)
+        direct_ovdc_networks = ext_net_obj.list_associated_direct_org_vdc_networks(filter)
+        result = []
+        result.append({'Direct Org VDC Networks':direct_ovdc_networks})
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
vcd-cli command to list associated direct org vDC networks in external network

Command to list the direct Org vdc networks associated with external network:
 vcd network list-direct-org-vdc-network ExtNw
 vcd network external list-direct-org-vdc-network ExtNw --filter connectedTo==Ex*

Testing done :
Added test: "test_0075_list_associated_direct_org_vdc_networks"
Status: passed