### PR TITLE
VP-1790 : [VCD-CLI] : List Firewall Source

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -173,6 +173,16 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0081_list_firewall_rule_source(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'source-list', TestFirewallRule.__name,
+                TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_delete_firewall_rule(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -177,7 +177,7 @@ class TestFirewallRule(BaseTestCase):
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=[
-                'services', 'firewall', 'source-list', TestFirewallRule.__name,
+                'services', 'firewall', 'list-source', TestFirewallRule.__name,
                 TestFirewallRule._rule_id.text
             ])
         TestFirewallRule._logger.debug('result output {0}'.format(result))

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -80,8 +80,8 @@ def firewall(ctx):
                 Info firewall rule
 
     \b
-            vcd gateway services firewall source-list test_gateway1 rule_id
-                List firewall rule source
+            vcd gateway services firewall list-source test_gateway1 rule_id
+                List firewall rule's source
     """
 
 
@@ -310,7 +310,7 @@ def info_firewall_rule(ctx, name, id):
         stderr(e, ctx)
 
 
-@firewall.command('source-list', short_help='list of firewall rule source')
+@firewall.command('list-source', short_help='list of firewall rule\'s source')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -78,6 +78,10 @@ def firewall(ctx):
     \b
             vcd gateway services firewall info test_gateway1 rule_id
                 Info firewall rule
+
+    \b
+            vcd gateway services firewall source-list test_gateway1 rule_id
+                List firewall rule source
     """
 
 
@@ -301,6 +305,19 @@ def info_firewall_rule(ctx, name, id):
     try:
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         result = firewall_rule_resource.info_firewall_rule()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command('source-list', short_help='list of firewall rule source')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+def list_firewall_rule_source(ctx, name, id):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        result = firewall_rule_resource.list_firewall_rule_source()
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1790 : [VCD-CLI] : List Firewall Source.

Adding a command to list firewall rule's source  of rule id.

To list a firewall rule's source, following command can be used:
vcd gateway services firewall source-list gateway_name rule_id 

Testing Done:
Added test_0081_list_firewall_rule_source to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/349)
<!-- Reviewable:end -->
