### PR TITLE
 Modified the command to look consistent and added missing test case

### DIFF
--- a/system_tests/routed_tests.py
+++ b/system_tests/routed_tests.py
@@ -73,7 +73,7 @@ class VdcNetworkTests(BaseTestCase):
         result = self._runner.invoke(
             network,
             args=[
-                'routed', 'add-ip-ranges', VdcNetworkTests._name, '--ip-range',
+                'routed', 'add-ip-range', VdcNetworkTests._name, '--ip-range',
                 VdcNetworkTests.__ip_range1, '--ip-range',
                 VdcNetworkTests.__ip_range2
             ])
@@ -96,7 +96,7 @@ class VdcNetworkTests(BaseTestCase):
         result = self._runner.invoke(
             network,
             args=[
-                'routed', 'modify-ip-range', VdcNetworkTests._name,
+                'routed', 'update-ip-range', VdcNetworkTests._name,
                 '--ip-range', VdcNetworkTests.__ip_range1, '--new-ip-range',
                 VdcNetworkTests.__new_ip_range
             ])

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -34,9 +34,14 @@ dhcp_pool_test.py \
 extnet_tests.py \
 firewall_rule_tests.py \
 gateway_tests.py \
+ipsec_vpn_tests.py \
 nat_rule_tests.py \
 org_tests.py \
-routed_tests.py"
+pvdc_tests.py \
+routed_tests.py \
+static_route_tests.py \
+vapp_tests.py \
+vc_tests.py"
 
 if [ $# == 0 ]; then
   echo "No tests provided, will run stable list: ${STABLE_TESTS}"

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -50,23 +50,23 @@ def routed(ctx):
                 --retain-net-info-across-deployments-enabled
             Creates a routed org vdc network
 \b
-        vcd network routed edit routed_net1
+        vcd network routed update routed_net1
                 --name new_name
                 --description new_description
                 --shared-enabled/--shared-disabled
             Edit name, description and shared state of org vdc network
 
 \b
-        vcd network routed add-ip-ranges routed_net1
+        vcd network routed add-ip-range routed_net1
                 --ip-range  2.2.3.1-2.2.3.2
                 --ip-range 2.2.4.1-2.2.4.2
-            Add IP ranges to a routed org vdc network
+            Add IP range/s to a routed org vdc network
 
 \b
-        vcd network routed modify-ip-range routed_net1
+        vcd network routed update-ip-range routed_net1
                 --ip-range 192.168.1.2-192.168.1.20
                 --new-ip-range 192.168.1.25-192.168.1.50
-            Modify an IP range of a routed org vdc network
+            Update an IP range of a routed org vdc network
 
 \b
         vcd network routed remove-ip-range routed_net1
@@ -329,7 +329,7 @@ def add_dns_of_routed_vdc_network(ctx, name, primary_dns_ip, secondary_dns_ip,
 
 
 @routed.command(
-    'add-ip-ranges', short_help='add IP range to routed org vdc network')
+    'add-ip-range', short_help='add IP range/s to routed org vdc network')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.option(
@@ -370,9 +370,8 @@ def list_routed_networks(ctx):
 
 
 @routed.command(
-    'modify-ip-range',
-    short_help='Modify IP range of '
-    'routed org vdc network.')
+    'update-ip-range',
+    short_help='Update IP range of routed org vdc network.')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.option(

--- a/vcd_cli/routed.py
+++ b/vcd_cli/routed.py
@@ -54,7 +54,7 @@ def routed(ctx):
                 --name new_name
                 --description new_description
                 --shared-enabled/--shared-disabled
-            Edit name, description and shared state of org vdc network
+            Update name, description and shared state of org vdc network
 
 \b
         vcd network routed add-ip-range routed_net1


### PR DESCRIPTION
Updated the below command:

	vcd network routed add-ip-range routed_net1
                --ip-range  2.2.3.1-2.2.3.2
                --ip-range 2.2.4.1-2.2.4.2
            Add IP range/s to a routed org vdc network

	vcd network routed update-ip-range routed_net1
                --ip-range 192.168.1.2-192.168.1.20
                --new-ip-range 192.168.1.25-192.168.1.50
            Update an IP range of a routed org vdc network

It also include the adding of missing test case to run_system_tests.py file.

Testing Done: Executed the routed nw test successfully.

@shashim22 @guptaankit52

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/344)
<!-- Reviewable:end -->
