### PR TITLE
VP-1589: Delete a NAT Rule

### DIFF
--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -97,5 +97,5 @@ external_network:
     - subnet: '2.2.3.1/20'
       ip_ranges:
         - '2.2.3.2-2.2.3.160'
-  gateway_sub_allocated_ip_range: '2.2.3.70-2.2.3.120'
-  new_gateway_sub_allocated_ip_range: '2.2.3.72-2.2.3.110'
+  gateway_sub_allocated_ip_range: '2.2.3.70-2.2.3.99'
+  new_gateway_sub_allocated_ip_range: '2.2.3.72-2.2.3.99'


### PR DESCRIPTION
vcd-Cli command to delete the SNAT/DNAT rule

ex- vcd gateway services nat delete <<gateway-name>> <<nat-id>>

Testing Done: 
Added below test case to delete SNAT and DNAT rule
test_0030_delete_nat_rule

status: passed