### PR TITLE
VP-1926, VP-1930

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -42,6 +42,7 @@ class VAppTest(BaseTestCase):
     _vapp_network_dns_suffix = 'example.com'
     _vapp_network_ip_range = '90.80.70.2-90.80.70.100'
     _vapp_network_new_ip_range = '90.80.70.104-90.80.70.110'
+    _vapp_network_description = 'This is test network'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -96,13 +97,27 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0031_update_vapp_network(self):
+        """Update a vapp network's name and description."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'update', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, '-d',
+                VAppTest._vapp_network_description
+            ])
+        self.assertEqual(0, result.exit_code)
+
     def test_0035_add_ip_range_to_vapp_network(self):
         """Add I{ range to vapp network."""
         result = VAppTest._runner.invoke(
             vapp,
             args=[
-                'network', 'add-ip-range', VAppTest._test_vapp_name,
-                VAppTest._vapp_network_name, '--ip-range',
+                'network',
+                'add-ip-range',
+                VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name,
+                '--ip-range',
                 VAppTest._vapp_network_new_ip_range,
             ])
         self.assertEqual(0, result.exit_code)
@@ -114,7 +129,7 @@ class VAppTest(BaseTestCase):
             args=[
                 'network', 'delete-ip-range', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name, '--ip-range',
-                 VAppTest._vapp_network_new_ip_range
+                VAppTest._vapp_network_new_ip_range
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -43,6 +43,10 @@ class VAppTest(BaseTestCase):
     _vapp_network_ip_range = '90.80.70.2-90.80.70.100'
     _vapp_network_new_ip_range = '90.80.70.104-90.80.70.110'
     _vapp_network_description = 'This is test network'
+    _vapp_network_update_ip_range = '90.80.70.20-90.80.70.40'
+    _new_vapp_network_dns1 = '8.8.8.10'
+    _new_vapp_network_dns2 = '8.8.8.11'
+    _new_vapp_network_dns_suffix = 'example1.com'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -122,7 +126,19 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
-    def test_0040_delete_ip_range_to_vapp_network(self):
+    def test_0036_update_ip_range_to_vapp_network(self):
+        """Update IP range to vapp network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'update-ip-range', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, '--ip-range',
+                VAppTest._vapp_network_ip_range, '--new-ip-range',
+                VAppTest._vapp_network_update_ip_range
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0037_delete_ip_range_to_vapp_network(self):
         """Delete IP range of vapp network."""
         result = VAppTest._runner.invoke(
             vapp,
@@ -130,6 +146,19 @@ class VAppTest(BaseTestCase):
                 'network', 'delete-ip-range', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name, '--ip-range',
                 VAppTest._vapp_network_new_ip_range
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0038_add_dns_to_vapp_network(self):
+        """Add DNS details to vapp network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'add-dns', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, '--dns1',
+                VAppTest._new_vapp_network_dns1, '--dns2',
+                VAppTest._new_vapp_network_dns2, '--dns-suffix',
+                VAppTest._new_vapp_network_dns_suffix
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -58,6 +58,15 @@ def network(ctx):
         vdc vapp network delete-ip-range vapp1 vapp-network1
                 --ip-range 6.6.5.2-6.6.5.20
             Delete IP range of the vApp network.
+\b
+        vdc vapp network update-ip-range vapp1 vapp-network1
+                --ip-range 6.6.5.2-6.6.5.20 --new-ip-range 6.6.5.10-6.6.5.18
+            Update IP range of the vApp network.
+\b
+        vdc vapp network add-dns vapp1 vapp-network1
+                --dns1 6.6.5.2 --dns2 6.6.5.10-6.6.5.18
+                --dns-suffix example.com
+            Update IP range of the vApp network.
     """
     pass
 
@@ -204,6 +213,72 @@ def delete_ip_range(ctx, vapp_name, network_name, ip_range):
         vapp = get_vapp(ctx, vapp_name)
         ranges = ip_range.split('-')
         task = vapp.delete_ip_range(network_name, ranges[0], ranges[1])
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command(
+    'update-ip-range', short_help='update IP range/s to the network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    required=True,
+    metavar='<ip>',
+    help='IP range in StartAddress-EndAddress format')
+@click.option(
+    '-n',
+    '--new-ip-range',
+    'new_ip_range',
+    required=True,
+    metavar='<ip>',
+    help='new IP range in StartAddress-EndAddress format')
+def update_ip_range(ctx, vapp_name, network_name, ip_range, new_ip_range):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        range = ip_range.split('-')
+        new_range = new_ip_range.split('-')
+        task = vapp.update_ip_range(network_name, range[0], range[1],
+                                    new_range[0], new_range[1])
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command('add-dns', short_help='add DNS to vapp network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.option(
+    '--dns1',
+    'primary_dns_ip',
+    default=None,
+    metavar='<ip>',
+    help='IP of the primary dns server')
+@click.option(
+    '--dns2',
+    'secondary_dns_ip',
+    default=None,
+    metavar='<ip>',
+    help='IP of the secondary dns server')
+@click.option(
+    '--dns-suffix',
+    'dns_suffix',
+    default=None,
+    metavar='<name>',
+    help='dns suffix')
+def add_dns_to_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
+                            secondary_dns_ip, dns_suffix):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.update_dns_vapp_network(network_name, primary_dns_ip,
+                                            secondary_dns_ip, dns_suffix)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -57,16 +57,16 @@ def network(ctx):
 \b
         vdc vapp network delete-ip-range vapp1 vapp-network1
                 --ip-range 6.6.5.2-6.6.5.20
-            Delete IP range of the vApp network.
+            Delete IP range from vApp network.
 \b
         vdc vapp network update-ip-range vapp1 vapp-network1
                 --ip-range 6.6.5.2-6.6.5.20 --new-ip-range 6.6.5.10-6.6.5.18
-            Update IP range of the vApp network.
+            Update IP range of vApp network.
 \b
         vdc vapp network add-dns vapp1 vapp-network1
                 --dns1 6.6.5.2 --dns2 6.6.5.10-6.6.5.18
                 --dns-suffix example.com
-            Update IP range of the vApp network.
+            Add DNS detail to vApp network.
     """
     pass
 

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -21,6 +21,7 @@ from vcd_cli.vcd import vcd  # NOQA
 from vcd_cli.vapp import vapp  # NOQA
 from vcd_cli.vapp import get_vapp
 
+
 @vapp.group(short_help='work with vapp network')
 @click.pass_context
 def network(ctx):
@@ -46,6 +47,9 @@ def network(ctx):
 \b
         vdc vapp network delete vapp1 vapp-network1
             Delete a vApp network.
+\b
+        vdc vapp network update vapp1 vapp-network1 -n NewName -d Description
+            Update a vApp network.
 \b
         vdc vapp network add-ip-range vapp1 vapp-network1
                 --ip-range 6.6.5.2-6.6.5.20
@@ -124,6 +128,36 @@ def delete_vapp_network(ctx, vapp_name, network_name):
         restore_session(ctx, vdc_required=True)
         vapp = get_vapp(ctx, vapp_name)
         task = vapp.delete_vapp_network(network_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command(
+    'update', short_help='update vapp network\'s name and description')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('network-name', metavar='<network-name>', required=True)
+@click.option(
+    '-n',
+    '--name',
+    'name',
+    default=None,
+    metavar='<name>',
+    help='new name of the network')
+@click.option(
+    '-d',
+    '--description',
+    'description',
+    default=None,
+    metavar='<description>',
+    help='new description of the network')
+def update_vapp_network(ctx, vapp_name, network_name, name, description):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+
+        task = vapp.update_vapp_network(network_name, name, description)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1926 : [VCDCLI] Update IP range of vApp network.
VP-1930 : [VCDCLI] Add DNS details to vApp network.

Adding a commands to Update IP range and Add DNS details to vApp network.

To Update IP range of a vApp network, following command can be used:
vdc vapp network update-ip-range vapp1 vapp-network1 --ip-range 6.6.5.2-6.6.5.20 --new-ip-range 6.6.5.10-6.6.5.18 

To Add DNS details of a vApp network, following command can be used:
vdc vapp network add-dns vapp1 vapp-network1 --dns1 6.6.5.2 --dns2 6.6.5.10-6.6.5.18 --dns-suffix example.com

Testing Done:
Added test_0036_update_ip_range_to_vapp_network , test_0038_add_dns_to_vapp_network to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/381)
<!-- Reviewable:end -->
