### PR TITLE
VP-1862 : [Vcd-Cli] Added code to set syslog server IP for gateway

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -570,15 +570,15 @@ class GatewayTest(BaseTestCase):
         self.assertTrue(
             self._validate_result_for_unclosed_sslsocket_warning(result_info))
 
-        def test_0031_set_tenant_syslog_ip(self):
-            """Set information of the gateway tenant syslog ip server.
+    def test_0031_set_tenant_syslog_ip(self):
+        """Set information of the gateway tenant syslog ip server.
 
-            It will trigger the cli command with option set-syslog-server
-            """
-            result = self._runner.invoke(
-                gateway, args=['set-syslog-server', self._name, '192.168.5.6'])
-            GatewayTest._logger.debug('result output {0}'.format(result))
-            self.assertEqual(0, result.exit_code)
+        It will trigger the cli command with option set-syslog-server
+        """
+        result = self._runner.invoke(
+            gateway, args=['set-syslog-server', self._name, '192.168.5.6'])
+        GatewayTest._logger.debug('result output {0}'.format(result))
+        self.assertEqual(0, result.exit_code)
 
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -109,8 +109,9 @@ class GatewayTest(BaseTestCase):
             args=['create', self._name, '-e', GatewayTest._ext_network_name])
         GatewayTest._logger.debug("vcd gateway create <name> -e <ext nw>: {"
                                   "0}".format(result_create1.output))
-        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
-            result_create1))
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(
+                result_create1))
         self._delete_gateway()
 
     def _validate_result_for_unclosed_sslsocket_warning(self, result):
@@ -137,8 +138,9 @@ class GatewayTest(BaseTestCase):
                                       GatewayTest._ext_network_name,
                                       GatewayTest._subnet_addr,
                                       result_create2.output))
-        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
-            result_create2))
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(
+                result_create2))
         self._delete_gateway()
 
     def _get_ip_range(self):
@@ -170,8 +172,9 @@ class GatewayTest(BaseTestCase):
                                       GatewayTest._ext_network_name,
                                       GatewayTest._subnet_addr, ip_range,
                                       result_create3.output))
-        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
-            result_create3))
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(
+                result_create3))
         self._delete_gateway()
 
     def test_0004_create_gateway_with_default_gateway_and_dns_relay_enabled(
@@ -195,8 +198,9 @@ class GatewayTest(BaseTestCase):
             "--default-gateway-ip {0} --dns-relay-enabled "
             "--advanced-enabled : {"
             "1}".format(GatewayTest._gateway_ip, result_create5.output))
-        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
-            result_create5))
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(
+                result_create5))
         self._delete_gateway()
 
     def test_0005_create_gateway_with_configure_rate_limit(self):
@@ -263,8 +267,7 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with command 'info'
         """
-        result_info = self._runner.invoke(
-            gateway, args=['info', self._name])
+        result_info = self._runner.invoke(gateway, args=['info', self._name])
         self.assertEqual(0, result_info.exit_code)
 
     def test_0010_redeploy_gateway(self):
@@ -272,8 +275,7 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with option redeploy
         """
-        result = self._runner.invoke(
-            gateway, args=['redeploy', self._name])
+        result = self._runner.invoke(gateway, args=['redeploy', self._name])
         self.assertEqual(0, result.exit_code)
 
     def test_0011_sync_syslog_settings(self):
@@ -292,8 +294,8 @@ class GatewayTest(BaseTestCase):
         result_info = self._runner.invoke(
             gateway, args=['list-config-ip-settings', self._name])
         GatewayTest._logger.debug('result output {0}'.format(result_info))
