### PR TITLE
Updating the pysdk version to fix jenkin's test failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ keyring >= 10.6.0, <= 12.0.0
 # Pycryptodome 3.5.0 does not compile on Mac OS X.
 pycryptodome >= 3.4.7,<3.5
 pypiwin32 >= 223;platform_system=="Windows"
-pyvcloud >= 20.0.4.dev19
+pyvcloud >= 20.0.4.dev42
 tabulate >= 0.7.5
 unittest-xml-reporting >= 2.2.1


### PR DESCRIPTION
It looks like vcd-cli doesn't pick the latest changes from pysdk because of that I am pushed latest changes to pypi and updating the CLI reference.

Testing Done: python setup.py develop refers to latest pysdk

https://pypi.org/project/pyvcloud/20.0.4.dev42/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/365)
<!-- Reviewable:end -->
