### PR TITLE
VP-1541:[VCDCLI] Delete a firewall rule

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -153,6 +153,16 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0051_delete_firewall_rule(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'delete', TestFirewallRule.__name,
+                TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0099_cleanup(self):
         """Release all resources held by this object for testing purposes."""
         self._logout()

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -64,9 +64,14 @@ def firewall(ctx):
     \b
             vcd gateway services firewall enable test_gateway1 rule_id
                 enabled firewall rule
+
     \b
             vcd gateway services firewall disable test_gateway1 rule_id
                 disabled firewall rule
+
+    \b
+            vcd gateway services firewall delete test_gateway1 rule_id
+                delete firewall rule
     """
 
 
@@ -236,11 +241,11 @@ def get_firewall_rule(ctx, gateway_name, id):
     return resource
 
 
-@firewall.command('enable', short_help='enable firewall rule.')
+@firewall.command('enable', short_help='enable firewall rule')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)
-def enabled_firewall_rules(ctx, name, id):
+def enabled_firewall_rule(ctx, name, id):
     try:
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         firewall_rule_resource.enable_disable_firewall_rule(True)
@@ -249,14 +254,27 @@ def enabled_firewall_rules(ctx, name, id):
         stderr(e, ctx)
 
 
-@firewall.command('disable', short_help='disable firewall rule ')
+@firewall.command('disable', short_help='disable firewall rule')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)
-def disabled_firewall_rules(ctx, name, id):
+def disabled_firewall_rule(ctx, name, id):
     try:
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         firewall_rule_resource.enable_disable_firewall_rule(False)
         stdout('Firewall rule disabled successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command('delete', short_help='delete firewall rule')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+def delete_firewall_rule(ctx, name, id):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        firewall_rule_resource.delete()
+        stdout('Firewall rule deleted successfully', ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1541:[VCDCLI]: Delete a firewall rule.

Adding a comands to delete firewall rule on the basis of rule id.

To delete a firewall rule, following command can be used:
vcd gateway services firewall delete gateway_name rule_id 


Testing Done:
Added test_0051_delete_firewall_rule to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/337)
<!-- Reviewable:end -->
