### PR TITLE
VP-1841 : [VCD-CLI] : List Firewall Destination

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -195,6 +195,16 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0082_list_firewall_rule_destination(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'list-destination',
+                TestFirewallRule.__name, TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0091_update_firewall_rule_sequence(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -328,7 +328,8 @@ def info_firewall_rule(ctx, name, id):
 def list_firewall_rule_source(ctx, name, id):
     try:
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
-        result = firewall_rule_resource.list_firewall_rule_source()
+        result = firewall_rule_resource.list_firewall_rule_source_destination(
+            'source')
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -378,7 +379,8 @@ def delete_firewall_rule_source(ctx, name, id, source_value):
 def list_firewall_rule_destination(ctx, name, id):
     try:
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
-        result = firewall_rule_resource.list_firewall_rule_destination()
+        result = firewall_rule_resource.list_firewall_rule_source_destination(
+            'destination')
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -86,7 +86,7 @@ def firewall(ctx):
     \b
             vcd gateway services firewall list-destination test_gateway1
                     rule_id
-                List firewall rule's source
+                List firewall rule's destination
 
     \b
             vcd gateway services firewall update-sequence test_gateway1 rule_id

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -368,3 +368,17 @@ def delete_firewall_rule_source(ctx, name, id, source_value):
         stdout('Firewall rule source deleted successfully', ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@firewall.command(
+    'list-destination', short_help='list of firewall rule\'s destination')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+def list_firewall_rule_destination(ctx, name, id):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        result = firewall_rule_resource.list_firewall_rule_destination()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -84,6 +84,11 @@ def firewall(ctx):
                 List firewall rule's source
 
     \b
+            vcd gateway services firewall list-destination test_gateway1
+                    rule_id
+                List firewall rule's source
+
+    \b
             vcd gateway services firewall update-sequence test_gateway1 rule_id
                     --index new_index
                 Change sequence of firewall rule


### PR DESCRIPTION
VP-1841 : [VCD-CLI] : List Firewall Destination.

Adding a command to list firewall rule's destination of rule id.

To list a firewall rule's destination, following command can be used:
vcd gateway services firewall list-destination gateway_name rule_id

Testing Done:
Added test_0082_list_firewall_rule_destination to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/359)
<!-- Reviewable:end -->
