### PR TITLE
VP-1524,VP-1629:List Rate Limits and disable Rate limit

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -460,7 +460,7 @@ class GatewayTest(BaseTestCase):
 
     def test_0020_update_rate_limit(self):
         """Updates existing rate limit of gateway.
-         It will trigger the cli command configure-rate-limits update
+         It will trigger the cli command configure-rate-limits list
         """
         self._config = Environment.get_config()
         config = self._config['external_network']
@@ -468,13 +468,33 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway,
             args=[
-                'configure-rate-limits', 'update', self._name, '-r',
+                'configure-rate-limits', 'list', self._name, '-r',
                 [(ext_name, '101.0', '101.0')]])
+
+    def test_0021_list_rate_limit(self):
+        """Lists rate limit of gateway.
+         It will trigger the cli command configure-rate-limits update
+        """
+        result = self._runner.invoke(
+            gateway,
+            args=['configure-rate-limits', 'list', self._name])
+
+    def test_0022_disable_rate_limit(self):
+        """Disables rate limit of gateway.
+         It will trigger the cli command configure-rate-limits disable
+        """
+        self._config = Environment.get_config()
+        config = self._config['external_network']
+        ext_name = config['name']
+        result = self._runner.invoke(
+            gateway,
+            args=['configure-rate-limits', 'disable', self._name, '-e',
+                  ext_name])
 
     @unittest.skip("Skipping test case because set syslog server is not in "
                    "code. It should be unskipped after set syslog server is "
                    "written")
-    def test_0021_get_tenant_syslog_ip(self):
+    def test_0024_get_tenant_syslog_ip(self):
         """Get information of the gateway tenant syslog ip server.
 
         It will trigger the cli command with option list-syslog-server

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -755,8 +755,8 @@ def update_configure_rate_limits(ctx, name, rate_limit_config):
 def list_rate_limits(ctx, name):
     try:
         gateway_resource = _get_gateway(ctx, name)
-        task = gateway_resource.list_rate_limits()
-        stdout(task, ctx)
+        rate_limits = gateway_resource.list_rate_limits()
+        stdout(rate_limits, ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -712,8 +712,12 @@ def configure_rate_limits(ctx):
 \b
     Examples
         vcd gateway configure-rate-limits update gateway1
-            --e extNw1 101.0 101.0
+            -r extNw1 101.0 101.0
             updates the rate limit of gateway.
+\b
+        vcd gateway configure-rate-limits list test_gateway1
+\b
+        vcd gateway configure-rate-limits disable test_gateway1 -e ExtNw
     """
     pass
 
@@ -739,6 +743,40 @@ def update_configure_rate_limits(ctx, name, rate_limit_config):
             rate_limit_conf[config[0]] = [config[1], config[2]]
         gateway_resource = _get_gateway(ctx, name)
         task = gateway_resource.edit_rate_limits(rate_limit_conf)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@configure_rate_limits.command('list', short_help='list rate limit of gateway.'
+                               )
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+def list_rate_limits(ctx, name):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.list_rate_limits()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@configure_rate_limits.command('disable', short_help=' Disable rate limit of '
+                                                     'gateway.')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=True,
+    required=True,
+    help='external network connected to the gateway.')
+def disable_rate_limits(ctx, name, external_network_name):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.disable_rate_limits(external_network_name)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1524: List Rate limits of the gateway
VP-1629: Disable rate limit of the gateway

User would be able to list the rate limits of the gateway using command line : 
 vcd gateway configure-rate-limits list test_gateway1

User would be able to disable the rate limits of the gateway using command line: 
vcd gateway configure-rate-limits disable test_gateway1 -e ExtNw

Testing:
Added: test_0019_list_rate_limit and test_0020_disable_rate_limit test case to gateway_test.py and All test cases are passed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/304)
<!-- Reviewable:end -->
