### PR TITLE
[VP 1768]Provided CLi support for list objects and object types for firewall rule edit

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -68,11 +68,30 @@ class TestFirewallRule(BaseTestCase):
     def test_0001_list_firewall_rules(self):
         """Get information of the firewall rules.
 
-        It will trigger the cli command with option gateway services firewall list
+        It will trigger the cli command with option gateway services
+        firewall list.
         """
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=['services', 'firewall', 'list', TestFirewallRule.__name])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
+    def test_0011_list_object_types(self):
+        """List object types."""
+        result = TestFirewallRule._runner.invoke(
+            gateway, args=['services', 'firewall', 'list-object-types',
+                           TestFirewallRule.__name, '--type', 'source'])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
+    def test_0021_list_objects(self):
+        """List objects for the provided object type."""
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=['services', 'firewall', 'list-objects',
+                  TestFirewallRule.__name, '--type', 'source',
+                  '--object-type', 'gatewayinterface'])
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -29,10 +29,24 @@ def firewall(ctx):
     \b
         Examples
             vcd gateway services firewall create test_gateway1 --name rule1
-            --action accept --type User --enabled --logging-enabled
+                    --action accept --type User
+                    --enabled --logging-enabled
 
-            create new firewall rule
+                create new firewall rule
 
+    \b
+            vcd gateway services firewall list test_gateway1
+                List firewall rules
+
+    \b
+            vcd gateway services firewall list-object-types test_gateway1
+                    --type source
+                List of object types
+
+    \b
+            vcd gateway services firewall list-objects test_gateway1
+                    --type source --object-type gatewayinterface
+                List of object for provided object type
     """
 
 
@@ -42,6 +56,7 @@ def firewall(ctx):
 @click.option(
     '--name',
     'name',
+    required=True,
     metavar='<firewall rule name>',
     help='firewall rule name')
 @click.option(
@@ -80,7 +95,7 @@ def create_firewall_rule(ctx, gateway_name, name, action, type,
     except Exception as e:
         stderr(e, ctx)
 
-@firewall.command('list', short_help='displays all firewall rules.')
+@firewall.command('list', short_help='displays all firewall rules')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 def rules_list(ctx, name):
@@ -88,5 +103,62 @@ def rules_list(ctx, name):
         gateway_resource = get_gateway(ctx, name)
         firewall_rules = gateway_resource.get_firewall_rules_list()
         stdout(firewall_rules, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@firewall.command('list-object-types', short_help='list object types')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '--type',
+    'type',
+    metavar='<source/destination>',
+    required=True,
+    type=click.Choice([
+        'source',
+        'destination'
+    ]),
+    help='type. possible value will be source/destination')
+def list_object_types(ctx, name, type):
+    try:
+        gateway_resource = get_gateway(ctx, name)
+        object_types = gateway_resource.list_firewall_object_types(type)
+        stdout(object_types, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command('list-objects', short_help='list objects for provided '
+                                             'object type')
+@click.pass_context
+@click.argument('name', metavar='<gateway name>', required=True)
+@click.option(
+    '--type',
+    'type',
+    metavar='<source/destination>',
+    required=True,
+    type=click.Choice([
+        'source',
+        'destination'
+    ]),
+    help='type. possible value will be source/destination')
+@click.option(
+    '--object-type',
+    'object_type',
+    required=True,
+    metavar='<object type>',
+    type=click.Choice([
+        'gatewayinterface',
+        'virtualmachine',
+        'network',
+        'ipset',
+        'securitygroup'
+    ]),
+    help='object type')
+def list_objects(ctx, name, type, object_type):
+    try:
+        gateway_resource = get_gateway(ctx, name)
+        objects = gateway_resource.list_firewall_objects(type, object_type)
+        stdout(objects, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Added new command to fetch object types and object for forewall rule edit.

vcd gateway services firewall list-object-types test_gateway1 --type source

vcd gateway services firewall list-objects test_gateway1 --type source--object-type gatewayinterface

@guptaankit52 @kousgy123 