### PR TITLE
[VP-1378]: List connected vApps to org vDC routed network

### DIFF
--- a/system_tests/routed_tests.py
+++ b/system_tests/routed_tests.py
@@ -133,6 +133,13 @@ class VdcNetworkTests(BaseTestCase):
             args=['routed', 'list-allocated-ip', VdcNetworkTests._name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0050_list_connected_vapps(self):
+        """Test list connected vApps to a routed org vdc network"""
+        result = self._runner.invoke(
+            network,
+            args=['routed', 'list-connected-vapps', VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(
             network, args=['routed', 'delete', VdcNetworkTests._name])

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -75,6 +75,14 @@ def routed(ctx):
 \b
         vcd network routed list-metadata vdc_routed_nw
             List all metadata entries in a routed org vdc network
+
+\b
+        vcd network routed list-allocated-ip vdc_routed_nw
+            List all allocated IP in a routed org vdc network
+
+\b
+        vcd network routed list-connected-vapps vdc_routed_nw
+            List all connected vApps in a routed org vdc network
     """
     pass
 
@@ -447,5 +455,20 @@ def list_allocated_ip_address(ctx, name):
         vdcNetwork = VdcNetwork(client, resource=routed_network)
         allocated_ip_addresses = vdcNetwork.list_allocated_ip_address()
         stdout(allocated_ip_addresses, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@routed.command('list-connected-vapps', short_help='list connected vApps')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def list_connected_vapps(ctx, name):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        client = ctx.obj['client']
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        vdcNetwork = VdcNetwork(client, resource=routed_network)
+        connected_vapps = vdcNetwork.list_connected_vapps()
+        stdout(connected_vapps, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Added command to list vApps connected to an org vdc routed network.
Command:
vcd network routed list-connected-vapps <routed-network>
Output:
Name                 Status
-------------------  ----------
test-connected-vapp  UNDEPLOYED

Testing done:
Added a test test_0050_list_connected_vapps to routed_tests.py. All test cases in this class are passing.