### PR TITLE
VP-2085 : [VcdCLI]Stop vApp

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -91,6 +91,14 @@ class VAppTest(BaseTestCase):
             vapp, args=['power-on', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0025_stop_vapp(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['stop', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+        result = VAppTest._runner.invoke(
+            vapp, args=['power-on', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0030_reset_vapp_network(self):
         """Reset a vapp network."""
         result = VAppTest._runner.invoke(

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -42,11 +42,13 @@ def vapp(ctx):
 \b
     Description
         The vapp command manages vApps.
+
 \b
         'vapp create' creates a new vApp in the current vDC. When '--catalog'
         and '--template' are not provided, it creates an empty vApp and VMs can
         be added later. When specifying a template in a catalog, it creates an
         instance of the catalog template.
+
 \b
         'vapp add-vm' adds a VM to the vApp. When '--catalog' is used, the
         <source-vapp> parameter refers to a template in the specified catalog
@@ -55,25 +57,32 @@ def vapp(ctx):
         vDC and the command will copy the <source-vm> found in the vApp. The
         name of the VM and other options can be customized when the VM is added
         to the vApp.
+
 \b
     Examples
         vcd vapp list
             Get list of vApps in current virtual datacenter.
+
 \b
         vcd vapp list vapp1
             Get list of VMs in vApp 'vapp1'.
+
 \b
         vcd vapp info vapp1
             Get details of the vApp 'vapp1'.
+
 \b
         vcd vapp create vapp1
             Create an empty vApp with name 'vapp1'.
+
 \b
         vcd vapp create vapp1 --network net1
             Create an empty vApp connected to a network.
+
 \b
         vcd vapp create vapp1 -c catalog1 -t template1
             Instantiate a vApp from a catalog template.
+
 \b
         vcd vapp create vapp1 -c catalog1 -t template1
                  --cpu 4 --memory 4096 --disk-size 20000
@@ -81,83 +90,113 @@ def vapp(ctx):
                  --hostname myhost --vm-name vm1 --accept-all-eulas
                  --storage-profile '*'
             Instantiate a vApp with customized settings.
+
 \b
         vcd vapp update vapp1 -n vapp-new-name -d "new description"
             Updates vApp name and description.
+
 \b
         vcd vapp delete vapp1 --yes --force
             Delete a vApp.
+
 \b
         vcd --no-wait vapp delete vapp1 --yes --force
             Delete a vApp without waiting for completion.
+
 \b
         vcd vapp update-lease vapp1 7776000
             Set vApp lease to 90 days.
+
 \b
         vcd vapp update-lease vapp1 0
             Set vApp lease to no expiration.
+
 \b
         vcd vapp shutdown vapp1 --yes
             Gracefully shutdown a vApp.
+
 \b
         vcd vapp reboot vapp1 --yes
             Reboot a vApp.
+
 \b
         vcd vapp power-off vapp1
             Power off a vApp.
+
 \b
         vcd vapp power-off vapp1 vm1 vm2
             Power off vm1 and vm2 of vapp1.
+
 \b
         vcd vapp reset vapp1 vm1 vm2
             Power reset vm1 and vm2 of vapp1.
+
 \b
         vcd vapp deploy vapp1 vm1 vm2
             Deploy vm1 and vm2 of vapp1.
+
 \b
         vcd vapp undeploy vapp1 vm1 vm2
             Undeploy vm1 and vm2 of vapp1.
+
+\b
+        vcd vapp stop vapp1
+            stop a vApp.
+
 \b
         vcd vapp delete vapp1 vm1 vm2
             Delete vm1 and vm2 from vapp1.
+
 \b
         vcd vapp reboot vapp1 vm1 vm2 --yes
             Reboot vm1 and vm2 in vApp.
+
 \b
         vcd vapp shutdown vapp1 vm1 vm2 --yes
             Shutdown vm1 and vm2 in vApp.
+
 \b
         vcd vapp power-on vapp1
             Power on a vApp.
+
 \b
         vcd vapp reset vapp1
             Power reset vapp1.
+
 \b
         vcd vapp deploy vapp1
             Deploy vapp1.
+
 \b
         vcd vapp power-on vapp1 vm1 vm2
             Power on vm1 and vm2 of vapp1.
+
 \b
         vcd vapp capture vapp1 catalog1
             Capture a vApp as a template in a catalog.
+
 \b
         vcd vapp attach vapp1 vm1 disk1
             Attach a disk to a VM in the given vApp.
+
 \b
         vcd vapp detach vapp1 vm1 disk1
             Detach a disk from a VM in the given vApp.
+
 \b
         vcd vapp add-disk vapp1 vm1 10000
             Add a disk of 10000 MB to a VM.
+
 \b
         vcd vapp add-vm vapp1 template1.ova vm1 -c catalog1
             Add a VM to a vApp. Instantiate the source VM \'vm1\' that is in
             the \'template1.ova\' template in the \'catalog1\' catalog and
             place the new VM inside \'vapp1\' vApp.
+
 \b
         vdc vapp connect vapp1 org-vdc-network1
             Connects the network org-vdc-network1 to vapp1.
+
 \b
         vdc vapp disconnect vapp1 org-vdc-network1
             Disconnects the network org-vdc-network1 from vapp1.
@@ -633,6 +672,23 @@ def undeploy(ctx, name, vm_names, action):
                 vm.reload()
                 task = vm.undeploy(action)
                 stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('stop', short_help='stop a vApp')
+@click.pass_context
+@click.argument('name', required=True)
+def stopVapp(ctx, name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        vapp_resource = vdc.get_vapp(name)
+        vapp = VApp(client, resource=vapp_resource)
+        task = vapp.undeploy()
+        stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP-2085 : [VcdCLI]Stop vApp.


Adding a command to stop a vApp.
To stop  a vApp, following command can be used:
vcd vapp stop vapp_name

Testing Done:
Added test_0025_stop_vapp to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/396)
<!-- Reviewable:end -->
