### PR TITLE
VP-1797, VP-1800: add-nic and list-nics commands to vm.

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -32,6 +32,8 @@ class VmTest(BaseTestCase):
 
     Be aware that this test will delete existing vcd-cli sessions.
     """
+    DEFAULT_ADAPTER_TYPE = 'VMXNET3'
+    DEFAULT_IP_MODE = 'POOL'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -57,9 +59,9 @@ class VmTest(BaseTestCase):
             vm,
             args=[
                 'add-nic', VAppConstants.name, VAppConstants.vm1_name,
-                '--adapter-type', 'VMXNET3', '--connect', '--primary',
-                '--network', VAppConstants.network1_name, '--ip-address-mode',
-                'POOL'
+                '--adapter-type', VmTest.DEFAULT_ADAPTER_TYPE, '--connect',
+                '--primary', '--network', VAppConstants.network1_name,
+                '--ip-address-mode', VmTest.DEFAULT_IP_MODE
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -1,0 +1,91 @@
+# VMware vCloud Director vCD CLI
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.vapp_constants import VAppConstants
+from pyvcloud.system_test_framework.environment import CommonRoles
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.vm import VM
+
+from vcd_cli.login import login, logout
+from vcd_cli.org import org
+from vcd_cli.vm import vm
+
+
+class VmTest(BaseTestCase):
+    """Test VM related commands
+
+    Be aware that this test will delete existing vcd-cli sessions.
+    """
+
+    def test_0000_setup(self):
+        """Load configuration and create a click runner to invoke CLI."""
+        VmTest._config = Environment.get_config()
+        VmTest._logger = Environment.get_default_logger()
+        VmTest._client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+
+        VmTest._runner = CliRunner()
+        default_org = VmTest._config['vcd']['default_org_name']
+        VmTest._login(self)
+        VmTest._runner.invoke(org, ['use', default_org])
+        VmTest._test_vdc = Environment.get_test_vdc(VmTest._client)
+        VmTest._test_vapp = Environment.get_test_vapp_with_network(
+            VmTest._client)
+        VmTest._test_vm = VM(
+            VmTest._client,
+            href=VmTest._test_vapp.get_vm(VAppConstants.vm1_name).get('href'))
+
+    def test_0100_add_nic(self):
+        """Add a nic to the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'add-nic', VAppConstants.name, VAppConstants.vm1_name,
+                '--adapter-type', 'VMXNET3', '--connect', '--primary',
+                '--network', VAppConstants.network1_name, '--ip-address-mode',
+                'POOL'
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0100_list_nics(self):
+        """Add a nic to the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['list-nics', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_9998_tearDown(self):
+        """logout from the session."""
+        VmTest._logout(self)
+
+    def _login(self):
+        org = VmTest._config['vcd']['default_org_name']
+        user = Environment.get_username_for_role_in_test_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        password = VmTest._config['vcd']['default_org_user_password']
+        login_args = [
+            VmTest._config['vcd']['host'], org, user, "-i", "-w",
+            "--password={0}".format(password)
+        ]
+        result = VmTest._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        VmTest._runner.invoke(logout)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -34,26 +34,36 @@ def vm(ctx):
     Examples
         vcd vm list
             Get list of VMs in current virtual datacenter.
+
 \b
         vcd vm info vapp1 vm1
             Get details of the VM 'vm1' in vApp 'vapp1'.
+
 \b
         vcd vm update vapp1 vm1 --cpu 2 --core 2
             Modifies the VM 'vm1' in vApp 'vapp1' to be configured
             with 2 cpu and 2 cores .
+
 \b
         vcd vm update vapp1 vm1 --memory 512
             Modifies the VM 'vm1' in vApp 'vapp1' to be configured
             with the specified memory .
+
 \b
         vcd vm update vapp1 vm1 --cpu 2 --memory 512
             Modifies the VM 'vm1' in vApp 'vapp1' to be configured
             with 2 cpu and the specified memory .
+
 \b
-        vcd vm add-nic vapp1 vm1 --adapter-type VMXNET3
-            --primary --connect --network network_name
-            --ip-address-mode MANUAL --ip-address 192.168.1.10
+        vcd vm add-nic vapp1 vm1
+                --adapter-type VMXNET3
+                --primary
+                --connect
+                --network network_name
+                --ip-address-mode MANUAL
+                --ip-address 192.168.1.10
             Adds a nic to the VM.
+
 \b
         vcd vm list-nics vapp1 vm1
             Lists the nics of the VM.
@@ -156,28 +166,28 @@ def update(ctx, vapp_name, vm_name, cpu, cores, memory):
         NetworkAdapterType.VMXNET2.value, NetworkAdapterType.VMXNET3.value,
         NetworkAdapterType.E1000.value
     ]),
-    help='Adapter type of the nic. One of VLANCE|VMXNET|VMXNET2|VMXNET3|E1000')
+    help='adapter type of nic - one of VLANCE|VMXNET|VMXNET2|VMXNET3|E1000')
 @click.option(
     'primary',
     '--primary',
     required=False,
     is_flag=True,
     metavar='<primary>',
-    help='Whether nic has to be a primary.')
+    help='whether nic has to be a primary')
 @click.option(
     'connect',
     '--connect',
     required=False,
     is_flag=True,
     metavar='<connect>',
-    help='Whether nic has to be connected.')
+    help='whether nic has to be connected')
 @click.option(
     'network',
     '--network',
     required=False,
     default='none',
     metavar='<network>',
-    help='Network to connect to.')
+    help='network to connect to')
 @click.option(
     'ip_address_mode',
     '--ip-address-mode',
@@ -188,13 +198,13 @@ def update(ctx, vapp_name, vm_name, cpu, cores, memory):
         IpAddressMode.DHCP.value, IpAddressMode.POOL.value,
         IpAddressMode.MANUAL.value
     ]),
-    help='IP address allocation mode. One of DHCP|POOL|MANUAL|NONE.')
+    help='IP address allocation mode - one of DHCP|POOL|MANUAL|NONE')
 @click.option(
     'ip_address',
     '--ip-address',
     required=False,
     metavar='<ip-address>',
-    help='Manual IP address that needs to  be allocated to the nic.')
+    help='nanual IP address that needs to be allocated to the nic')
 def add_nic(ctx, vapp_name, vm_name, adapter_type, primary, connect, network,
             ip_address_mode, ip_address):
     try:

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -13,6 +13,8 @@
 #
 
 import click
+from pyvcloud.vcd.client import IpAddressMode
+from pyvcloud.vcd.client import NetworkAdapterType
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vm import VM
@@ -47,6 +49,14 @@ def vm(ctx):
         vcd vm update vapp1 vm1 --cpu 2 --memory 512
             Modifies the VM 'vm1' in vApp 'vapp1' to be configured
             with 2 cpu and the specified memory .
+\b
+        vcd vm add-nic vapp1 vm1 --adapter-type VMXNET3
+            --primary --connect --network network_name
+            --ip-address-mode MANUAL --ip-address 192.168.1.10
+            Adds a nic to the VM.
+\b
+        vcd vm list-nics vapp1 vm1
+            Lists the nics of the VM.
     """
     pass
 
