### PR TITLE
VP-1553: Delete DHCP Pool

### DIFF
--- a/system_tests/dhcp_pool_test.py
+++ b/system_tests/dhcp_pool_test.py
@@ -80,7 +80,7 @@ class TestDhcpPool(BaseTestCase):
     def test_0002_info_dhcp_pool(self):
         """info about DHCP pool.
 
-         It will trigger the cli command service dhcp-pool info
+         It will trigger the cli command services dhcp-pool info
         """
         result = TestDhcpPool._runner.invoke(
             gateway,

--- a/system_tests/dhcp_pool_test.py
+++ b/system_tests/dhcp_pool_test.py
@@ -28,6 +28,7 @@ class TestDhcpPool(BaseTestCase):
     # All tests in this module should be run as System Administrator.
     _pool_ip_range = '30.20.10.110-30.20.10.112'
     _gateway_name = GatewayConstants.name
+    _pool_id = 'pool-1'
 
     def test_0000_setup(self):
         """Adds new DHCP pool to the gateway.
@@ -61,10 +62,22 @@ class TestDhcpPool(BaseTestCase):
         self.assertEqual(0, result.exit_code)
         self.assertTrue("logged in" in result.output)
 
-    @unittest.skip
     def test_0098_teardown(self):
-        """Will implement in next check in, have to implement delete DHCP pool.
+        """Delete a DHCP Pool from gateway.
+
+        It will trigger the cli command service dhcp-pool delete
         """
+        self._config = Environment.get_config()
+        TestDhcpPool._logger = Environment.get_default_logger()
+        TestDhcpPool._runner = CliRunner()
+        default_org = self._config['vcd']['default_org_name']
+        TestDhcpPool._runner.invoke(org, ['use', default_org])
+        result = TestDhcpPool._runner.invoke(
+            gateway,
+            args=[
+                'services', 'dhcp-pool', 'delete', TestDhcpPool._gateway_name,
+                TestDhcpPool._pool_id])
+        self.assertEqual(0, result.exit_code)
 
     def _logout(self):
         """Logs out current session, ignoring errors"""

--- a/system_tests/dhcp_pool_test.py
+++ b/system_tests/dhcp_pool_test.py
@@ -28,7 +28,7 @@ class TestDhcpPool(BaseTestCase):
     # All tests in this module should be run as System Administrator.
     _pool_ip_range = '30.20.10.110-30.20.10.112'
     _gateway_name = GatewayConstants.name
-    _pool_id = 'pool-1'
+    _pool_id = None
 
     def test_0000_setup(self):
         """Adds new DHCP pool to the gateway.
@@ -61,6 +61,40 @@ class TestDhcpPool(BaseTestCase):
         result = TestDhcpPool._runner.invoke(login, args=login_args)
         self.assertEqual(0, result.exit_code)
         self.assertTrue("logged in" in result.output)
+
+    def test_0001_list_dhcp_pool(self):
+        """List DHCP pool.
+
+         It will trigger the cli command service dhcp-pool list
+        """
+        result = TestDhcpPool._runner.invoke(
+            gateway,
+            args=[
+                'services', 'dhcp-pool', 'list', TestDhcpPool._gateway_name])
+        ip_pool_row = self.get_row_containing_word(result.output,
+                                                   TestDhcpPool._pool_ip_range)
+        ip_pool_arr = ip_pool_row.strip().split()
+        TestDhcpPool._pool_id = ip_pool_arr[1]
+        self.assertEqual(0, result.exit_code)
+
+    def test_0002_info_dhcp_pool(self):
+        """info about DHCP pool.
+
+         It will trigger the cli command service dhcp-pool info
+        """
+        result = TestDhcpPool._runner.invoke(
+            gateway,
+            args=[
+                'services', 'dhcp-pool', 'info', TestDhcpPool._gateway_name,
+                TestDhcpPool._pool_id])
+
+        self.assertEqual(0, result.exit_code)
+
+    def get_row_containing_word(self, output, word):
+        rows = output.split('\n')
+        for row in rows:
+            if row.find(word) != -1:
+                return row
 
     def test_0098_teardown(self):
         """Delete a DHCP Pool from gateway.

--- a/system_tests/dhcp_pool_test.py
+++ b/system_tests/dhcp_pool_test.py
@@ -99,7 +99,7 @@ class TestDhcpPool(BaseTestCase):
     def test_0098_teardown(self):
         """Delete a DHCP Pool from gateway.
 
-        It will trigger the cli command service dhcp-pool delete
+        It will trigger the cli command services dhcp-pool delete
         """
         self._config = Environment.get_config()
         TestDhcpPool._logger = Environment.get_default_logger()

--- a/vcd_cli/dhcp_pool.py
+++ b/vcd_cli/dhcp_pool.py
@@ -39,16 +39,13 @@ def dhcp_pool(ctx):
             Create dhcp rule.
     \b
             vcd gateway services dhcp-pool delete test_gateway1 pool-1
-
-            Deletes the DHCP pool
+                Deletes the DHCP pool
     \b
             vcd gateway services dhcp-pool list test_gateway1
-
-            Lists the DHCP pool
+                Lists the DHCP pool
     \b
             vcd gateway services dhcp-pool info test_gateway1 pool-1
-
-            Info DHCP pool
+                Info DHCP pool
 
     """
 

--- a/vcd_cli/dhcp_pool.py
+++ b/vcd_cli/dhcp_pool.py
@@ -41,6 +41,14 @@ def dhcp_pool(ctx):
             vcd gateway services dhcp-pool delete test_gateway1 pool-1
 
             Deletes the DHCP pool
+    \b
+            vcd gateway services dhcp-pool list test_gateway1
+
+            Lists the DHCP pool
+    \b
+            vcd gateway services dhcp-pool info test_gateway1 pool-1
+
+            Info DHCP pool
 
     """
 
@@ -140,9 +148,34 @@ def get_dhcp_pool(ctx, gateway_name, pool_id):
     """Get the DHCP pool resource.
 
     It will restore sessions if expired. It will reads the client and
-    creates the DHCP pool resource.
+    creates the DHCP pool resource object.
     """
     restore_session(ctx, vdc_required=True)
     client = ctx.obj['client']
     resource = DhcpPool(client, gateway_name, pool_id)
     return resource
+
+
+@dhcp_pool.command("list", short_help="lists the DHCP pool")
+@click.pass_context
+@click.argument('gateway_name', metavar='<gateway name>', required=True)
+def list_dhcp_pool(ctx, gateway_name):
+    try:
+        gateway_resource = get_gateway(ctx, gateway_name)
+        result = gateway_resource.list_dhcp_pools()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@dhcp_pool.command("info", short_help="info about DHCP pool")
+@click.pass_context
+@click.argument('gateway_name', metavar='<gateway name>', required=True)
+@click.argument('pool_id', metavar='<dhcp pool id>', required=True)
+def info_dhcp_pool(ctx, gateway_name, pool_id):
+    try:
+        resource = get_dhcp_pool(ctx, gateway_name, pool_id)
+        result = resource.get_pool_info()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION
VP-1553: Delete DHCP Pool

User would be able to delete the DHCP pool of the gateway

e.g:
vcd gateway services dhcp-pool delete test_gateway1 pool-1

Output: 
DHCP Pool deleted successfully

Test: Testing done.

Added test_0098_teardown method to dhcp_pool_test.py

All test cases are passing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/316)
<!-- Reviewable:end -->
