### PR TITLE
Vp 1535

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from click.testing import CliRunner
-import click
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.constants.gateway_constants \
     import GatewayConstants
@@ -67,8 +66,9 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._runner.invoke(logout)
 
     def test_0001_list_firewall_rules(self):
-        """Get information of the fire rules.
-        It will trigger the cli command with option gateway firewall list
+        """Get information of the firewall rules.
+
+        It will trigger the cli command with option gateway services firewall list
         """
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from click.testing import CliRunner
-
+import click
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.constants.gateway_constants \
     import GatewayConstants
@@ -65,6 +65,16 @@ class TestFirewallRule(BaseTestCase):
     def _logout(self):
         """Logs out current session, ignoring errors"""
         TestFirewallRule._runner.invoke(logout)
+
+    def test_0001_list_firewall_rules(self):
+        """Get information of the fire rules.
+        It will trigger the cli command with option gateway firewall list
+        """
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=['services', 'firewall', 'list', TestFirewallRule.__name])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
 
     def test_0099_cleanup(self):
         """Release all resources held by this object for testing purposes."""

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -85,13 +85,8 @@ def create_firewall_rule(ctx, gateway_name, name, action, type,
 @click.argument('name', metavar='<name>', required=True)
 def rules_list(ctx, name):
     try:
-
         gateway_resource = get_gateway(ctx, name)
-        firewall_rules = gateway_resource.get_firewall_rules()
-        firewall_rule_list = []
-        for firewall_rule in firewall_rules.iter('firewallRule'):
-            firewall_rule_list.append(dict(ID=firewall_rule.find('id').text, name=firewall_rule.find('name').text,
-                                           ruleType=firewall_rule.find('ruleType').text))
-        stdout(firewall_rule_list, ctx)
+        firewall_rules = gateway_resource.get_firewall_rules_list()
+        stdout(firewall_rules, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -79,3 +79,19 @@ def create_firewall_rule(ctx, gateway_name, name, action, type,
         stdout('Firewall rule created successfully.', ctx)
     except Exception as e:
         stderr(e, ctx)
+
+@firewall.command('list', short_help='displays all firewall rules.')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+def rules_list(ctx, name):
+    try:
+
+        gateway_resource = get_gateway(ctx, name)
+        firewall_rules = gateway_resource.get_firewall_rules()
+        firewall_rule_list = []
+        for firewall_rule in firewall_rules.iter('firewallRule'):
+            firewall_rule_list.append(dict(ID=firewall_rule.find('id').text, name=firewall_rule.find('name').text,
+                                           ruleType=firewall_rule.find('ruleType').text))
+        stdout(firewall_rule_list, ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION
VP-1535:[VCDCLI]: Enable Firewall rule.
VCDCLI:User will be able to perform unable and disable operation on firewall rule.

vcd gateway services firewall enabled firewall_rule_id gateway_name.
output:
if rule is in enabled state then 
            output:  firewall rule is already enabled.
else
        output : Firewall rule enabled successfully.


vcd gateway services firewall disabled firewall_rule_id gateway_name.
output:
if rule is in disabled state then 
            output:  firewall rule is already disabled.
else
        output : Firewall rule disabled successfully.

Testing Done:
Added test_0002_enabled_firewall_rules method to firewall_rule_tests.py.
Added test_0003_disabled_firewall_rules method to firewall_rule_tests.py.

