### PR TITLE
VP-1796 : [VCD-CLI] delete values from Firewall Service

### DIFF
--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -197,6 +197,18 @@ class TestFirewallRule(BaseTestCase):
         TestFirewallRule._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 
+    def test_0073_delete_firewall_rule_service(self):
+        protocol_to_delete = 'tcp'
+        result = TestFirewallRule._runner.invoke(
+            gateway,
+            args=[
+                'services', 'firewall', 'delete-service',
+                TestFirewallRule.__name, TestFirewallRule._rule_id.text,
+                protocol_to_delete
+            ])
+        TestFirewallRule._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
+
     def test_0081_list_firewall_rule_source(self):
         result = TestFirewallRule._runner.invoke(
             gateway,

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -109,6 +109,11 @@ def firewall(ctx):
     \b
             vcd gateway services firewall list-service test_gateway1 rule_id
                 List firewall rule's services
+
+    \b
+            vcd gateway services firewall delete-service test_gateway1 rule_id
+                    protocol
+                It will delete all services of given protocol
     """
 
 
@@ -430,5 +435,21 @@ def list_firewall_rule_service(ctx, name, id):
         firewall_rule_resource = get_firewall_rule(ctx, name, id)
         result = firewall_rule_resource.list_firewall_rule_service()
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@firewall.command(
+    'delete-service',
+    short_help='delete firewall rule\'s service from gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('id', metavar='<id>', required=True)
+@click.argument('protocol', metavar='<protocol>', required=True)
+def delete_firewall_rule_service(ctx, name, id, protocol):
+    try:
+        firewall_rule_resource = get_firewall_rule(ctx, name, id)
+        firewall_rule_resource.delete_firewall_rule_service(protocol)
+        stdout('Firewall rule\'s service deleted successfully', ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/firewall_rule.py
+++ b/vcd_cli/firewall_rule.py
@@ -96,14 +96,13 @@ def firewall(ctx):
     \b
             vcd gateway services firewall delete-source test_gateway1 rule_id
                     source_value
-                Delete source value of firewall rule
-                It will delete all source values of given source_value
+                Delete all source value of firewall rule by providing
+                    source_value
 
     \b
             vcd gateway services firewall delete-destination test_gateway1
                     rule_id destination_value
-                Delete destination value of firewall rule
-                It will delete all destination values of given
+                Delete all destination value of firewall rule by providing
                     destination_value
 
     \b
@@ -113,7 +112,7 @@ def firewall(ctx):
     \b
             vcd gateway services firewall delete-service test_gateway1 rule_id
                     protocol
-                It will delete all services of given protocol
+                Delete all services of firewall rule by providing protocol.
     """
 
 
@@ -378,7 +377,7 @@ def update_firewall_rule_sequence(ctx, name, id, new_index):
 
 @firewall.command(
     'delete-source',
-    short_help='delete firewall rule\'s source value of gateway')
+    short_help='delete firewall rule\'s source value of a firewall rule')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)
@@ -410,7 +409,7 @@ def list_firewall_rule_destination(ctx, name, id):
 
 @firewall.command(
     'delete-destination',
-    short_help='delete firewall rule\'s destination value of gateway')
+    short_help='delete firewall rule\'s destination value of a firewall rule')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)
@@ -441,7 +440,7 @@ def list_firewall_rule_service(ctx, name, id):
 
 @firewall.command(
     'delete-service',
-    short_help='delete firewall rule\'s service from gateway')
+    short_help='delete firewall rule\'s service of a firewall rule')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.argument('id', metavar='<id>', required=True)


### PR DESCRIPTION
VP-1796 : [VCD-CLI] delete values from Firewall Service.

Adding a command to delete firewall rule's service of rule id.

To delete a firewall rule's service, following command can be used:
vcd gateway services firewall delete-service gateway_name rule_id protocol

Testing Done:
Added test_0073_delete_firewall_rule_service to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/366)
<!-- Reviewable:end -->
