### PR TITLE
[VP-1376] List IP allocations of a routed org vdc network

### DIFF
--- a/system_tests/routed_tests.py
+++ b/system_tests/routed_tests.py
@@ -126,6 +126,13 @@ class VdcNetworkTests(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0040_list_allocated_ip_address(self):
+        """Test list allocated IP address of a routed org vdc network"""
+        result = self._runner.invoke(
+            network,
+            args=['routed', 'list-allocated-ip', VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(
             network, args=['routed', 'delete', VdcNetworkTests._name])

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -434,3 +434,18 @@ def remove_metadata(ctx, name, key, domain):
                ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@routed.command('list-allocated-ip', short_help='list allocated IP addresses')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def list_allocated_ip_address(ctx, name):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        client = ctx.obj['client']
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        vdcNetwork = VdcNetwork(client, resource=routed_network)
+        allocated_ip_addresses = vdcNetwork.list_allocated_ip_address()
+        stdout(allocated_ip_addresses, ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION
Adding support to list allocated IP Addresses of a org vdc routed network. Listing three columns, 'IP Address', 'Is Deployed' and 'Type'.

Sample command:
vcd network routed list-allocated-ip <routed-network>

Sample output:
IP Address          Is Deployed         Type
=======         ========         =========
20.30.40.1           true                      vsmAllocated

Testing done:
Added a test test_0040_list_allocated_ip_address to routed_test.py. All test cases in the class are passing.