### PR TITLE
VP-1560:[VCDCLI] Get Firewall rule info

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -153,7 +153,17 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
-    def test_0051_delete_firewall_rule(self):
+    def test_0061_info_firewall_rule(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'info', TestFirewallRule.__name,
+                TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
+    def test_0098_delete_firewall_rule(self):
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=[

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -17,6 +17,7 @@ import click
 from pyvcloud.vcd.firewall_rule import FirewallRule
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
+from vcd_cli.vcd import vcd  #NOQA
 from vcd_cli.gateway import gateway  # NOQA
 from vcd_cli.gateway import get_gateway
 from vcd_cli.gateway import services
@@ -72,6 +73,10 @@ def firewall(ctx):
     \b
             vcd gateway services firewall delete test_gateway1 rule_id
                 delete firewall rule
+
+    \b
+            vcd gateway services firewall info test_gateway1 rule_id
+                Info firewall rule
     """
 
 
@@ -276,5 +281,18 @@ def delete_firewall_rule(ctx, name, id):
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         firewall_rule_resource.delete()
         stdout('Firewall rule deleted successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command('info', short_help='info about firewall rule')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+def info_firewall_rule(ctx, name, id):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        result = firewall_rule_resource.info_firewall_rule()
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1560:[VCDCLI] Get Firewall rule info.

Adding a command to info firewall rule on the basis of rule id.

To info a firewall rule, following command can be used:
vcd gateway services firewall info gateway_name rule_id 

Testing Done:
Added test_0061_info_firewall_rule to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/339)
<!-- Reviewable:end -->
