### PR TITLE
[VP-1393]: Create a vApp network.

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -1,0 +1,100 @@
+# VMware vCloud Director vCD CLI
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid1
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import CommonRoles
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.system_test_framework.utils import create_vapp_from_template
+
+from vcd_cli.login import login, logout
+from vcd_cli.org import org
+from vcd_cli.vapp import vapp
+
+
+class VAppTest(BaseTestCase):
+    """Test vApp related commands
+
+    Be aware that this test will delete existing vcd-cli sessions.
+    """
+    _test_vapp_name = 'test_vApp_' + str(uuid1())
+
+    _vapp_network_name = 'vapp_network_' + str(uuid1())
+    _vapp_network_description = 'Test vApp network'
+    _vapp_network_cidr = '90.80.70.1/24'
+    _vapp_network_dns1 = '8.8.8.8'
+    _vapp_network_dns2 = '8.8.8.9'
+    _vapp_network_dns_suffix = 'example.com'
+    _vapp_network_ip_range = '90.80.70.2-90.80.70.100'
+
+    def test_0000_setup(self):
+        """Load configuration and create a click runner to invoke CLI."""
+        VAppTest._config = Environment.get_config()
+        VAppTest._logger = Environment.get_default_logger()
+        VAppTest._client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+
+        VAppTest._runner = CliRunner()
+        default_org = VAppTest._config['vcd']['default_org_name']
+        VAppTest._login(self)
+        VAppTest._runner.invoke(org, ['use', default_org])
+        VAppTest._test_vdc = Environment.get_test_vdc(VAppTest._client)
+        VAppTest._test_vapp = create_vapp_from_template(
+            VAppTest._client, VAppTest._test_vdc, VAppTest._test_vapp_name,
+            VAppTest._config['vcd']['default_catalog_name'],
+            VAppTest._config['vcd']['default_template_file_name'])
+
+    def test_0001_create_vapp_network(self):
+        """Create a vApp network as per configuration stated above."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'create-vapp-network', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, '--subnet',
+                VAppTest._vapp_network_cidr, '--description',
+                VAppTest._vapp_network_description, '--dns1',
+                VAppTest._vapp_network_dns1, '--dns2',
+                VAppTest._vapp_network_dns2, '--dns-suffix',
+                VAppTest._vapp_network_dns_suffix, '--ip-range',
+                VAppTest._vapp_network_ip_range
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0098_tearDown(self):
+        """Delete vApp and logout from the session."""
+        result_delete = VAppTest._runner.invoke(
+            vapp,
+            args=['delete', VAppTest._test_vapp_name, '--yes', '--force'])
+        self.assertEqual(0, result_delete.exit_code)
+        VAppTest._logout(self)
+
+    def _login(self):
+        org = VAppTest._config['vcd']['default_org_name']
+        user = Environment.get_username_for_role_in_test_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        password = VAppTest._config['vcd']['default_org_user_password']
+        login_args = [
+            VAppTest._config['vcd']['host'], org, user, "-i", "-w",
+            "--password={0}".format(password)
+        ]
+        result = VAppTest._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        VAppTest._runner.invoke(logout)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -75,10 +75,10 @@ def vapp(ctx):
         vcd vapp create vapp1 -c catalog1 -t template1
             Instantiate a vApp from a catalog template.
 \b
-        vcd vapp create vapp1 -c catalog1 -t template1 \\
-                 --cpu 4 --memory 4096 --disk-size 20000 \\
-                 --network net1 --ip-allocation-mode pool \\
-                 --hostname myhost --vm-name vm1 --accept-all-eulas \\
+        vcd vapp create vapp1 -c catalog1 -t template1
+                 --cpu 4 --memory 4096 --disk-size 20000
+                 --network net1 --ip-allocation-mode pool
+                 --hostname myhost --vm-name vm1 --accept-all-eulas
                  --storage-profile '*'
             Instantiate a vApp with customized settings.
 \b
@@ -159,6 +159,17 @@ def vapp(ctx):
 \b
         vdc vapp disconnect vapp1 org-vdc-network1
             Disconnects the network org-vdc-network1 from vapp1.
+\b
+        vdc vapp create-vapp-network vapp1 vapp-network1
+                --subnet 192.168.1.1/24
+                --description 'vApp network'
+                --dns1 8.8.8.8
+                --dns2 8.8.8.9
+                --dns-suffix example.com
+                --ip-range 192.168.1.2-192.168.1.49
+                --ip-range 192.168.1.100-192.168.1.149
+                --guest-vlan-allowed-enabled
+            Create a vApp network.
     """
     pass
 
