### PR TITLE
VP-1593: Change the NAT rule sequence

### DIFF
--- a/system_tests/nat_rule_tests.py
+++ b/system_tests/nat_rule_tests.py
@@ -51,6 +51,7 @@ class TestNatRule(BaseTestCase):
     _new_dnat1_desc = 'Updated DNAT Rule'
     _snat_id = None
     _dnat_id = None
+    _index = 1
 
     def test_0000_setup(self):
         """Adds new ip range present to the sub allocate pool of gateway.
@@ -169,6 +170,18 @@ class TestNatRule(BaseTestCase):
                 '-t', TestNatRule._new_dnat1_trans_addr, '-p',
                 TestNatRule._new_dnat1_protocol, '--desc',
                 TestNatRule._new_dnat1_desc, '--logging-disable'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0045_reorder_nat_rule(self):
+        """Reorder the NAT rule position on gateway.
+
+        Invoke the cli command 'services nat reorder'.
+        """
+        result = TestNatRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'nat', 'reorder', TestNatRule._name,
+                TestNatRule._snat_id, '--index', TestNatRule._index])
         self.assertEqual(0, result.exit_code)
 
     def test_0050_delete_nat_rule(self):

--- a/vcd_cli/nat_rule.py
+++ b/vcd_cli/nat_rule.py
@@ -35,26 +35,26 @@ def nat(ctx):
             vcd gateway services nat create-snat test_gateway1
                     --original-ip 2.2.3.12 --translated-ip 2.2.3.14 --desc
                     "SNAT Created" --vnic 0 --enabled --logging-enabled
-                create new SNAT rule
+                Create new SNAT rule
 
 \b
              vcd gateway services nat update-snat test_gateway1 196609
                      --original-ip 2.2.3.12 --translated-ip 2.2.3.14 --desc
                      "SNAT Updated" --vnic 0
-                 update SNAT rule
+                 Update SNAT rule
 
 \b
             vcd gateway services nat create-dnat test_gateway1
                     --original-ip 2.2.3.12 --translated-ip 2.2.3.14 --desc
                     "DNAT Created" --vnic 0 --protocol tcp -op 80 -tp 80
                     --enabled --logging-enabled
-                create new DNAT rule
+                Create new DNAT rule
 
 \b
             vcd gateway services nat update-dnat test_gateway1 196609
                      --original-ip 2.2.3.12 --translated-ip 2.2.3.14 --desc
                      "DNAT Updated" --vnic 0 --protocol udp -op 80 -tp 80
-                update DNAT rule
+                Update DNAT rule
 
 \b
             vcd gateway services nat list test_gateway1
@@ -67,6 +67,10 @@ def nat(ctx):
 \b
            vcd gateway services nat info test_gateway1 196609
                Get details of NAT rule
+
+\b
+           vcd gateway services nat reorder test_gateway1 196609 --index 2
+               Reorder the NAT rule position on gateway
     """
 
 
@@ -431,5 +435,24 @@ def update_dnat_rule(ctx, gateway_name, rule_id, original_address,
             original_port=original_Port,
             translated_port=translated_Port)
         stdout('DNAT rule updated successfully.', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@nat.command('reorder', short_help='reorder NAT rule position on gateway')
+@click.pass_context
+@click.argument('gateway_name', metavar='<gateway name>', required=True)
+@click.argument('rule_id', metavar='<nat rule id>', required=True)
+@click.option(
+    '--index',
+    'index',
+    metavar='<int>',
+    type=int,
+    help='index where NAT rule will be moved/shifted')
+def reorder_nat_rule(ctx, gateway_name, rule_id, index):
+    try:
+        gateway_resource = get_gateway(ctx, gateway_name)
+        gateway_resource.reorder_nat_rule(rule_id, position=index)
+        stdout('NAT rule reordered successfully.', ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
Change the NAT rule sequence/order using vcd-cli

New command added:
vcd gateway services nat reorder

Testing done: 

Added test 'test_0045_reorder_nat_rule' and it's passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/362)
<!-- Reviewable:end -->
