### PR TITLE
VP-1605,1610: Add and list static routes

### DIFF
--- a/system_tests/static_route_tests.py
+++ b/system_tests/static_route_tests.py
@@ -49,7 +49,7 @@ class TestStaticRoute(BaseTestCase):
         result = TestStaticRoute._runner.invoke(
             gateway,
             args=[
-                'services', 'static', 'create', TestStaticRoute._name,
+                'services', 'static-route', 'create', TestStaticRoute._name,
                 '--type', TestStaticRoute._type, '--network',
                 TestStaticRoute._network, '--next-hop',
                 TestStaticRoute._next_hop, '--mtu', TestStaticRoute._mtu,
@@ -79,7 +79,7 @@ class TestStaticRoute(BaseTestCase):
         result = TestStaticRoute._runner.invoke(
             gateway,
             args=[
-                'services', 'static', 'list',
+                'services', 'static-route', 'list',
                 TestStaticRoute._name])
         self.assertEqual(0, result.exit_code)
 

--- a/system_tests/static_route_tests.py
+++ b/system_tests/static_route_tests.py
@@ -1,0 +1,95 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.constants.gateway_constants \
+    import GatewayConstants
+from pyvcloud.system_test_framework.environment import Environment
+
+from vcd_cli.static_route import gateway
+from vcd_cli.org import org
+from vcd_cli.login import login, logout
+
+
+class TestStaticRoute(BaseTestCase):
+    """Test Static Route functionalities implemented in pyvcloud."""
+    # All tests in this module should be run as System Administrator.
+    _next_hop = '2.2.3.81'
+    _network = '192.169.1.0/24'
+    _name = GatewayConstants.name
+    _mtu = 1500
+    _type = 'User'
+    _vnic = 0
+    _desc = 'Static Route created'
+
+    def test_0000_setup(self):
+        """Add Static Route in the gateway.
+        It will trigger the cli command 'services static create'
+        """
+        self._config = Environment.get_config()
+        TestStaticRoute._logger = Environment.get_default_logger()
+        TestStaticRoute._runner = CliRunner()
+        default_org = self._config['vcd']['default_org_name']
+        self._login()
+        TestStaticRoute._runner.invoke(org, ['use', default_org])
+        result = TestStaticRoute._runner.invoke(
+            gateway,
+            args=[
+                'services', 'static', 'create', TestStaticRoute._name,
+                '--type', TestStaticRoute._type, '--network',
+                TestStaticRoute._network, '--next-hop',
+                TestStaticRoute._next_hop, '--mtu', TestStaticRoute._mtu,
+                '--desc', TestStaticRoute._desc, '-v',
+                TestStaticRoute._vnic])
+        self.assertEqual(0, result.exit_code)
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = TestStaticRoute._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def test_0025_list_static_routes(self):
+        """List all static routes on a gateway.
+
+        Invoke the cli command 'services static list'.
+        """
+        result = TestStaticRoute._runner.invoke(
+            gateway,
+            args=[
+                'services', 'static', 'list',
+                TestStaticRoute._name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0098_teardown(self):
+        """Will implement with delete."""
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        TestStaticRoute._runner.invoke(logout)
+
+    def test_0099_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        self._logout()

--- a/vcd_cli/static_route.py
+++ b/vcd_cli/static_route.py
@@ -1,0 +1,104 @@
+# vCloud CLI 0.1
+#
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the
+# Apache License, Version 2.0 (the "License").
+# You may not use this product except in compliance with the License.
+#
+# This product may include a number of subcomponents with
+# separate copyright notices and license terms. Your use of the source
+# code for the these subcomponents is subject to the terms and
+# conditions of the subcomponent's license, as noted in the LICENSE file.
+#
+
+import click
+from vcd_cli.utils import stderr
+from vcd_cli.utils import stdout
+# Don't change the order of vcd  and gateway
+from vcd_cli.vcd import vcd #NOQA
+from vcd_cli.gateway import gateway # NOQA
+from vcd_cli.gateway import get_gateway
+from vcd_cli.gateway import services
+
+
+@services.group('static', short_help='manage static routes of gateway')
+@click.pass_context
+def static(ctx):
+    """Manages static routes of gateway.
+
+\b
+        Examples
+            vcd gateway services static create test_gateway1 --type User
+            --network 192.169.1.0/24 --next-hop 2.2.3.30 --mtu 1500
+            --desc "Static Route Created" -v 0
+                Create a new static route
+
+\b
+            vcd gateway services static list test_gateway1
+                List all static routes
+    """
+
+
+@static.command("create", short_help="create a new static route")
+@click.pass_context
+@click.argument('gateway_name', metavar='<gateway name>', required=True)
+@click.option(
+    '--type',
+    'type',
+    default='User',
+    metavar='<User>',
+    help='type')
+@click.option(
+    '-n',
+    '--network',
+    'network',
+    default=None,
+    metavar='<ip>',
+    help='IP address of network in CIDR format')
+@click.option(
+    '-h',
+    '--next-hop',
+    'next_hop',
+    default=None,
+    metavar='<ip>',
+    help='IP address of the next hop')
+@click.option(
+    '--mtu',
+    'mtu',
+    default=1500,
+    metavar='<mtu>',
+    help='enable/disable the SNAT rule')
+@click.option(
+    '--desc',
+    'description',
+    default=None,
+    metavar='<description>',
+    help='description')
+@click.option(
+    '-v',
+    'vnic',
+    default=0,
+    metavar='<vnic>',
+    help='interface of gateway')
+def create_static_route(ctx, gateway_name, type, network, next_hop,
+                        mtu, description, vnic):
+    try:
+        gateway_resource = get_gateway(ctx, gateway_name)
+        gateway_resource.add_static_route(network, next_hop, mtu,
+                                          description, type, vnic)
+        stdout('Static route created successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@static.command('list', short_help='List all static routes on a gateway')
+@click.pass_context
+@click.argument('gateway_name', metavar='<gateway name>', required=True)
+def list_static_routes(ctx, gateway_name):
+    try:
+        gateway_resource = get_gateway(ctx, gateway_name)
+        static_route_list = gateway_resource.list_static_routes()
+        stdout(static_route_list, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/static_route.py
+++ b/vcd_cli/static_route.py
@@ -22,25 +22,25 @@ from vcd_cli.gateway import get_gateway
 from vcd_cli.gateway import services
 
 
-@services.group('static', short_help='manage static routes of gateway')
+@services.group('static-route', short_help='manage static routes of gateway')
 @click.pass_context
-def static(ctx):
+def static_route(ctx):
     """Manages static routes of gateway.
 
 \b
         Examples
-            vcd gateway services static create test_gateway1 --type User
+            vcd gateway services static-route create test_gateway1 --type User
             --network 192.169.1.0/24 --next-hop 2.2.3.30 --mtu 1500
             --desc "Static Route Created" -v 0
                 Create a new static route
 
 \b
-            vcd gateway services static list test_gateway1
+            vcd gateway services static-route list test_gateway1
                 List all static routes
     """
 
 
-@static.command("create", short_help="create a new static route")
+@static_route.command("create", short_help="create a new static route")
 @click.pass_context
 @click.argument('gateway_name', metavar='<gateway name>', required=True)
 @click.option(
@@ -92,7 +92,7 @@ def create_static_route(ctx, gateway_name, type, network, next_hop,
         stderr(e, ctx)
 
 
-@static.command('list', short_help='List all static routes on a gateway')
+@static_route.command('list', short_help='List all static routes on a gateway')
 @click.pass_context
 @click.argument('gateway_name', metavar='<gateway name>', required=True)
 def list_static_routes(ctx, gateway_name):

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -117,6 +117,7 @@ else:
     from vcd_cli import org  # NOQA
     from vcd_cli import nat_rule  # NOQA
     from vcd_cli import dhcp_pool  # NOQA
+    from vcd_cli import static_route  # NOQA
     from vcd_cli import netpool  # NOQA
     from vcd_cli import network  # NOQA
     from vcd_cli import nsxt  # NOQA

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -110,22 +110,22 @@ else:
     load_user_plugins()
     from vcd_cli import catalog  # NOQA
     from vcd_cli import disk  # NOQA
+    from vcd_cli import dhcp_pool  # NOQA
     from vcd_cli import firewall_rule  # NOQA
     from vcd_cli import gateway  # NOQA
     from vcd_cli import info  # NOQA
     from vcd_cli import login  # NOQA
-    from vcd_cli import org  # NOQA
     from vcd_cli import nat_rule  # NOQA
-    from vcd_cli import dhcp_pool  # NOQA
-    from vcd_cli import static_route  # NOQA
     from vcd_cli import netpool  # NOQA
     from vcd_cli import network  # NOQA
     from vcd_cli import nsxt  # NOQA
+    from vcd_cli import org  # NOQA
     from vcd_cli import profile  # NOQA
     from vcd_cli import pvdc  # NOQA
     from vcd_cli import role  # NOQA
     from vcd_cli import right  # NOQA
     from vcd_cli import routed # NOQA
+    from vcd_cli import static_route  # NOQA
     from vcd_cli import search  # NOQA
     from vcd_cli import system  # NOQA
     from vcd_cli import task  # NOQA


### PR DESCRIPTION
Vcd-cli command to "add and list static routes".

Commands to create and list static routes:
            vcd gateway services static create test_gateway1 --type User
            --network 192.169.1.0/24 --next-hop 2.2.3.30 --mtu 1500
            --desc "Static Route Created" -v 0

           vcd gateway services static list test_gateway1


Testing done:
test_0000_setup ( Add static route)
test_0025_list_static_routes

Both tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/329)
<!-- Reviewable:end -->
