### PR TITLE
VP-1792 : [VCDCLI] delete values from Firewall Source

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -173,6 +173,18 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0071_delete_firewall_rule_source(self):
+        source_value = 'vnic-0'
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'delete-source',
+                TestFirewallRule.__name, TestFirewallRule._rule_id.text,
+                source_value
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0081_list_firewall_rule_source(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -87,6 +87,11 @@ def firewall(ctx):
             vcd gateway services firewall update-sequence test_gateway1 rule_id
                     --index new_index
                 Change sequence of firewall rule
+
+    \b
+            vcd gateway services firewall delete-source test_gateway1 rule_id
+                    source_value
+                Delete source value of firewall rule
     """
 
 
@@ -344,5 +349,21 @@ def update_firewall_rule_sequence(ctx, name, id, new_index):
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         firewall_rule_resource.update_firewall_rule_sequence(new_index)
         stdout('Firewall rule sequence updated successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command(
+    'delete-source',
+    short_help='delete firewall rule\'s source value of gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+@click.argument('source_value', metavar='<source_value>', required=True)
+def delete_firewall_rule_source(ctx, name, id, source_value):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        firewall_rule_resource.delete_firewall_rule_source(source_value)
+        stdout('Firewall rule source deleted successfully', ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -92,6 +92,7 @@ def firewall(ctx):
             vcd gateway services firewall delete-source test_gateway1 rule_id
                     source_value
                 Delete source value of firewall rule
+                It will delete all source value of given source_value
     """
 
 


### PR DESCRIPTION
VP-1792 : [VCDCLI] delete values from Firewall Source.


Adding a command to delete firewall rule's source value of rule id.

To delete a firewall rule's source value, following command can be used:
vcd gateway services firewall delete-source gateway_name rule_id  source_value


Testing Done:
Added test_0071_delete_firewall_rule_source to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/354)
<!-- Reviewable:end -->
