### PR TITLE
[VP-1386, VP-1388, VP-1532] Provided options for converting to SubInterface, Distributed Routing and network Info

### DIFF
--- a/system_tests/routed_tests.py
+++ b/system_tests/routed_tests.py
@@ -14,7 +14,8 @@ from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.constants.gateway_constants \
     import GatewayConstants
 from pyvcloud.system_test_framework.environment import Environment
-
+from vcd_cli.vcd import vcd  # NOQA
+from vcd_cli.gateway import gateway
 from vcd_cli.login import login, logout
 from vcd_cli.org import org
 from vcd_cli.network import network
@@ -163,6 +164,62 @@ class VdcNetworkTests(BaseTestCase):
         result = self._runner.invoke(
             network,
             args=['routed', 'list-connected-vapps', VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0060_convert_to_sub_interface(self):
+        """Test convert to sub interface of a routed org vdc network"""
+        result = self._runner.invoke(
+            network,
+            args=['routed', 'convert-to-sub-interface', VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0070_convert_to_internal_interface(self):
+        """Test convert to internal interface of a routed org vdc network"""
+        result = self._runner.invoke(
+            network,
+            args=['routed', 'convert-to-internal-interface',
+                  VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0075_convert_to_distributed_interface(self):
+        """Test convert to distributed interface of a routed org vdc network"""
+        try:
+            result_advanced_gateway = self._runner.invoke(
+                gateway,
+                args=['enable-distributed-routing', GatewayConstants.name,
+                      '--enable'])
+            self.assertEqual(0, result_advanced_gateway.exit_code)
+        except:
+            # Ignore the failure as we can't check if it is already enabled
+            pass
+
+        result = self._runner.invoke(
+            network,
+            args=['routed', 'convert-to-distributed-interface',
+                  VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
+        # Revert
+        result = self._runner.invoke(
+            network,
+            args=['routed', 'convert-to-internal-interface',
+                  VdcNetworkTests._name])
+        self.assertEqual(0, result.exit_code)
+
+        try:
+            result_advanced_gateway = self._runner.invoke(
+                gateway,
+                args=['enable-distributed-routing', GatewayConstants.name,
+                      '--disable'])
+            self.assertEqual(0, result_advanced_gateway.exit_code)
+        except:
+            # Ignore the failure as we can't check if it is already enabled
+            pass
+
+    def test_0075_info(self):
+        """Test info of a routed org vdc network"""
+        result = self._runner.invoke(
+            network, args=['routed', 'info', VdcNetworkTests._name])
         self.assertEqual(0, result.exit_code)
 
     def test_0098_tearDown(self):

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -99,19 +99,19 @@ def routed(ctx):
             Add DNS details in a routed org vdc network
 
 \b
-        vcd network routed convert-to-sub-interface vdc_routed_nw
+        vcd network routed convert-to-sub-interface routed_net1
             Convert routed org vdc network to sub interface
 
 \b
-        vcd network routed convert-to-internal-interface vdc_routed_nw
+        vcd network routed convert-to-internal-interface routed_net1
             Convert routed org vdc network to internal interface
 
 \b
-        vcd network routed convert-to-distributed-interface vdc_routed_nw
+        vcd network routed convert-to-distributed-interface routed_net1
             Convert routed org vdc network to distributed interface
 
 \b
-        vcd network routed info vdc_routed_nw
+        vcd network routed info routed_net1
             Show routed vdc network details
 
     """
@@ -617,7 +617,7 @@ def convert_to_distributed_interface(ctx, name):
         stderr(e, ctx)
 
 
-@routed.command('info', short_help='show routed network information.')
+@routed.command('info', short_help='show routed network information')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 def info(ctx, name):

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -98,6 +98,22 @@ def routed(ctx):
                 --dns-suffix domain.com
             Add DNS details in a routed org vdc network
 
+\b
+        vcd network routed convert-to-sub-interface vdc_routed_nw
+            Convert routed org vdc network to sub interface
+
+\b
+        vcd network routed convert-to-internal-interface vdc_routed_nw
+            Convert routed org vdc network to internal interface
+
+\b
+        vcd network routed convert-to-distributed-interface vdc_routed_nw
+            Convert routed org vdc network to distributed interface
+
+\b
+        vcd network routed info vdc_routed_nw
+            Show routed vdc network details
+
     """
     pass
 
@@ -549,5 +565,94 @@ def list_connected_vapps(ctx, name):
         vdcNetwork = VdcNetwork(client, resource=routed_network)
         connected_vapps = vdcNetwork.list_connected_vapps()
         stdout(connected_vapps, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@routed.command('convert-to-sub-interface',
+                short_help='convert to sub interface')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def convert_to_sub_interface(ctx, name):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        client = ctx.obj['client']
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        vdcNetwork = VdcNetwork(client, resource=routed_network)
+        task = vdcNetwork.convert_to_sub_interface()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@routed.command('convert-to-internal-interface',
+                short_help='convert to internal interface')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def convert_to_internal_interface(ctx, name):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        client = ctx.obj['client']
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        vdcNetwork = VdcNetwork(client, resource=routed_network)
+        task = vdcNetwork.convert_to_internal_interface()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@routed.command('convert-to-distributed-interface',
+                short_help='convert to distributed interface')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def convert_to_distributed_interface(ctx, name):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        client = ctx.obj['client']
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        vdcNetwork = VdcNetwork(client, resource=routed_network)
+        task = vdcNetwork.convert_to_distributed_interface()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@routed.command('info', short_help='show routed network information.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def info(ctx, name):
+    try:
+        vdc = _get_vdc_ref(ctx)
+        routed_network = vdc.get_routed_orgvdc_network(name)
+        output = {}
+        output['fence_mode'] = routed_network.Configuration.FenceMode
+        output['is_retail_info'] = \
+            routed_network.Configuration.RetainNetInfoAcrossDeployments
+        if hasattr(routed_network, 'SubInterface'):
+            output['is_sub_interface'] = \
+                routed_network.Configuration.SubInterface
+        if hasattr(routed_network, 'DistributedInterface'):
+            output['is_distributed_interface'] = \
+                routed_network.Configuration.DistributedInterface
+        if hasattr(routed_network, 'GuestVlanAllowed'):
+            output['is_guest_vlan_allowed'] = \
+                routed_network.Configuration.GuestVlanAllowed
+
+        if hasattr(routed_network, 'ProviderInfo'):
+            output['provider_info'] = routed_network.ProviderInfo
+        if hasattr(routed_network, 'IsShared'):
+            output['is_shared'] = routed_network.IsShared
+        if hasattr(routed_network, 'VimPortGroupRef'):
+            output['vim_server_href'] =  \
+                routed_network.VimPortGroupRef.VimServerRef.get('href')
+            output['vim_server_id'] = \
+                routed_network.VimPortGroupRef.VimServerRef.get('id')
+            output['vim_server_type'] = \
+                routed_network.VimPortGroupRef.VimServerRef.get('type')
+            output['vim_server_moref'] = routed_network.VimPortGroupRef.MoRef
+            output['vim_server_vim_object_type'] = \
+                routed_network.VimPortGroupRef.VimObjectType
+
+        stdout(output, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
It includes below options:
1: Convert to Subinterface. Command: vcd network routed convert-to-internal-interface vdc_routed_nw
2: Convert to Distributed Routing. Command: vcd network routed convert-to-distributed-interface vdc_routed_nw
3: Routed vdc network Info. Command: vcd network routed info vdc_routed_nw

Testing Done: Added new test cases and executed them successfully.

@shashim22 @guptaankit52

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/324)
<!-- Reviewable:end -->
