### PR TITLE
VP-1396, VP-1398: reset and delete vapp network commands.

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -67,7 +67,7 @@ class VAppTest(BaseTestCase):
         result = VAppTest._runner.invoke(
             vapp,
             args=[
-                'create-vapp-network', VAppTest._test_vapp_name,
+                'network', 'create', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name, '--subnet',
                 VAppTest._vapp_network_cidr, '--description',
                 VAppTest._vapp_network_description, '--dns1',
@@ -89,7 +89,7 @@ class VAppTest(BaseTestCase):
         result = VAppTest._runner.invoke(
             vapp,
             args=[
-                'reset-vapp-network', VAppTest._test_vapp_name,
+                'network', 'reset', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name
             ])
         self.assertEqual(0, result.exit_code)
@@ -99,7 +99,7 @@ class VAppTest(BaseTestCase):
         result = VAppTest._runner.invoke(
             vapp,
             args=[
-                'delete-vapp-network', VAppTest._test_vapp_name,
+                'network', 'delete', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name
             ])
         self.assertEqual(0, result.exit_code)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -54,11 +54,15 @@ class VAppTest(BaseTestCase):
         VAppTest._runner.invoke(org, ['use', default_org])
         VAppTest._test_vdc = Environment.get_test_vdc(VAppTest._client)
         VAppTest._test_vapp = create_vapp_from_template(
-            VAppTest._client, VAppTest._test_vdc, VAppTest._test_vapp_name,
+            VAppTest._client,
+            VAppTest._test_vdc,
+            VAppTest._test_vapp_name,
             VAppTest._config['vcd']['default_catalog_name'],
-            VAppTest._config['vcd']['default_template_file_name'])
+            VAppTest._config['vcd']['default_template_file_name'],
+            power_on=False,
+            deploy=False)
 
-    def test_0001_create_vapp_network(self):
+    def test_0010_create_vapp_network(self):
         """Create a vApp network as per configuration stated above."""
         result = VAppTest._runner.invoke(
             vapp,
@@ -74,7 +78,33 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
-    def test_0020_update_vapp(self):
+    def test_0020_poweron_vapp(self):
+        """Power on the vapp."""
+        result = VAppTest._runner.invoke(
+            vapp, args=['power-on', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0030_reset_vapp_network(self):
+        """Reset a vapp network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'reset-vapp-network', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0040_delete_vapp_network(self):
+        """Delete a vapp network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'delete-vapp-network', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0050_update_vapp(self):
         """Update a vApp name and description."""
         new_name = VAppTest._test_vapp_name + 'updated'
         new_desc = 'vapp description'

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -161,23 +161,6 @@ def vapp(ctx):
 \b
         vdc vapp disconnect vapp1 org-vdc-network1
             Disconnects the network org-vdc-network1 from vapp1.
-\b
-        vdc vapp create-vapp-network vapp1 vapp-network1
-                --subnet 192.168.1.1/24
-                --description 'vApp network'
-                --dns1 8.8.8.8
-                --dns2 8.8.8.9
-                --dns-suffix example.com
-                --ip-range 192.168.1.2-192.168.1.49
-                --ip-range 192.168.1.100-192.168.1.149
-                --guest-vlan-allowed-enabled
-            Create a vApp network.
-\b
-        vdc vapp reset-vapp-network vapp1 vapp-network1
-            Reset a vApp network.
-\b
-        vdc vapp delete-vapp-network vapp1 vapp-network1
-            Delete a vApp network.
     """
     pass
 
@@ -942,7 +925,36 @@ def add_vm(ctx, name, source_vapp, source_vm, catalog, target_vm, hostname,
         stderr(e, ctx)
 
 
-@vapp.command('create-vapp-network', short_help='create a vApp network')
+@vapp.group(short_help='work with vapp network')
+@click.pass_context
+def network(ctx):
+    """Work with vapp network.
+
+\b
+   Description
+        Work with the vapp networks.
+\b
+        vdc vapp network create vapp1 vapp-network1
+                --subnet 192.168.1.1/24
+                --description 'vApp network'
+                --dns1 8.8.8.8
+                --dns2 8.8.8.9
+                --dns-suffix example.com
+                --ip-range 192.168.1.2-192.168.1.49
+                --ip-range 192.168.1.100-192.168.1.149
+                --guest-vlan-allowed-enabled
+            Create a vApp network.
+\b
+        vdc vapp network reset vapp1 vapp-network1
+            Reset a vApp network.
+\b
+        vdc vapp network delete vapp1 vapp-network1
+            Delete a vApp network.
+    """
+    pass
+
+
+@network.command('create', short_help='create a vApp network')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
 @click.argument('name', metavar='<name>', required=True)
@@ -985,7 +997,7 @@ def create_vapp_network(ctx, vapp_name, name, subnet, description,
         stderr(e, ctx)
 
 
-@vapp.command('reset-vapp-network', short_help='reset a vApp network')
+@network.command('reset', short_help='reset a vApp network')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
 @click.argument('network-name', metavar='<network-name>', required=True)
@@ -999,7 +1011,7 @@ def reset_vapp_network(ctx, vapp_name, network_name):
         stderr(e, ctx)
 
 
-@vapp.command('delete-vapp-network', short_help='delete a vApp network')
+@network.command('delete', short_help='delete a vApp network')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
 @click.argument('network-name', metavar='<network-name>', required=True)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -158,7 +158,6 @@ def vapp(ctx):
 \b
         vdc vapp connect vapp1 org-vdc-network1
             Connects the network org-vdc-network1 to vapp1.
-
 \b
         vdc vapp disconnect vapp1 org-vdc-network1
             Disconnects the network org-vdc-network1 from vapp1.
@@ -173,6 +172,12 @@ def vapp(ctx):
                 --ip-range 192.168.1.100-192.168.1.149
                 --guest-vlan-allowed-enabled
             Create a vApp network.
+\b
+        vdc vapp reset-vapp-network vapp1 vapp-network1
+            Reset a vApp network.
+\b
+        vdc vapp delete-vapp-network vapp1 vapp-network1
+            Delete a vApp network.
     """
     pass
 
@@ -971,11 +976,7 @@ def create_vapp_network(ctx, vapp_name, name, subnet, description,
                         ip_ranges, is_guest_vlan_allowed):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp_resource = vdc.get_vapp(vapp_name)
-        vapp = VApp(client, resource=vapp_resource)
+        vapp = _get_vapp(ctx, vapp_name)
         task = vapp.create_vapp_network(
             name, subnet, description, primary_dns_ip, secondary_dns_ip,
             dns_suffix, ip_ranges, is_guest_vlan_allowed)
@@ -991,11 +992,7 @@ def create_vapp_network(ctx, vapp_name, name, subnet, description,
 def reset_vapp_network(ctx, vapp_name, network_name):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp_resource = vdc.get_vapp(vapp_name)
-        vapp = VApp(client, resource=vapp_resource)
+        vapp = _get_vapp(ctx, vapp_name)
         task = vapp.reset_vapp_network(network_name)
         stdout(task, ctx)
     except Exception as e:
@@ -1009,11 +1006,7 @@ def reset_vapp_network(ctx, vapp_name, network_name):
 def delete_vapp_network(ctx, vapp_name, network_name):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp_resource = vdc.get_vapp(vapp_name)
-        vapp = VApp(client, resource=vapp_resource)
+        vapp = _get_vapp(ctx, vapp_name)
         task = vapp.delete_vapp_network(network_name)
         stdout(task, ctx)
     except Exception as e:
@@ -1201,12 +1194,16 @@ def list_acl(ctx, vapp_name):
 def update_vapp(ctx, vapp_name, name, description):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp = VApp(client, resource=vdc.get_vapp(vapp_name))
+        vapp = _get_vapp(ctx, vapp_name)
 
         task = vapp.edit_name_and_description(name, description)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+def _get_vapp(ctx, vapp_name):
+    client = ctx.obj['client']
+    vdc_href = ctx.obj['profiles'].get('vdc_href')
+    vdc = VDC(client, href=vdc_href)
+    return VApp(client, resource=vdc.get_vapp(vapp_name))

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -984,6 +984,42 @@ def create_vapp_network(ctx, vapp_name, name, subnet, description,
         stderr(e, ctx)
 
 
+@vapp.command('reset-vapp-network', short_help='reset a vApp network')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('network-name', metavar='<network-name>', required=True)
+def reset_vapp_network(ctx, vapp_name, network_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        vapp_resource = vdc.get_vapp(vapp_name)
+        vapp = VApp(client, resource=vapp_resource)
+        task = vapp.reset_vapp_network(network_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('delete-vapp-network', short_help='delete a vApp network')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('network-name', metavar='<network-name>', required=True)
+def delete_vapp_network(ctx, vapp_name, network_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        vapp_resource = vdc.get_vapp(vapp_name)
+        vapp = VApp(client, resource=vapp_resource)
+        task = vapp.delete_vapp_network(network_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
 @vapp.group(short_help='work with vapp acl')
 @click.pass_context
 def acl(ctx):


### PR DESCRIPTION
This CL addes rest-vapp-network and delete-vapp-network commmands to vapp.
Added following tests to vapp: test_0020_poweron_vapp, test_0030_reset_vapp_network, test_0040_delete_vapp_network

Testing done:
manually run the commands.
ran the complete vapp tests locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/363)
<!-- Reviewable:end -->
