### PR TITLE
VP-1550: Add DHCP Pool

### DIFF
--- a/system_tests/dhcp_pool_test.py
+++ b/system_tests/dhcp_pool_test.py
@@ -1,0 +1,75 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from click.testing import CliRunner
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.constants.gateway_constants \
+    import GatewayConstants
+from pyvcloud.system_test_framework.environment import Environment
+from vcd_cli.dhcp_pool import gateway
+from vcd_cli.org import org
+from vcd_cli.login import login, logout
+
+
+class TestDhcpPool(BaseTestCase):
+    """Test DHCP Pool functionalities implemented in pyvcloud."""
+    # All tests in this module should be run as System Administrator.
+    _pool_ip_range = '30.20.10.110-30.20.10.112'
+    _gateway_name = GatewayConstants.name
+
+    def test_0000_setup(self):
+        """Adds new DHCP pool to the gateway.
+
+         It will trigger the cli command service dhcp-pool create
+        """
+        self._config = Environment.get_config()
+        TestDhcpPool._logger = Environment.get_default_logger()
+        TestDhcpPool._runner = CliRunner()
+        default_org = self._config['vcd']['default_org_name']
+        self._login()
+        TestDhcpPool._runner.invoke(org, ['use', default_org])
+        result = TestDhcpPool._runner.invoke(
+            gateway,
+            args=[
+                'services', 'dhcp-pool', 'create', TestDhcpPool._gateway_name,
+                '-r', TestDhcpPool._pool_ip_range])
+        self.assertEqual(0, result.exit_code)
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = TestDhcpPool._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    @unittest.skip
+    def test_0098_teardown(self):
+        """Will implement in next check in, have to implement delete DHCP pool.
+        """
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        self._runner.invoke(logout)
+
+    def test_0099_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        self._logout()

--- a/vcd_cli/dhcp_pool.py
+++ b/vcd_cli/dhcp_pool.py
@@ -19,6 +19,8 @@ from vcd_cli.gateway import get_gateway
 from vcd_cli.gateway import services
 
 LEASE_TIME = '8640'
+
+
 @services.group('dhcp-pool', short_help='manage DHCP pool of the gateway')
 @click.pass_context
 def dhcp_pool(ctx):

