### PR TITLE
VP-1802: vm: delete-nic command

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -65,10 +65,20 @@ class VmTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
-    def test_0100_list_nics(self):
-        """Add a nic to the VM."""
+    def test_0101_list_nics(self):
+        """List all nisc of the VM."""
         result = VmTest._runner.invoke(
             vm, args=['list-nics', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0105_delete_nic(self):
+        """Delete a nic of the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'delete-nic', VAppConstants.name, VAppConstants.vm1_name,
+                '--index', 0
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -66,7 +66,7 @@ class VmTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_0101_list_nics(self):
-        """List all nisc of the VM."""
+        """List all nics of the VM."""
         result = VmTest._runner.invoke(
             vm, args=['list-nics', VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -229,3 +229,24 @@ def list_nics(ctx, vapp_name, vm_name):
         stdout(nics, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@vm.command('delete-nic', short_help='Delete the nic with the index')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'index',
+    '--index',
+    required=True,
+    metavar='<index>',
+    type=click.INT,
+    help='index of the nic to be deleted')
+def delete_nic(ctx, vapp_name, vm_name, index):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.delete_nic(index)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -67,6 +67,11 @@ def vm(ctx):
 \b
         vcd vm list-nics vapp1 vm1
             Lists the nics of the VM.
+
+\b
+        vcd vm delete-nic vapp1 vm1
+                --index 1
+            Deletes the nic at given index.
     """
     pass
 


### PR DESCRIPTION
this CL adds delete-nic command to the vm command group.
added test case for the same in vm_tests

testing done: ran the command locally.
ran the test cases in dev setup successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/372)
<!-- Reviewable:end -->
