### PR TITLE
[VP-1683] Add support for adding DNS details in routed network

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -52,6 +52,7 @@ vcd:
   default_ovdc_network_gateway_ip: '10.1.1.1'
   default_ovdc_network_gateway_netmask: '255.255.255.0'
   default_direct ovdc_network_name: 'test-direct-vdc-network'
+  default_ovdc_network_network_cidr: '10.1.1.1/20'
 
   default_catalog_name: 'test-cat'
   default_template_file_name: 'test_vapp_template.ova'

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -32,7 +32,7 @@ class GatewayTest(BaseTestCase):
         Be aware that this test will delete existing vcd-cli sessions.
         """
     _runner = None
-    _name = 'test_gateway1'
+    _name = ('test_gateway1'+ str(uuid1()))[:34]
     _external_network_name = 'external_network_' + str(uuid1())
     _subnet_addr = None
     _ext_network_name = None

--- a/system_tests/routed_tests.py
+++ b/system_tests/routed_tests.py
@@ -31,6 +31,9 @@ class VdcNetworkTests(BaseTestCase):
     __ip_range1 = '6.6.5.2-6.6.5.20'
     __ip_range2 = '6.6.6.2-6.6.6.20'
     __new_ip_range = '6.6.5.12-6.6.5.22'
+    __dns1 = '8.8.8.8'
+    __dns2 = '8.8.8.9'
+    __dns_suffix = 'example.com'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -72,6 +75,18 @@ class VdcNetworkTests(BaseTestCase):
                 'routed', 'add-ip-ranges', VdcNetworkTests._name, '--ip-range',
                 VdcNetworkTests.__ip_range1, '--ip-range',
                 VdcNetworkTests.__ip_range2
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0011_add_dns_of_routed_nw(self):
+
+        result = self._runner.invoke(
+            network,
+            args=[
+                'routed', 'add-dns', VdcNetworkTests._name, '--dns1',
+                VdcNetworkTests.__dns1, '--dns2',
+                VdcNetworkTests.__dns2, '--dns-suffix',
+                VdcNetworkTests.__dns_suffix
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -14,6 +14,7 @@
 
 import click
 from pyvcloud.vcd.client import ApiVersion
+from pyvcloud.vcd.client import EdgeGatewayType
 from pyvcloud.vcd.client import GatewayBackingConfigType
 from pyvcloud.vcd.vdc import VDC
 from vcd_cli.utils import restore_session
@@ -54,6 +55,7 @@ def gateway(ctx):
             --subnet 10.10.20.1/28 --ip-range 10.10.20.5-10.10.20.10
             --configure-rate-limit extnw1 100 200
             --flips-mode-disabled
+            --gateway-type
             Create gateway.
                 Parameter --external-network is a required parameter and
                 can have multiple entries.
@@ -234,12 +236,18 @@ def list_gateways(ctx):
     default=False,
     metavar='<is flip flop mode>',
     help='flip flip mode')
+@click.option(
+    '--gateway-type',
+    'gateway_type',
+    default=EdgeGatewayType.NSXV_BACKED.value,
+    metavar='NSXV_BACKED/NSXT_BACKED/NSXT_IMPORTED',
+    help='gateway type')
 def create_gateway(ctx, name, external_networks_name, description,
                    default_gateway_external_network, default_gw_ip,
                    is_dns_relay, is_ha, is_advanced, is_distributed_routing,
                    configure_ip_settings, sub_allocated_ext_net_name,
                    sub_allocated_subnet, ip_ranges, configure_rate_limits,
-                   is_flip_flop, gateway_config):
+                   is_flip_flop, gateway_config, gateway_type):
     try:
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
@@ -284,8 +292,8 @@ def create_gateway(ctx, name, external_networks_name, description,
                 is_sub_allocate_ip_pools_enabled,
                 ext_net_to_subnet_with_ip_range,
                 ext_net_to_rate_limit)
-        else:
-            result = vdc.create_gateway(
+        elif float(api_version) <= float(ApiVersion.VERSION_31.value):
+            result = vdc.create_gateway_api_version_31(
                 name, external_networks_name, gateway_config, description,
                 is_configured_default_gw, default_gateway_external_network,
                 default_gw_ip, is_dns_relay, is_ha, is_advanced,
@@ -294,6 +302,16 @@ def create_gateway(ctx, name, external_networks_name, description,
                 is_sub_allocate_ip_pools_enabled,
                 ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit,
                 is_flip_flop)
+        else:
+            result = vdc.create_gateway_api_version_32(
+                name, external_networks_name, gateway_config, description,
+                is_configured_default_gw, default_gateway_external_network,
+                default_gw_ip, is_dns_relay, is_ha, is_advanced,
+                is_distributed_routing, is_ip_settings_configured,
+                ext_net_to_participated_subnet_with_ip_settings,
+                is_sub_allocate_ip_pools_enabled,
+                ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit,
+                is_flip_flop, gateway_type)
         stdout(result.Tasks.Task[0], ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/network.py
+++ b/vcd_cli/network.py
@@ -15,6 +15,7 @@
 import click
 from pyvcloud.vcd.external_network import ExternalNetwork
 from pyvcloud.vcd.platform import Platform
+from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.client import NSMAP
 
@@ -188,7 +189,7 @@ def isolated(ctx):
         delete or list isolated org vdc networks.
 \b
     Examples
-        vcd network isolated create isolated-net1 --gateway-ip 192.168.1.1 \\
+        vcd network isolated create isolated-net1 --gateway 192.168.1.1 \\
                 --netmask 255.255.255.0 --description 'Isolated VDC network' \\
                 --primary-dns-ip 8.8.8.8 --dns-suffix example.com \\
                 --ip-range-start 192.168.1.100 --ip-range-end 192.168.1.199 \\
@@ -345,11 +346,12 @@ def create_isolated_network(ctx, name, gateway_ip, netmask, description,
         client = ctx.obj['client']
         in_use_vdc_href = ctx.obj['profiles'].get('vdc_href')
         vdc = VDC(client, href=in_use_vdc_href)
+        prefix_len = netmask_to_cidr_prefix_len(gateway_ip, netmask)
+        network_cidr = gateway_ip + '/' + str(prefix_len)
 
         result = vdc.create_isolated_vdc_network(
             network_name=name,
-            gateway_ip=gateway_ip,
-            netmask=netmask,
+            network_cidr=network_cidr,
             description=description,
             primary_dns_ip=primary_dns_ip,
             secondary_dns_ip=secondary_dns_ip,

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -85,8 +85,10 @@ def routed(ctx):
             List all connected vApps in a routed org vdc network
 
 \b
-        vcd network routed add-dns vdc_routed_nw --dns1 2.2.3.1 --dns2
-        2.2.3.2 --dns-suffix domain.com
+        vcd network routed add-dns vdc_routed_nw
+                --dns1 2.2.3.1
+                --dns2 2.2.3.2
+                --dns-suffix domain.com
             Add DNS details in a routed org vdc network
 
     """


### PR DESCRIPTION
User can add DNS details in routed network usinf CLI command: vcd network routed add-dns vdc_routed_nw --dns1 2.2.3.1 --dns2
        2.2.3.2 --dns-suffix domain.com

It also include isolated network creation failure and gateway creation failure

Testing Done: Added new test case in routed_test for add DNS details and executed them successfully
Manually created isolated network successfully
Executed gateway test successfully.

@shashim22 @chaitanya118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/320)
<!-- Reviewable:end -->
