### PR TITLE
VP-1603:List vSphere Networks

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -298,6 +298,15 @@ class ExtNetTest(BaseTestCase):
             external, args=['list-direct-org-vdc-network', self._name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0080_list_vsphere_networks(self):
+        """List associated vSphere Networks.
+
+        Invoke the command 'external list-vsphere-network' in network.
+        """
+        result = self._runner.invoke(
+            external, args=['list-vsphere-network', self._name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0100_delete(self):
         """Delete the external network created.
 

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -144,6 +144,12 @@ def external(ctx):
 
        List associated direct org vDC networks
 
+\b
+       vcd network external list-vsphere-network ExtNw
+               --filter networkName==Ext*
+
+       List associated vSphere Networks
+
     """
     pass
 
@@ -1188,6 +1194,28 @@ def list_direct_org_vdc_networks(ctx, name, filter):
         result = []
         result.append({'Direct Org VDC Networks':direct_ovdc_networks})
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@external.command(
+    'list-vsphere-network',
+     short_help='List associated vSphere Networks.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '--filter',
+    'filter',
+    default=None,
+    metavar='<networkName==Ext*>',
+    help='filter for vSphere Network')
+def list_vsphere_network(ctx, name, filter):
+    try:
+        platform = _get_platform(ctx)
+        client = ctx.obj['client']
+        ext_net = platform.get_external_network(name)
+        ext_net_obj = ExternalNetwork(client, resource=ext_net)
+        vSphere_network_list = ext_net_obj.list_vsphere_network(filter)
+        stdout(vSphere_network_list, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
List the vSphere Networks associated with the external networks.
Result will be in below format:
Name            vCenter
-----------      ---------
DPortGroup5   vc1
TestbedPG2     vc2

Command to list the vsphere network:
vcd network external list-vsphere-network ExtNw --filter networkName==ExtNw


Testing done:
Added test case : test_0080_list_vsphere_networks
Test status : passed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/305)
<!-- Reviewable:end -->
