### PR TITLE
VP-1474,VP-1657,VP-1659:Configure default gateway,DNS and list

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -36,7 +36,7 @@ class GatewayTest(BaseTestCase):
     _external_network_name = 'external_network_' + str(uuid1())
     _subnet_addr = None
     _ext_network_name = None
-    _gateway_ip = None
+    _gateway_ip = '2.2.3.1'
     _logger = None
 
     def test_0000_setup(self):
@@ -491,10 +491,50 @@ class GatewayTest(BaseTestCase):
             args=['configure-rate-limits', 'disable', self._name, '-e',
                   ext_name])
 
+    def test_0023_configure_default_gateways(self):
+        """Configures gateway for provided external networks and gateway IP.
+         It will trigger the cli command configure-default-gateway update
+        """
+        self._config = Environment.get_config()
+        config = self._config['external_network']
+        GatewayTest._logger.debug("config :{0} ".format(config))
+        ext_name = config['name']
+        ip_scopes = config['ip_scopes'][0]
+        subnet = ip_scopes['subnet']
+        ip = subnet.split('/')[0]
+        GatewayTest._logger.debug("vcd gateway configure-default-gateway "
+                                  "update {0} -e {1} --gateway-ip {2}".format(
+            self._name, ext_name, ip))
+        result = self._runner.invoke(
+            gateway,
+            args=['configure-default-gateway', 'update', self._name, '-e',
+                  ext_name, '--gateway-ip', ip,
+                  '--default-gateway-enable'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0024_enable_dns_relay(self):
+        """Enables/disables the dns relay of the default gateway.
+         It will trigger the cli command configure-default-gateway
+             enable-dns-relay
+        """
+        result = self._runner.invoke(
+            gateway,
+            args=['configure-default-gateway', 'enable-dns-relay', self._name,
+                  '--dns-relay-enable'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0025_list_configure_default_gateways(self):
+        """Lists the configured default gateway.
+         It will trigger the cli command configure-default-gateway list
+        """
+        result = self._runner.invoke(
+            gateway, args=['configure-default-gateway', 'list', self._name])
+        self.assertEqual(0, result.exit_code)
+
     @unittest.skip("Skipping test case because set syslog server is not in "
                    "code. It should be unskipped after set syslog server is "
                    "written")
-    def test_0024_get_tenant_syslog_ip(self):
+    def test_0030_get_tenant_syslog_ip(self):
         """Get information of the gateway tenant syslog ip server.
 
         It will trigger the cli command with option list-syslog-server

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -509,7 +509,7 @@ class GatewayTest(BaseTestCase):
             gateway,
             args=['configure-default-gateway', 'update', self._name, '-e',
                   ext_name, '--gateway-ip', ip,
-                  '--default-gateway-enable'])
+                  '--enable'])
         self.assertEqual(0, result.exit_code)
 
     def test_0024_enable_dns_relay(self):
@@ -520,7 +520,7 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway,
             args=['configure-default-gateway', 'enable-dns-relay', self._name,
-                  '--dns-relay-enable'])
+                  '--enable'])
         self.assertEqual(0, result.exit_code)
 
     def test_0025_list_configure_default_gateways(self):

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -810,8 +810,10 @@ def configure_default_gateway(ctx):
 \b
         vcd gateway configure-default-gateway enable-dns-relay gateway1
             --enable
+            enables the dns relay.
 \b
         vcd gateway configure-default-gateway list gateway1
+            lists the configured default gateway.
 
     """
     pass

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -794,3 +794,94 @@ def list_syslog_server(ctx, name):
         stdout(syslog_server, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@gateway.group('configure-default-gateway', short_help='configures the default'
+                                                       'gateway')
+@click.pass_context
+def configure_default_gateway(ctx):
+    """Configures the default gateway in vCloud Director.
+
+\b
+    Examples
+        vcd gateway configure-default-gateway update gateway1
+            -e extNw1 --gateway-ip 2.2.3.1 --default-gateway-enable
+            updates default gateway.
+\b
+        vcd gateway configure-default-gateway enable-dns-relay gateway1
+            --dns-relay-enable
+\b
+        vcd gateway configure-default-gateway list gateway1
+
+    """
+    pass
+
+
+@configure_default_gateway.command('update', short_help='configures the '
+                                                        'default gateway.')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '-e',
+    '--external-network',
+    'external_network_name',
+    metavar='<external network>',
+    multiple=False,
+    required=True,
+    help='external network connected to the gateway.')
+@click.option(
+    '-i',
+    '--gateway-ip',
+    'gateway_ip',
+    metavar='<ip>',
+    multiple=False,
+    required=True,
+    help='IP of the gateway.')
+@click.option(
+    '--default-gateway-enable/--default-gateway-disable',
+    'is_default_gateway',
+    default=None,
+    metavar='<bool>',
+    help='enables/disables the default gateway')
+def configure_default_gateways(ctx, name, external_network_name, gateway_ip,
+                               is_default_gateway):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.configure_default_gateway(
+            external_network_name, gateway_ip, is_default_gateway)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@configure_default_gateway.command('enable-dns-relay',
+                                   short_help='enables/disables the dns relay')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '--dns-relay-enable/--dns-relay-disable',
+    'is_dns_relay',
+    default=None,
+    metavar='<bool>',
+    help='enables/disables the dns relay')
+def enable_dns_relay(ctx, name, is_dns_relay):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        task = gateway_resource.configure_dns_default_gateway(is_dns_relay)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@configure_default_gateway.command('list',
+                                   short_help='lists the configure default'
+                                              ' gateway')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+def list_configure_default_gateways(ctx, name):
+    try:
+        gateway_resource = _get_gateway(ctx, name)
+        configured_list = gateway_resource.list_configure_default_gateway()
+        stdout(configured_list, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -805,11 +805,11 @@ def configure_default_gateway(ctx):
 \b
     Examples
         vcd gateway configure-default-gateway update gateway1
-            -e extNw1 --gateway-ip 2.2.3.1 --default-gateway-enable
+            -e extNw1 --gateway-ip 2.2.3.1 --enable
             updates default gateway.
 \b
         vcd gateway configure-default-gateway enable-dns-relay gateway1
-            --dns-relay-enable
+            --enable
 \b
         vcd gateway configure-default-gateway list gateway1
 
@@ -818,7 +818,7 @@ def configure_default_gateway(ctx):
 
 
 @configure_default_gateway.command('update', short_help='configures the '
-                                                        'default gateway.')
+                                                        'default gateway')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -838,17 +838,17 @@ def configure_default_gateway(ctx):
     required=True,
     help='IP of the gateway.')
 @click.option(
-    '--default-gateway-enable/--default-gateway-disable',
-    'is_default_gateway',
+    '--enable/--disable',
+    'is_enable',
     default=None,
     metavar='<bool>',
     help='enables/disables the default gateway')
 def configure_default_gateways(ctx, name, external_network_name, gateway_ip,
-                               is_default_gateway):
+                               is_enable):
     try:
         gateway_resource = _get_gateway(ctx, name)
         task = gateway_resource.configure_default_gateway(
-            external_network_name, gateway_ip, is_default_gateway)
+            external_network_name, gateway_ip, is_enable)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -859,15 +859,15 @@ def configure_default_gateways(ctx, name, external_network_name, gateway_ip,
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
-    '--dns-relay-enable/--dns-relay-disable',
-    'is_dns_relay',
+    '--enable/-disable',
+    'is_enable',
     default=None,
     metavar='<bool>',
     help='enables/disables the dns relay')