@@ -60,6 +70,21 @@ def list_vms(ctx):
         stderr(e, ctx)
 
 
+def _get_vapp(ctx, vapp_name):
+    client = ctx.obj['client']
+    vdc_href = ctx.obj['profiles'].get('vdc_href')
+    vdc = VDC(client, href=vdc_href)
+    vapp_resource = vdc.get_vapp(vapp_name)
+    return VApp(client, resource=vapp_resource)
+
+
+def _get_vm(ctx, vapp_name, vm_name):
+    client = ctx.obj['client']
+    vapp = _get_vapp(ctx, vapp_name)
+    vm_resource = vapp.get_vm(vm_name)
+    return VM(client, resource=vm_resource)
+
+
 @vm.command(short_help='show VM details')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
@@ -67,11 +92,7 @@ def list_vms(ctx):
 def info(ctx, vapp_name, vm_name):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp_resource = vdc.get_vapp(vapp_name)
-        vapp = VApp(client, resource=vapp_resource)
+        vapp = _get_vapp(ctx, vapp_name)
         result = {}
         result['primary_ip'] = vapp.get_primary_ip(vm_name)
         stdout(result, ctx)
@@ -108,13 +129,7 @@ def info(ctx, vapp_name, vm_name):
 def update(ctx, vapp_name, vm_name, cpu, cores, memory):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp_resource = vdc.get_vapp(vapp_name)
-        vapp = VApp(client, resource=vapp_resource)
-        vm_resource = vapp.get_vm(vm_name)
-        vm = VM(client, resource=vm_resource)
+        vm = _get_vm(ctx, vapp_name, vm_name)
         if cpu is not None:
             task_cpu_update = vm.modify_cpu(cpu, cores)
             stdout("Updating cpu (and core(s) if specified) for the VM")
@@ -123,5 +138,84 @@ def update(ctx, vapp_name, vm_name, cpu, cores, memory):
             task_memory_update = vm.modify_memory(memory)
             stdout("Updating memory for the VM")
             stdout(task_memory_update, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('add-nic', short_help='Add a nic to the VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'adapter_type',
+    '--adapter-type',
+    required=False,
+    metavar='<adapter-type>',
+    type=click.Choice([
+        NetworkAdapterType.VLANCE.value, NetworkAdapterType.VMXNET.value,
+        NetworkAdapterType.VMXNET2.value, NetworkAdapterType.VMXNET3.value,
+        NetworkAdapterType.E1000.value
+    ]),
+    help='Adapter type of the nic. One of VLANCE|VMXNET|VMXNET2|VMXNET3|E1000')
+@click.option(
+    'primary',
+    '--primary',
+    required=False,
+    is_flag=True,
+    metavar='<primary>',
+    help='Whether nic has to be a primary.')
+@click.option(
+    'connect',
+    '--connect',
+    required=False,
+    is_flag=True,
+    metavar='<connect>',
+    help='Whether nic has to be connected.')
+@click.option(
+    'network',
+    '--network',
+    required=False,
+    default='none',
+    metavar='<network>',
+    help='Network to connect to.')
+@click.option(
+    'ip_address_mode',
+    '--ip-address-mode',
+    required=False,
+    default=IpAddressMode.DHCP.value,
+    metavar='<ip-address-mode>',
+    type=click.Choice([
+        IpAddressMode.DHCP.value, IpAddressMode.POOL.value,
+        IpAddressMode.MANUAL.value
+    ]),
+    help='IP address allocation mode. One of DHCP|POOL|MANUAL|NONE.')
+@click.option(
+    'ip_address',
+    '--ip-address',
+    required=False,
+    metavar='<ip-address>',
+    help='Manual IP address that needs to  be allocated to the nic.')
+def add_nic(ctx, vapp_name, vm_name, adapter_type, primary, connect, network,
+            ip_address_mode, ip_address):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.add_nic(adapter_type, primary, connect, network,
+                          ip_address_mode, ip_address)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('list-nics', short_help='List all the nics of the VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_nics(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        nics = vm.list_nics()
+        stdout(nics, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
This CL adds add-nic and list-nics commands to the vm command.
Added vm_tests to cover these two commands.

Testing done: ran the commands manually.
ran the newly added tests successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/371)
<!-- Reviewable:end -->