@@ -923,6 +934,53 @@ def add_vm(ctx, name, source_vapp, source_vm, catalog, target_vm, hostname,
         stderr(e, ctx)
 
 
+@vapp.command('create-vapp-network', short_help='create a vApp network')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('name', metavar='<name>', required=True)
+@click.option(
+    '--subnet', 'subnet', required=True, metavar='<CIDR>', help='Network CIDR')
+@click.option(
+    '--description',
+    'description',
+    metavar='<description>',
+    help='description')
+@click.option(
+    '--dns1', 'primary_dns_ip', metavar='<IP>', help='primary DNS IP')
+@click.option(
+    '--dns2', 'secondary_dns_ip', metavar='<IP>', help='secondary DNS IP')
+@click.option(
+    '--dns-suffix', 'dns_suffix', metavar='<Name>', help='dns suffix')
+@click.option(
+    '--ip-range',
+    'ip_ranges',
+    multiple=True,
+    metavar='<ip-range-start-ip-range-end>',
+    help='IP range')
+@click.option(
+    '--guest-vlan-allowed-enabled/--guest-vlan-allowed-disabled',
+    'is_guest_vlan_allowed',
+    default=False,
+    metavar='<bool>',
+    help='guest vlan allowed')
+def create_vapp_network(ctx, vapp_name, name, subnet, description,
+                        primary_dns_ip, secondary_dns_ip, dns_suffix,
+                        ip_ranges, is_guest_vlan_allowed):
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        vapp_resource = vdc.get_vapp(vapp_name)
+        vapp = VApp(client, resource=vapp_resource)
+        task = vapp.create_vapp_network(
+            name, subnet, description, primary_dns_ip, secondary_dns_ip,
+            dns_suffix, ip_ranges, is_guest_vlan_allowed)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
 @vapp.group(short_help='work with vapp acl')
 @click.pass_context
 def acl(ctx):
@@ -932,7 +990,7 @@ def acl(ctx):
    Description
         Work with vapp access control list in the current Organization.
 \b
-        vcd vapp acl add my-vapp 'user:TestUser1:Change'  \\
+        vcd vapp acl add my-vapp 'user:TestUser1:Change'
             'user:TestUser2:FullControl' 'user:TestUser3'
             Add one or more access setting to the specified vapp.
             access-list is specified in the format
@@ -955,8 +1013,6 @@ def acl(ctx):
 \b
         vcd vapp acl list my-vapp
             List acl of a vapp.
-
-
     """
     pass
 
@@ -1041,8 +1097,9 @@ def share(ctx, vapp_name, access_level):
         vapp = VApp(client, resource=vdc.get_vapp(vapp_name))
 
         vapp.share_with_org_members(everyone_access_level=access_level)
-        stdout('Vapp \'%s\' shared to all members of the org \'%s\'.' %
-               (vapp_name, ctx.obj['profiles'].get('org_in_use')), ctx)
+        stdout(
+            'Vapp \'%s\' shared to all members of the org \'%s\'.' %
+            (vapp_name, ctx.obj['profiles'].get('org_in_use')), ctx)
     except Exception as e:
         stderr(e, ctx)
 
@@ -1060,8 +1117,9 @@ def unshare(ctx, vapp_name):
         vapp = VApp(client, resource=vdc.get_vapp(vapp_name))
 
         vapp.unshare_from_org_members()
-        stdout('Vapp \'%s\' unshared from all members of the org \'%s\'.' %
-               (vapp_name, ctx.obj['profiles'].get('org_in_use')), ctx)
+        stdout(
+            'Vapp \'%s\' unshared from all members of the org \'%s\'.' %
+            (vapp_name, ctx.obj['profiles'].get('org_in_use')), ctx)
     except Exception as e:
         stderr(e, ctx)
 
@@ -1079,8 +1137,7 @@ def list_acl(ctx, vapp_name):
 
         acl = vapp.get_access_settings()
         stdout(
-            access_settings_to_list(acl,
-                                    ctx.obj['profiles'].get('org_in_use')),
-            ctx)
+            access_settings_to_list(
+                acl, ctx.obj['profiles'].get('org_in_use')), ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Added a command to create vApp network.

Command:
vdc vapp create-vapp-network vapp1 vapp-network1
                --subnet 192.168.1.1/24
                --description 'vApp network'
                --dns1 8.8.8.8
                --dns2 8.8.8.9
                --dns-suffix example.com
                --ip-range 192.168.1.2-192.168.1.49
                --ip-range 192.168.1.100-192.168.1.149
                --guest-vlan-allowed-enabled

Testing done:
Added a test case test_0001_create_vapp_network to new test class vapp_tests.py. All test cases are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/336)
<!-- Reviewable:end -->