-        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
-            result_info))
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(result_info))
 
     def _create_external_network(self):
         """Create an external network as per configuration stated above.
@@ -329,8 +331,8 @@ class GatewayTest(BaseTestCase):
                 '--port-group', _port_group, '--gateway', '10.10.30.1',
                 '--netmask', '255.255.255.0', '--ip-range',
                 '10.10.30.101-10.10.30.150', '--description',
-                self._external_network_name, '--dns1',
-                '8.8.8.8', '--dns2', '8.8.8.9', '--dns-suffix', 'example.com'
+                self._external_network_name, '--dns1', '8.8.8.8', '--dns2',
+                '8.8.8.9', '--dns-suffix', 'example.com'
             ])
         self.assertEqual(0, result.exit_code)
 
@@ -382,13 +384,11 @@ class GatewayTest(BaseTestCase):
          It will trigger the cli command update
         """
         result = self._runner.invoke(
-            gateway,
-            args=['update', self._name, '-n', 'gateway2'])
+            gateway, args=['update', self._name, '-n', 'gateway2'])
         self.assertEqual(0, result.exit_code)
         """ resetting back to original name"""
         result = self._runner.invoke(
-            gateway,
-            args=['update', 'gateway2', '-n', self._name])
+            gateway, args=['update', 'gateway2', '-n', self._name])
         self.assertEqual(0, result.exit_code)
 
     @unittest.skip("Its running for base gateway and not for other "
@@ -399,21 +399,18 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with option config-ip-settings
         """
-        GatewayTest._logger.debug("vcd gateway configure-ip-settings {} -e {} "
-                                  "-s {} True {}".format(self._name,
-                                                         GatewayTest.
-                                                         _ext_network_name,
-                                                         GatewayTest.
-                                                         _subnet_addr,
-                                                         GatewayTest.
-                                                         _new_config_ip))
+        GatewayTest._logger.debug(
+            "vcd gateway configure-ip-settings {} -e {} "
+            "-s {} True {}".format(self._name, GatewayTest._ext_network_name,
+                                   GatewayTest._subnet_addr,
+                                   GatewayTest._new_config_ip))
         result = self._runner.invoke(
             gateway,
             args=[
-                'configure-ip-settings', self._name,
-                '--external-network', GatewayTest._ext_network_name,
-                '--subnet-available', GatewayTest._subnet_addr, True,
-                GatewayTest._new_config_ip])
+                'configure-ip-settings', self._name, '--external-network',
+                GatewayTest._ext_network_name, '--subnet-available',
+                GatewayTest._subnet_addr, True, GatewayTest._new_config_ip
+            ])
         GatewayTest._logger.debug("result {} ".format(result.output))
         self.assertEqual(0, result.exit_code)
 
@@ -429,8 +426,9 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway,
             args=[
-                'sub-allocate-ip', 'add', self._name, '-e',
-                ext_name, '--ip-range', gateway_sub_allocated_ip_range])
+                'sub-allocate-ip', 'add', self._name, '-e', ext_name,
+                '--ip-range', gateway_sub_allocated_ip_range
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0018_edit_sub_allocated_ip_pools(self):
@@ -447,9 +445,10 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway,
             args=[
-                'sub-allocate-ip', 'update', self._name, '-e',
-                ext_name, '-o', gateway_sub_allocated_ip_range,
-                '-n', gateway_sub_allocated_ip_range1])
+                'sub-allocate-ip', 'update', self._name, '-e', ext_name, '-o',
+                gateway_sub_allocated_ip_range, '-n',
+                gateway_sub_allocated_ip_range1
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0019_remove_sub_allocated_ip_pools(self):
@@ -464,13 +463,14 @@ class GatewayTest(BaseTestCase):
         result = self._runner.invoke(
             gateway,
             args=[
-                'sub-allocate-ip', 'remove', self._name, '-e',
-                ext_name, '-i', gateway_sub_allocated_ip_range])
+                'sub-allocate-ip', 'remove', self._name, '-e', ext_name, '-i',
+                gateway_sub_allocated_ip_range
+            ])
 
-        GatewayTest._logger.debug(
-            "vcd gateway sub-allocate-ip remove {0}"
-            "-e {1} -i {2}".format(
-                self._name, ext_name, gateway_sub_allocated_ip_range))
+        GatewayTest._logger.debug("vcd gateway sub-allocate-ip remove {0}"
+                                  "-e {1} -i {2}".format(
+                                      self._name, ext_name,
+                                      gateway_sub_allocated_ip_range))
         self.assertEqual(0, result.exit_code)
 
     @unittest.skip("Its running for base gateway and not for other "
@@ -487,7 +487,8 @@ class GatewayTest(BaseTestCase):
             gateway,
             args=[
                 'configure-rate-limits', 'list', self._name, '-r',
-                [(ext_name, '101.0', '101.0')]])
+                [(ext_name, '101.0', '101.0')]
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0021_list_rate_limit(self):
@@ -495,8 +496,7 @@ class GatewayTest(BaseTestCase):
          It will trigger the cli command configure-rate-limits update
         """
         result = self._runner.invoke(
-            gateway,
-            args=['configure-rate-limits', 'list', self._name])
+            gateway, args=['configure-rate-limits', 'list', self._name])
         self.assertEqual(0, result.exit_code)
 
     def test_0022_disable_rate_limit(self):
