### PR TITLE
VP-1846 : [VCD-CLI] List Firewall Service

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -217,6 +217,16 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0083_list_firewall_rule_service(self):
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'list-service',
+                TestFirewallRule.__name, TestFirewallRule._rule_id.text
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0091_update_firewall_rule_sequence(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -105,6 +105,10 @@ def firewall(ctx):
                 Delete destination value of firewall rule
                 It will delete all destination values of given
                     destination_value
+
+    \b
+            vcd gateway services firewall list-service test_gateway1 rule_id
+                List firewall rule's services
     """
 
 
@@ -413,5 +417,19 @@ def delete_firewall_rule_destination(ctx, name, id, destination_value):
         firewall_rule_resource.delete_firewall_rule_source_destination(
             destination_value, 'destination')
         stdout('Firewall rule destination deleted successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command(
+    'list-service', short_help='list of firewall rule\'s services')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+def list_firewall_rule_service(ctx, name, id):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        result = firewall_rule_resource.list_firewall_rule_service()
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -421,8 +421,7 @@ def delete_firewall_rule_destination(ctx, name, id, destination_value):
         stderr(e, ctx)
 
 
-@firewall.command(
-    'list-service', short_help='list of firewall rule\'s services')
+@firewall.command('list-service', short_help='list firewall rule\'s services')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)


### PR DESCRIPTION
VP-1846 : [VCD-CLI] List Firewall Service.

Adding a command to list firewall rule's services of rule id.

To list a firewall rule's services, following command can be used:
vcd gateway services firewall list-service gateway_name rule_id

Testing Done:
Added test_0083_list_firewall_rule_service to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/364)
<!-- Reviewable:end -->