--- a/vcd_cli/dhcp_pool.py
+++ b/vcd_cli/dhcp_pool.py
@@ -1,0 +1,120 @@
+# vCloud CLI 0.1
+#
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the
+# Apache License, Version 2.0 (the "License").
+# You may not use this product except in compliance with the License.
+#
+# This product may include a number of subcomponents with
+# separate copyright notices and license terms. Your use of the source
+# code for the these subcomponents is subject to the terms and
+# conditions of the subcomponent's license, as noted in the LICENSE file.
+#
+import click
+from pyvcloud.vcd.client import ApiVersion
+from pyvcloud.vcd.client import GatewayBackingConfigType
+from pyvcloud.vcd.vdc import VDC
+
+from vcd_cli.utils import restore_session
+from vcd_cli.utils import stderr
+from vcd_cli.utils import stdout
+from vcd_cli.vcd import vcd
+from vcd_cli.utils import tuple_to_dict
+from vcd_cli.gateway import gateway  # NOQA
+from vcd_cli.gateway import get_gateway
+from vcd_cli.gateway import services
+
+LEASE_TIME = '8640'
+@services.group('dhcp-pool', short_help='manage DHCP pool of the gateway')
+@click.pass_context
+def dhcp_pool(ctx):
+    """Manages DHCP pool of gateway.
+
+    \b
+        Examples
+            vcd gateway services dhcp-pool create gateway1 --range 30.20.10.11-
+            30.20.10.15 --enable-auto-dns --gateway-ip 30.20.10.1 --domain
+            abc.com --primary-server 30.20.10.20 --secondary-server 30.20.10.21
+            --lease 8640 --subnet 255.255.255.0
+
+    """
+
+
+@dhcp_pool.command("create", short_help="create new DHCP pool")
+@click.pass_context
+@click.argument('gateway_name', metavar='<gateway name>', required=True)
+@click.option(
+   '-r',
+   '--range',
+   'ip_range',
+   required=True,
+   default=None,
+   metavar='<IP range of the pool>',
+   help='IP range of the DHCP pool')
+@click.option(
+   '--enable-auto-dns/--disable-auto-dns',
+   'is_auto_dns',
+   metavar='<bool>',
+   default=False,
+   help='Auto configure DNS')
+@click.option(
+   '-g'
+   '--gateway-ip',
+   'gateway_ip',
+   metavar='<default-gateway-ip>',
+   default=None,
+   help='Default gateway ip')
+@click.option(
+   '-d'
+   '--domain',
+   'domain',
+   metavar='<domain-name>',
+   default=None,
+   help='domain name')
+@click.option(
+   '-p'
+   '--primary-server',
+   'primary_server',
+   metavar='<primary-name-server>',
+   default=None,
+   help='primary server ip')
+@click.option(
+   '-s'
+   '--secondary-server',
+   'secondary_server',
+   metavar='<secondary-name-server>',
+   default=None,
+   help='secondary server ip')
+@click.option(
+   '-l'
+   '--lease',
+   'lease',
+   metavar='<lease-time>',
+   default=LEASE_TIME,
+   help='lease time')
+@click.option(
+   '--never-expire-lease/--expire-lease',
+   'lease_expire',
+   metavar='<bool>',
+   default=False,
+   help='lease lease expire')
+@click.option(
+   '--subnet',
+   'subnet',
+   metavar='<subnet>',
+   default=None,
+   help='subnet mask')
+def create_dhcp_pool(ctx, gateway_name, ip_range, is_auto_dns, gateway_ip,
+                     domain, lease_expire, primary_server, secondary_server,
+                     lease, subnet):
+    try:
+        gateway_resource = get_gateway(ctx, gateway_name)
+        gateway_resource.add_dhcp_pool(ip_range, is_auto_dns, gateway_ip
+                                              , domain, lease_expire, lease,
+                                              subnet, primary_server,
+                                              secondary_server)
+        stdout('DHCP Pool created successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+

--- a/vcd_cli/dhcp_pool.py
+++ b/vcd_cli/dhcp_pool.py
@@ -12,15 +12,8 @@
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
 import click
-from pyvcloud.vcd.client import ApiVersion
-from pyvcloud.vcd.client import GatewayBackingConfigType
-from pyvcloud.vcd.vdc import VDC
-
-from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
-from vcd_cli.vcd import vcd
-from vcd_cli.utils import tuple_to_dict
 from vcd_cli.gateway import gateway  # NOQA
 from vcd_cli.gateway import get_gateway
 from vcd_cli.gateway import services
@@ -36,7 +29,8 @@ def dhcp_pool(ctx):
             vcd gateway services dhcp-pool create gateway1 --range 30.20.10.11-
             30.20.10.15 --enable-auto-dns --gateway-ip 30.20.10.1 --domain
             abc.com --primary-server 30.20.10.20 --secondary-server 30.20.10.21
-            --lease 8640 --subnet 255.255.255.0
+            --expire-lease --lease 8640 --subnet 255.255.255.0
+            Create dhcp rule.
 
     """
 

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -115,6 +115,7 @@ else:
     from vcd_cli import login  # NOQA
     from vcd_cli import org  # NOQA
     from vcd_cli import nat_rule  # NOQA
+    from vcd_cli import dhcp_pool  # NOQA
     from vcd_cli import netpool  # NOQA
     from vcd_cli import network  # NOQA
     from vcd_cli import nsxt  # NOQA


### PR DESCRIPTION
VP-1550: Add DHCP Pool

VCDCLI: User would be able to add DHCP pool to the gateway using command line e.g:

vcd gateway services dhcp-pool create gateway1 --range 30.20.10.11-
            30.20.10.15 --enable-auto-dns --gateway-ip 30.20.10.1 --domain
            abc.com --primary-server 30.20.10.20 --secondary-server 30.20.10.21
            --expire-lease --lease 8640 --subnet 255.255.255.0

Created dhcp_pool.py to achieve  add DHCP Pool

Testing : done

Added dhcp_pool_test.py , and all test cases are passing