@@ -508,8 +508,9 @@ class GatewayTest(BaseTestCase):
         ext_name = config['name']
         result = self._runner.invoke(
             gateway,
-            args=['configure-rate-limits', 'disable', self._name, '-e',
-                  ext_name])
+            args=[
+                'configure-rate-limits', 'disable', self._name, '-e', ext_name
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0023_configure_default_gateways(self):
@@ -528,9 +529,10 @@ class GatewayTest(BaseTestCase):
                                   "2}".format(self._name, ext_name, ip))
         result = self._runner.invoke(
             gateway,
-            args=['configure-default-gateway', 'update', self._name, '-e',
-                  ext_name, '--gateway-ip', ip,
-                  '--enable'])
+            args=[
+                'configure-default-gateway', 'update', self._name, '-e',
+                ext_name, '--gateway-ip', ip, '--enable'
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0024_enable_dns_relay(self):
@@ -540,8 +542,10 @@ class GatewayTest(BaseTestCase):
         """
         result = self._runner.invoke(
             gateway,
-            args=['configure-default-gateway', 'enable-dns-relay', self._name,
-                  '--enable'])
+            args=[
+                'configure-default-gateway', 'enable-dns-relay', self._name,
+                '--enable'
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0025_list_configure_default_gateways(self):
@@ -563,8 +567,18 @@ class GatewayTest(BaseTestCase):
         result_info = self._runner.invoke(
             gateway, args=['list-syslog-server', self._name])
         GatewayTest._logger.debug('result output {0}'.format(result_info))
-        self.assertTrue(self._validate_result_for_unclosed_sslsocket_warning(
-            result_info))
+        self.assertTrue(
+            self._validate_result_for_unclosed_sslsocket_warning(result_info))
+
+        def test_0031_set_tenant_syslog_ip(self):
+            """Set information of the gateway tenant syslog ip server.
+
+            It will trigger the cli command with option set-syslog-server
+            """
+            result = self._runner.invoke(
+                gateway, args=['set-syslog-server', self._name, '192.168.5.6'])
+            GatewayTest._logger.debug('result output {0}'.format(result))
+            self.assertEqual(0, result.exit_code)
 
     def test_0098_tearDown(self):
         result_delete = self._runner.invoke(

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -575,8 +575,9 @@ class GatewayTest(BaseTestCase):
 
         It will trigger the cli command with option set-syslog-server
         """
+        ip = '192.168.5.6'
         result = self._runner.invoke(
-            gateway, args=['set-syslog-server', self._name, '192.168.5.6'])
+            gateway, args=['set-syslog-server', self._name, ip])
         GatewayTest._logger.debug('result output {0}'.format(result))
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -91,6 +91,10 @@ def gateway(ctx):
              Synchronizes syslog settings of the gateway with given name
 
 \b
+        vcd gateway set-syslog-server gateway1 ip_address
+             Set syslog server ip address of the gateway
+
+\b
         vcd gateway list-syslog-server gateway1
              List syslog server of the gateway with given name
 
@@ -296,8 +300,7 @@ def create_gateway(ctx, name, external_networks_name, description,
                 is_distributed_routing, is_ip_settings_configured,
                 ext_net_to_participated_subnet_with_ip_settings,
                 is_sub_allocate_ip_pools_enabled,
-                ext_net_to_subnet_with_ip_range,
-                ext_net_to_rate_limit)
+                ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit)
         elif float(api_version) <= float(ApiVersion.VERSION_31.value):
             result = vdc.create_gateway_api_version_31(
                 name, external_networks_name, gateway_config, description,
@@ -453,8 +456,8 @@ def sync_syslog_settings(ctx, name):
         stderr(e, ctx)
 
 
-@gateway.command('list-config-ip-settings',
-                 short_help='shows config ip settings.')
+@gateway.command(
+    'list-config-ip-settings', short_help='shows config ip settings.')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 def list_config_ip_settings(ctx, name):
@@ -466,8 +469,24 @@ def list_config_ip_settings(ctx, name):
         stderr(e, ctx)
 
 
-@gateway.group('configure-external-network',
-               short_help='configures external networks of an edge gateway')
+@gateway.command(
+    'set-syslog-server',
+    short_help='set syslog server ip of the given gateway')
+@click.pass_context
+@click.argument('name', metavar='<name>', required=True)
+@click.argument('ip', metavar='<ip>', required=True)
+def set_syslog_server(ctx, name, ip):
+    try:
+        gateway_resource = get_gateway(ctx, name)
+        gateway_resource.set_tenant_syslog_server_ip(ip)
+        stdout('Syslog server ip set succesfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@gateway.group(
+    'configure-external-network',
+    short_help='configures external networks of an edge gateway')
 @click.pass_context
 def configure_external_network(ctx):
     """Configures external networks of edge gateways in vCloud Director.
@@ -542,8 +561,7 @@ def remove_external_network(ctx, name, external_network_name):
 
 
 @gateway.command(
-    'update',
-    short_help='update name, description and HA of gateway.')
+    'update', short_help='update name, description and HA of gateway.')
 @click.pass_context
 @click.argument('name', metavar='<name>', required=True)
 @click.option(
@@ -572,8 +590,8 @@ def edit_gateway(ctx, name, new_name, desc, is_enabled):
         stderr(e, ctx)
 
 
-@gateway.command('configure-ip-settings', short_help='edit config ip settings.'
-                 )
+@gateway.command(
+    'configure-ip-settings', short_help='edit config ip settings.')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -612,8 +630,9 @@ def edit_gateway_config_ip_settings(ctx, name, external_networks_name,
         stderr(e, ctx)
 
 
-@gateway.group('sub-allocate-ip',
-               short_help='configures Sub allocate ip pools of gateway')
+@gateway.group(
+    'sub-allocate-ip',
+    short_help='configures Sub allocate ip pools of gateway')
 @click.pass_context
 def sub_allocate_ip(ctx):
     """Configures sub-allocate ip pools of gateway in vCloud Director.
@@ -659,8 +678,7 @@ def sub_allocate_ip(ctx):
     multiple=True,
     required=True,
     help='ip ranges used for static pool allocation in the network.')
