### PR TITLE
VP-1539 : [VCDCLI]: Edit Firewall rule name

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -153,7 +153,17 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
-    def test_0051_delete_firewall_rule(self):
+    def test_0061_info_firewall_rule(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'info', TestFirewallRule.__name,
+                TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
+    def test_0098_delete_firewall_rule(self):
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=[

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -128,9 +128,19 @@ class TestFirewallRule(BaseTestCase):
                 '--destination', OvdcNetConstants.routed_net_name + ':network',
                 '--destination', '2.3.2.2:ip', '--service', 'tcp', 'any',
                 'any', '--service', 'tcp', 'any', 'any', '--service', 'any',
-                'any', 'any', '--service', 'icmp', 'any', 'any'
+                'any', 'any', '--service', 'icmp', 'any', 'any', '--name',
+                'new_name'
             ])
         TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+        # revert back name change to old name
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'update', TestFirewallRule.__name,
+                TestFirewallRule._rule_id.text, '--name',
+                TestFirewallRule.__firewall_rule_name
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0041_enable_firewall_rule(self):

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -17,6 +17,7 @@ import click
 from pyvcloud.vcd.firewall_rule import FirewallRule
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
+from vcd_cli.vcd import vcd  #NOQA
 from vcd_cli.gateway import gateway  # NOQA
 from vcd_cli.gateway import get_gateway
 from vcd_cli.gateway import services
@@ -72,6 +73,10 @@ def firewall(ctx):
     \b
             vcd gateway services firewall delete test_gateway1 rule_id
                 delete firewall rule
+
+    \b
+            vcd gateway services firewall info test_gateway1 rule_id
+                Info firewall rule
     """
 
 
@@ -276,5 +281,18 @@ def delete_firewall_rule(ctx, name, id):
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         firewall_rule_resource.delete()
         stdout('Firewall rule deleted successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command('info', short_help='info about firewall rule')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+def info_firewall_rule(ctx, name, id):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        result = firewall_rule_resource.info_firewall_rule()
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -60,6 +60,7 @@ def firewall(ctx):
                     --source ExtNw:gatewayinterface
                     --source 10.20.3.2:ip
                     --service tcp any any
+                    --name new_name
                 Edit firewall rule
 
     \b
@@ -212,8 +213,14 @@ def list_objects(ctx, name, type, object_type):
     default=None,
     metavar='<protocol> <source port> <destination port>',
     help='configure services of firewall')
+@click.option(
+    '--name',
+    'new_name',
+    default=None,
+    metavar='<name>',
+    help='new name of the firewall rule')
 def update_firewall(ctx, name, rule_id, source_values, destination_values,
-                    services):
+                    services, new_name):
     try:
         restore_session(ctx, vdc_required=True)
         client = ctx.obj['client']
@@ -227,7 +234,8 @@ def update_firewall(ctx, name, rule_id, source_values, destination_values,
             for service in services:
                 application_services.append(tuple_to_dict([service]))
 
-        firewall.edit(source_values, destination_values, application_services)
+        firewall.edit(source_values, destination_values, application_services,
+                      new_name)
 
         stdout('Firewall rule updated successfully.', ctx)
     except Exception as e:


### PR DESCRIPTION
VP-1539 : [VCDCLI]: Edit Firewall rule name.

Enhanced the update feature to support edit of firewall rule name as well .
To rename a firewall rule, following command can be used:
vcd gateway services firewall update gateway_name rule_id  --name new_name 

Testing Done:
Enhanced test_0031_update to firewall_rule_tests.py to verify name edit. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/341)
<!-- Reviewable:end -->
