### PR TITLE
VP-1902 : [VCDCLI] Update vApp network

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -42,6 +42,7 @@ class VAppTest(BaseTestCase):
     _vapp_network_dns_suffix = 'example.com'
     _vapp_network_ip_range = '90.80.70.2-90.80.70.100'
     _vapp_network_new_ip_range = '90.80.70.104-90.80.70.110'
+    _vapp_network_description = 'This is test network'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -96,13 +97,27 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0031_update_vapp_network(self):
+        """Update a vapp network's name and description."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'update', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, '-d',
+                VAppTest._vapp_network_description
+            ])
+        self.assertEqual(0, result.exit_code)
+
     def test_0035_add_ip_range_to_vapp_network(self):
         """Add I{ range to vapp network."""
         result = VAppTest._runner.invoke(
             vapp,
             args=[
-                'network', 'add-ip-range', VAppTest._test_vapp_name,
-                VAppTest._vapp_network_name, '--ip-range',
+                'network',
+                'add-ip-range',
+                VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name,
+                '--ip-range',
                 VAppTest._vapp_network_new_ip_range,
             ])
         self.assertEqual(0, result.exit_code)
@@ -114,7 +129,7 @@ class VAppTest(BaseTestCase):
             args=[
                 'network', 'delete-ip-range', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name, '--ip-range',
-                 VAppTest._vapp_network_new_ip_range
+                VAppTest._vapp_network_new_ip_range
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -21,6 +21,7 @@ from vcd_cli.vcd import vcd  # NOQA
 from vcd_cli.vapp import vapp  # NOQA
 from vcd_cli.vapp import get_vapp
 
+
 @vapp.group(short_help='work with vapp network')
 @click.pass_context
 def network(ctx):
@@ -46,6 +47,9 @@ def network(ctx):
 \b
         vdc vapp network delete vapp1 vapp-network1
             Delete a vApp network.
+\b
+        vdc vapp network update vapp1 vapp-network1 -n NewName -d Description
+            Update a vApp network.
 \b
         vdc vapp network add-ip-range vapp1 vapp-network1
                 --ip-range 6.6.5.2-6.6.5.20
@@ -124,6 +128,36 @@ def delete_vapp_network(ctx, vapp_name, network_name):
         restore_session(ctx, vdc_required=True)
         vapp = get_vapp(ctx, vapp_name)
         task = vapp.delete_vapp_network(network_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command(
+    'update', short_help='update vapp network\'s name and description')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('network-name', metavar='<network-name>', required=True)
+@click.option(
+    '-n',
+    '--name',
+    'name',
+    default=None,
+    metavar='<name>',
+    help='new name of the network')
+@click.option(
+    '-d',
+    '--description',
+    'description',
+    default=None,
+    metavar='<description>',
+    help='new description of the network')
+def update_vapp_network(ctx, vapp_name, network_name, name, description):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+
+        task = vapp.update_vapp_network(network_name, name, description)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1902 : [VCDCLI] Update vApp network.

To update a vapp network, following command can be used:
vcd vapp network update  vapp_name vapp_network_name -n vapp_network_new_name -d vapp_network_new_description

Testing Done:
Added test_0031_update_vapp_network to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/380)
<!-- Reviewable:end -->