-def add_sub_allocated_ip_pools(ctx, name, external_network_name,
-                               ip_range):
+def add_sub_allocated_ip_pools(ctx, name, external_network_name, ip_range):
     try:
         gateway_resource = get_gateway(ctx, name)
         task = gateway_resource.add_sub_allocated_ip_pools(
@@ -739,8 +757,9 @@ def remove_sub_allocated_ip_pools(ctx, name, external_network_name, ip_range):
         stderr(e, ctx)
 
 
-@gateway.group('configure-rate-limits', short_help='configures rate limits of'
-                                                   ' gateway')
+@gateway.group(
+    'configure-rate-limits', short_help='configures rate limits of'
+    ' gateway')
 @click.pass_context
 def configure_rate_limits(ctx):
     """Configures rate limit of gateway in vCloud Director.
@@ -758,8 +777,9 @@ def configure_rate_limits(ctx):
     pass
 
 
-@configure_rate_limits.command('update', short_help='updates rate limit of '
-                                                    'gateway.')
+@configure_rate_limits.command(
+    'update', short_help='updates rate limit of '
+    'gateway.')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -784,8 +804,8 @@ def update_configure_rate_limits(ctx, name, rate_limit_config):
         stderr(e, ctx)
 
 
-@configure_rate_limits.command('list', short_help='list rate limit of gateway.'
-                               )
+@configure_rate_limits.command(
+    'list', short_help='list rate limit of gateway.')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 def list_rate_limits(ctx, name):
@@ -797,8 +817,9 @@ def list_rate_limits(ctx, name):
         stderr(e, ctx)
 
 
-@configure_rate_limits.command('disable', short_help=' Disable rate limit of '
-                                                     'gateway.')
+@configure_rate_limits.command(
+    'disable', short_help=' Disable rate limit of '
+    'gateway.')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -832,8 +853,9 @@ def list_syslog_server(ctx, name):
         stderr(e, ctx)
 
 
-@gateway.group('configure-default-gateway', short_help='configures the default'
-                                                       'gateway')
+@gateway.group(
+    'configure-default-gateway', short_help='configures the default'
+    'gateway')
 @click.pass_context
 def configure_default_gateway(ctx):
     """Configures the default gateway in vCloud Director.
@@ -855,8 +877,9 @@ def configure_default_gateway(ctx):
     pass
 
 
-@configure_default_gateway.command('update', short_help='configures the '
-                                                        'default gateway')
+@configure_default_gateway.command(
+    'update', short_help='configures the '
+    'default gateway')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -892,8 +915,8 @@ def configure_default_gateways(ctx, name, external_network_name, gateway_ip,
         stderr(e, ctx)
 
 
-@configure_default_gateway.command('enable-dns-relay',
-                                   short_help='enables/disables the dns relay')
+@configure_default_gateway.command(
+    'enable-dns-relay', short_help='enables/disables the dns relay')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 @click.option(
@@ -911,9 +934,9 @@ def enable_dns_relay(ctx, name, is_enable):
         stderr(e, ctx)
 
 
-@configure_default_gateway.command('list',
-                                   short_help='lists the configure default'
-                                              ' gateway')
+@configure_default_gateway.command(
+    'list', short_help='lists the configure default'
+    ' gateway')
 @click.pass_context
 @click.argument('name', metavar='<gateway name>', required=True)
 def list_configure_default_gateways(ctx, name):

--- a/vcd_cli/gateway.py
+++ b/vcd_cli/gateway.py
@@ -91,7 +91,7 @@ def gateway(ctx):
              Synchronizes syslog settings of the gateway with given name
 
 \b
-        vcd gateway set-syslog-server gateway1 ip_address
+        vcd gateway set-syslog-server gateway1 10.11.11.11
              Set syslog server ip address of the gateway
 
 \b


### PR DESCRIPTION
VP-1862 : [Vcd-Cli] Added code to set syslog server IP for gateway.


Adding a command to set syslog server IP of a gateway.
To set a syslog server IP, following command can be used:
vcd gateway set-syslog-server  gateway_name ip_address

Testing Done:
Added test_0031_set_tenant_syslog_ip to gateway_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/368)
<!-- Reviewable:end -->
