### PR TITLE
VP-1938, VP-1940

### DIFF
--- a/system_tests/vapp_network_dhcp_tests.py
+++ b/system_tests/vapp_network_dhcp_tests.py
@@ -79,14 +79,17 @@ class TestVappDhcp(BaseTestCase):
         result = TestVappDhcp._runner.invoke(
             vapp,
             args=[
-                'network',
-                'services',
-                'dhcp',
-                'enable',
-                TestVappDhcp._vapp_name,
-                TestVappDhcp._vapp_network_name,
-                '--enable',
-                False,
+                'network', 'services', 'dhcp', 'enable-dhcp',
+                TestVappDhcp._vapp_name, TestVappDhcp._vapp_network_name,
+                '--disable'
+            ])
+        self.assertEqual(0, result.exit_code)
+        result = TestVappDhcp._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'dhcp', 'enable-dhcp',
+                TestVappDhcp._vapp_name, TestVappDhcp._vapp_network_name,
+                '--enable'
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/system_tests/vapp_network_dhcp_tests.py
+++ b/system_tests/vapp_network_dhcp_tests.py
@@ -1,0 +1,108 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.vapp_constants import VAppConstants
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.system_test_framework.environment import developerModeAware
+from pyvcloud.vcd.client import TaskStatus
+from vcd_cli.login import login, logout
+from vcd_cli.vapp import vapp
+from vcd_cli.org import org
+
+
+class TestVappDhcp(BaseTestCase):
+    """Test vapp dhcp functionalities implemented in pyvcloud."""
+    _vapp_name = VAppConstants.name
+    _vapp_network_name = VAppConstants.network1_name
+    _vapp_network_dhcp_ip_range = '90.80.70.101-90.80.70.120'
+    _vapp_network_start_dhcp_ip = '90.80.70.101'
+    _vapp_network_end_dhcp_ip = '90.80.70.120'
+    _vapp_network_dhcp_default_lease_time = 3600
+    _vapp_network_dhcp_max_lease_time = 7200
+    _enable = True
+    _disable = False
+
+    def test_0000_setup(self):
+        self._config = Environment.get_config()
+        TestVappDhcp._logger = Environment.get_default_logger()
+        TestVappDhcp._client = Environment.get_sys_admin_client()
+        TestVappDhcp._runner = CliRunner()
+        default_org = self._config['vcd']['default_org_name']
+        self._login()
+        TestVappDhcp._runner.invoke(org, ['use', default_org])
+        vapp = Environment.get_test_vapp_with_network(TestVappDhcp._client)
+        self.assertIsNotNone(vapp)
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = TestVappDhcp._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        TestVappDhcp._runner.invoke(logout)
+
+    def test_0011_set_dhcp_service(self):
+        result = TestVappDhcp._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'dhcp', 'set', TestVappDhcp._vapp_name,
+                TestVappDhcp._vapp_network_name, '-i',
+                TestVappDhcp._vapp_network_dhcp_ip_range
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0012_enable_dhcp_service(self):
+        result = TestVappDhcp._runner.invoke(
+            vapp,
+            args=[
+                'network',
+                'services',
+                'dhcp',
+                'enable',
+                TestVappDhcp._vapp_name,
+                TestVappDhcp._vapp_network_name,
+                '--enable',
+                False,
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    @developerModeAware
+    def test_0098_teardown(self):
+        """Test the  method vdc.delete_vapp().
+
+        Invoke the method for all the vApps created by setup.
+
+        This test passes if all the tasks for deleting the vApps succeed.
+        """
+        vdc = Environment.get_test_vdc(TestVappDhcp._client)
+        task = vdc.delete_vapp(name=TestVappDhcp._vapp_name, force=True)
+        result = TestVappDhcp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0099_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        self._logout()

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -219,7 +219,7 @@ def delete_ip_range(ctx, vapp_name, network_name, ip_range):
 
 
 @network.command(
-    'update-ip-range', short_help='update IP range/s to the network')
+    'update-ip-range', short_help='update IP range/s of the network')
 @click.pass_context
 @click.argument('vapp_name', metavar='<vapp-name>', required=True)
 @click.argument('network_name', metavar='<network-name>', required=True)
@@ -282,3 +282,10 @@ def add_dns_to_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+
+@network.group('services', short_help='manage vapp network services')
+@click.pass_context
+def services(ctx):
+    """Configure services of vapp network."""
+    pass

--- a/vcd_cli/vapp_network_dhcp.py
+++ b/vcd_cli/vapp_network_dhcp.py
@@ -35,7 +35,8 @@ def dhcp(ctx):
                 Set dhcp service information
 
     \b
-            vcd vapp network services dhcp enable vapp_name network_name
+            vcd vapp network services dhcp enable-dhcp vapp_name network_name
+                    --enable
                 Enable DHCP service.
     """
 

--- a/vcd_cli/vapp_network_dhcp.py
+++ b/vcd_cli/vapp_network_dhcp.py
@@ -1,0 +1,103 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import click
+from pyvcloud.vcd.vapp_dhcp import VappDhcp
+from vcd_cli.utils import restore_session
+from vcd_cli.utils import stderr
+from vcd_cli.utils import stdout
+from vcd_cli.vapp_network import services
+
+
+@services.group('dhcp', short_help='manage DHCP service of vapp network')
+@click.pass_context
+def dhcp(ctx):
+    """Manages DHCP service of vapp network.
+
+    \b
+        Examples
+            vcd vapp network services dhcp set vapp_name network_name --i
+                10.11.11.1-10.11.11.100 --default-lease-time 4500
+                --max-lease-time 7000
+            Set dhcp service information
+
+    \b
+            vcd vapp network services dhcp enable vapp_name network_name
+                --e False
+            Enable DHCP service.
+    """
+
+
+def get_vapp_network_dhcp(ctx, vapp_name, network_name):
+    """Get the VappDhcp object.
+
+    It will restore sessions if expired. It will reads the client and
+    creates the VappDhcp object.
+    """
+    restore_session(ctx, vdc_required=True)
+    client = ctx.obj['client']
+    vapp_dhcp = VappDhcp(client, vapp_name, network_name)
+    return vapp_dhcp
+
+
+@dhcp.command('set', short_help='Set DHCP service information')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.option(
+    '-i',
+    '--ip-range',
+    'ip_range',
+    required=True,
+    metavar='<ip>',
+    help='IP range in StartAddress-EndAddress format')
+@click.option(
+    '-dlt',
+    '--default-lease-time',
+    'default_lease_time',
+    default='3600',
+    metavar='<ip>',
+    help='default lease time')
+@click.option(
+    '-mlt',
+    '--max-lease-time',
+    'max_lease_time',
+    default='7200',
+    metavar='<ip>',
+    help='max lease time')
+def set(ctx, vapp_name, network_name, ip_range, default_lease_time,
+        max_lease_time):
+    try:
+        vapp_dhcp = get_vapp_network_dhcp(ctx, vapp_name, network_name)
+        result = vapp_dhcp.set_dhcp_service(ip_range, default_lease_time,
+                                            max_lease_time)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@dhcp.command('enable', short_help='Enable DHCP Service')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.option('--e', '--enable', 'enable', default=True, metavar='<bool>')
+def enable_dhcp_service(ctx, vapp_name, network_name, enable):
+    try:
+        vapp_dhcp = get_vapp_network_dhcp(ctx, vapp_name, network_name)
+        if enable == 'False' or enable is False:
+            result = vapp_dhcp.enable_dhcp_service(False)
+        else:
+            result = vapp_dhcp.enable_dhcp_service(True)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/vapp_network_dhcp.py
+++ b/vcd_cli/vapp_network_dhcp.py
@@ -33,7 +33,6 @@ def dhcp(ctx):
 
     \b
             vcd vapp network services dhcp enable vapp_name network_name
-                --e False
             Enable DHCP service.
     """
 

--- a/vcd_cli/vapp_network_dhcp.py
+++ b/vcd_cli/vapp_network_dhcp.py
@@ -18,6 +18,9 @@ from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
 from vcd_cli.vapp_network import services
 
+DEFAULT_LEASE_TIME = '3600'
+MAX_LEASE_TIME = '7200'
+
 
 @services.group('dhcp', short_help='manage DHCP service of vapp network')
 @click.pass_context
@@ -27,13 +30,13 @@ def dhcp(ctx):
     \b
         Examples
             vcd vapp network services dhcp set vapp_name network_name --i
-                10.11.11.1-10.11.11.100 --default-lease-time 4500
-                --max-lease-time 7000
-            Set dhcp service information
+                    10.11.11.1-10.11.11.100 --default-lease-time 4500
+                    --max-lease-time 7000
+                Set dhcp service information
 
     \b
             vcd vapp network services dhcp enable vapp_name network_name
-            Enable DHCP service.
+                Enable DHCP service.
     """
 
 
@@ -64,14 +67,14 @@ def get_vapp_network_dhcp(ctx, vapp_name, network_name):
     '-dlt',
     '--default-lease-time',
     'default_lease_time',
-    default='3600',
+    default=DEFAULT_LEASE_TIME,
     metavar='<ip>',
     help='default lease time')
 @click.option(
     '-mlt',
     '--max-lease-time',
     'max_lease_time',
-    default='7200',
+    default=MAX_LEASE_TIME,
     metavar='<ip>',
     help='max lease time')
 def set(ctx, vapp_name, network_name, ip_range, default_lease_time,
@@ -85,18 +88,16 @@ def set(ctx, vapp_name, network_name, ip_range, default_lease_time,
         stderr(e, ctx)
 
 
-@dhcp.command('enable', short_help='Enable DHCP Service')
+@dhcp.command('enable-dhcp', short_help='Enable DHCP Service')
 @click.pass_context
 @click.argument('vapp_name', metavar='<vapp-name>', required=True)
 @click.argument('network_name', metavar='<network-name>', required=True)
-@click.option('--e', '--enable', 'enable', default=True, metavar='<bool>')
-def enable_dhcp_service(ctx, vapp_name, network_name, enable):
+@click.option(
+    '--enable/--disable', 'is_enabled', default=True, metavar='<is_dhcp>')
+def enable_dhcp_service(ctx, vapp_name, network_name, is_enabled):
     try:
         vapp_dhcp = get_vapp_network_dhcp(ctx, vapp_name, network_name)
-        if enable == 'False' or enable is False:
-            result = vapp_dhcp.enable_dhcp_service(False)
-        else:
-            result = vapp_dhcp.enable_dhcp_service(True)
+        result = vapp_dhcp.enable_dhcp_service(is_enabled)
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -127,7 +127,7 @@ else:
     from vcd_cli import pvdc  # NOQA
     from vcd_cli import role  # NOQA
     from vcd_cli import right  # NOQA
-    from vcd_cli import routed # NOQA
+    from vcd_cli import routed  # NOQA
     from vcd_cli import static_route  # NOQA
     from vcd_cli import search  # NOQA
     from vcd_cli import service_certificates  # NOQA
@@ -136,6 +136,7 @@ else:
     from vcd_cli import user  # NOQA
     from vcd_cli import vapp  # NOQA
     from vcd_cli import vapp_network  # NOQA
+    from vcd_cli import vapp_network_dhcp  # NOQA
     from vcd_cli import vc  # NOQA
     from vcd_cli import vdc  # NOQA
     from vcd_cli import vm  # NOQA


### PR DESCRIPTION
VP-1938 : [VCDCLI] Enable DHCP of vApp network.
VP-1940 : [VCDCLI] Disable DHCP of vApp network.

Adding a commands to enable DHCP service of vapp network.

To enable DHCP service following command can use:
vcd vapp network services dhcp enable-dhcp  vapp_name network_name --enable.

To disable DHCP service following command can use:
vcd vapp network services dhcp enable-dhcp  vapp_name network_name --disable.

Adding a commands to set DHCP service of vapp network.
To set DHCP service following command can use:
vcd vapp network services dhcp set vapp_name network_name --i 10.11.11.1-10.11.11.100
--default-lease-time 4500  --max-lease-time 7000

Testing Done:
Added test_0011_set_dhcp_service,test_0012_enable_dhcp_service to vapp_network_dhcp_tests.py. 
All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/384)
<!-- Reviewable:end -->
