### PR TITLE
[VP-1735] Adding CLI support for Edit service of firewall rule

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -32,7 +32,7 @@ class TestFirewallRule(BaseTestCase):
     firewall create.
     """
     __name = GatewayConstants.name
-    __firewall_rule_name = 'rule1'+str(uuid1())
+    __firewall_rule_name = 'rule1' + str(uuid1())
 
     def test_0000_setup(self):
 
@@ -120,7 +120,11 @@ class TestFirewallRule(BaseTestCase):
                   '--destination', TestFirewallRule._ext_nw +
                   ':gatewayinterface', '--destination',
                   OvdcNetConstants.routed_net_name + ':network',
-                  '--destination', '2.3.2.2:ip'])
+                  '--destination', '2.3.2.2:ip',
+                  '--service', 'tcp', 'any', 'any',
+                  '--service', 'tcp', 'any', 'any',
+                  '--service', 'any', 'any', 'any',
+                  '--service', 'icmp', 'any', 'any'])
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -216,7 +216,7 @@ def update_firewall(ctx, name, rule_id, source_values, destination_values,
         if destination_values:
             firewall.validate_types(destination_values, 'destination')
         application_services = []
-        if services is not None and len(services) > 0:
+        if services:
             for service in services:
                 application_services.append(tuple_to_dict([service]))
 

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -21,6 +21,7 @@ from vcd_cli.gateway import gateway # NOQA
 from vcd_cli.gateway import get_gateway
 from vcd_cli.gateway import services
 from vcd_cli.utils import restore_session
+from vcd_cli.utils import tuple_to_dict
 
 
 @services.group('firewall', short_help='manage firewall rules of gateway')
@@ -57,6 +58,7 @@ def firewall(ctx):
                     --destination vm1:virtualmachine
                     --source ExtNw:gatewayinterface
                     --source 10.20.3.2:ip
+                    --service tcp any any
                 Edit firewall rule
     """
 
@@ -194,7 +196,17 @@ def list_objects(ctx, name, type, object_type):
     multiple=True,
     help='it should be in value:value_type format. for ex: '
          'Extnw:gatewayinterface')
-def update_firewall(ctx, name, rule_id, source_values, destination_values):
+@click.option(
+    '--service',
+    'services',
+    nargs=3,
+    type=click.Tuple([str, str, str]),
+    multiple=True,
+    default=None,
+    metavar='<protocol> <source port> <destination port>',
+    help='configure services of firewall')
+def update_firewall(ctx, name, rule_id, source_values, destination_values,
+                    services):
     try:
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
@@ -203,7 +215,12 @@ def update_firewall(ctx, name, rule_id, source_values, destination_values):
             firewall.validate_types(source_values, 'source')
         if destination_values:
             firewall.validate_types(destination_values, 'destination')
-        firewall.edit(source_values, destination_values)
+        application_services = []
+        if services is not None and len(services) > 0:
+            for service in services:
+                application_services.append(tuple_to_dict([service]))
+
+        firewall.edit(source_values, destination_values, application_services)
 
         stdout('Firewall rule updated successfully.', ctx)
     except Exception as e:


### PR DESCRIPTION
User can add services in the existing firewall rule.

Command: vcd gateway services firewall update test_gateway1 rule_id
                    --destination ExtNw:gatewayinterface
                    --destination ExtNw1:gatewayinterface
                    --destination vm1:virtualmachine
                    --source ExtNw:gatewayinterface
                    --source 10.20.3.2:ip
                    --service tcp any any

Testing Done: Updated firewall edit command to support service. Executed the complete class successfully.

@shashim22 @kousgy123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/334)
<!-- Reviewable:end -->
