### PR TITLE
Remove -h for --next-hop

### DIFF
--- a/vcd_cli/static_route.py
+++ b/vcd_cli/static_route.py
@@ -71,7 +71,6 @@ def static_route(ctx):
     metavar='<ip>',
     help='IP address of network in CIDR format')
 @click.option(
-    '-h',
     '--next-hop',
     'next_hop',
     default=None,


### PR DESCRIPTION
Below command is failing:
vcd gateway services static-route create -h

because -h for --next-hop is matching with -h help.