-def enable_dns_relay(ctx, name, is_dns_relay):
+def enable_dns_relay(ctx, name, is_enable):
     try:
         gateway_resource = _get_gateway(ctx, name)
-        task = gateway_resource.configure_dns_default_gateway(is_dns_relay)
+        task = gateway_resource.configure_dns_default_gateway(is_enable)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VCDCLI support to add default gateway, enable/disable the dns realy and list the supported configured default gateway.
Implemented configure_default_gateway, configure_dns_default_gateway, list_configure_default_gateways in gateway.py.

VP-1474: Configure default gateway
User would be able to enable the default gateway for provided external network and IP
 e.g:
vcd gateway configure-default-gateway update gateway1
            -e extNw1 --gateway-ip 2.2.3.1 --default-gateway-enable
        
VP-1657: Enable/Disable the DNS Relay
User would be able to enable/disable the DNS Relay
e.g:
vcd gateway configure-default-gateway enable-dns-relay gateway1 --dns-relay-enable

VP-1659: List default gateway
User would be able list the configured default gateway
e.g:
vcd gateway configure-default-gateway list gateway1

Testing:
Added test_0023_configure_default_gateways, test_0024_enable_dns_relay, test_0025_list_configure_default_gateways and test_0024_disable_configure_gateway to gateway_tests.py

All test cases are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/310)
<!-- Reviewable:end -->
