### PR TITLE
VP-1794 : [VCD-CLI] delete values from Firewall Destination

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -185,6 +185,18 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0072_delete_firewall_rule_destination(self):
+        source_value = 'vnic-0'
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'delete-destination',
+                TestFirewallRule.__name, TestFirewallRule._rule_id.text,
+                source_value
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0081_list_firewall_rule_source(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -186,13 +186,13 @@ class TestFirewallRule(BaseTestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_0072_delete_firewall_rule_destination(self):
-        source_value = 'vnic-0'
+        destination_value = 'vnic-0'
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=[
                 'services', 'firewall', 'delete-destination',
                 TestFirewallRule.__name, TestFirewallRule._rule_id.text,
-                source_value
+                destination_value
             ])
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
@@ -221,7 +221,7 @@ class TestFirewallRule(BaseTestCase):
         result = TestFirewallRule._runner.invoke(
             gateway,
             args=[
-                'services', 'firewall', 'update-sequence', '--index', '1',
+                'services', 'firewall', 'reorder', '--index', '1',
                 TestFirewallRule.__name, TestFirewallRule._rule_id.text
             ])
         TestFirewallRule._logger.debug('result output {0}'.format(result))

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -98,6 +98,12 @@ def firewall(ctx):
                     source_value
                 Delete source value of firewall rule
                 It will delete all source value of given source_value
+
+    \b
+            vcd gateway services firewall delete-destination test_gateway1
+                    rule_id destination_value
+                Delete destination value of firewall rule
+                It will delete all destination value of given destination_value
     """
 
 
@@ -370,7 +376,8 @@ def update_firewall_rule_sequence(ctx, name, id, new_index):
 def delete_firewall_rule_source(ctx, name, id, source_value):
     try:
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
-        firewall_rule_resource.delete_firewall_rule_source(source_value)
+        firewall_rule_resource.delete_firewall_rule_source_destination(
+            source_value, 'source')
         stdout('Firewall rule source deleted successfully', ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -387,5 +394,23 @@ def list_firewall_rule_destination(ctx, name, id):
         result = firewall_rule_resource.list_firewall_rule_source_destination(
             'destination')
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command(
+    'delete-destination',
+    short_help='delete firewall rule\'s destination value of gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+@click.argument(
+    'destination_value', metavar='<destination_value>', required=True)
+def delete_firewall_rule_destination(ctx, name, id, destination_value):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        firewall_rule_resource.delete_firewall_rule_source_destination(
+            destination_value, 'destination')
+        stdout('Firewall rule destination deleted successfully', ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -89,21 +89,22 @@ def firewall(ctx):
                 List firewall rule's destination
 
     \b
-            vcd gateway services firewall update-sequence test_gateway1 rule_id
+            vcd gateway services firewall reorder test_gateway1 rule_id
                     --index new_index
-                Change sequence of firewall rule
+                Reorder the firewall rule position on gateway
 
     \b
             vcd gateway services firewall delete-source test_gateway1 rule_id
                     source_value
                 Delete source value of firewall rule
-                It will delete all source value of given source_value
+                It will delete all source values of given source_value
 
     \b
             vcd gateway services firewall delete-destination test_gateway1
                     rule_id destination_value
                 Delete destination value of firewall rule
-                It will delete all destination value of given destination_value
+                It will delete all destination values of given
+                    destination_value
     """
 
 
@@ -347,7 +348,7 @@ def list_firewall_rule_source(ctx, name, id):
 
 
 @firewall.command(
-    'update-sequence', short_help='update sequence of firewall rule')
+    'reorder', short_help='reorder firewall rule position on gateway')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)


### PR DESCRIPTION
VP-1794 : [VCD-CLI] delete values from Firewall Destination.
Adding a command to delete firewall rule's destination value of rule id.

To delete a firewall rule's destination value, following command can be used:
vcd gateway services firewall delete-destination gateway_name rule_id source_value

Testing Done:
Added test_0072_delete_firewall_rule_destination to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/360)
<!-- Reviewable:end -->
