### PR TITLE
VP-1545 : [VCDCLI] Change the sequence of the firewall rules

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -187,7 +187,7 @@ class TestFirewallRule(BaseTestCase):
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=[
-                'services', 'firewall', 'sequence', '--index', '1',
+                'services', 'firewall', 'update-sequence', '--index', '1',
                 TestFirewallRule.__name, TestFirewallRule._rule_id.text
             ])
         TestFirewallRule._logger.debug('result output {0}'.format(result))

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -183,6 +183,16 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0091_update_firewall_rule_sequence(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'sequence', '--index', '1',
+                TestFirewallRule.__name, TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_delete_firewall_rule(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -84,7 +84,7 @@ def firewall(ctx):
                 List firewall rule's source
 
     \b
-            vcd gateway services firewall sequence test_gateway1 rule_id
+            vcd gateway services firewall update-sequence test_gateway1 rule_id
                     --index new_index
                 Change sequence of firewall rule
     """
@@ -328,7 +328,8 @@ def list_firewall_rule_source(ctx, name, id):
         stderr(e, ctx)
 
 
-@firewall.command('sequence', short_help='update sequence of firewall rule')
+@firewall.command(
+    'update-sequence', short_help='update sequence of firewall rule')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -82,6 +82,11 @@ def firewall(ctx):
     \b
             vcd gateway services firewall list-source test_gateway1 rule_id
                 List firewall rule's source
+
+    \b
+            vcd gateway services firewall sequence test_gateway1 rule_id
+                    --index new_index
+                Change sequence of firewall rule
     """
 
 
@@ -319,5 +324,24 @@ def list_firewall_rule_source(ctx, name, id):
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         result = firewall_rule_resource.list_firewall_rule_source()
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command('sequence', short_help='update sequence of firewall rule')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+@click.option(
+    '--index',
+    'new_index',
+    required=True,
+    metavar='<int>',
+    help='new index of the firewall rule')
+def update_firewall_rule_sequence(ctx, name, id, new_index):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        firewall_rule_resource.update_firewall_rule_sequence(new_index)
+        stdout('Firewall rule sequence updated successfully', ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1545 : [VCDCLI] Change the sequence of the firewall rules.

Adding a command to change firewall rule's sequence on the basis of rule id.

To change a firewall rule's sequence , following command can be used:
vcd gateway services firewall update-sequence gateway_name rule_id  --index new_index


Testing Done:
Added test_0091_update_firewall_rule_sequence to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/352)
<!-- Reviewable:end -->
