### PR TITLE
VP-2087,VP-2091,VP-2093,VP-2199

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -99,6 +99,26 @@ class VAppTest(BaseTestCase):
             vapp, args=['power-on', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0026_suspend_vapp(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['suspend', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0027_discard_suspended_state_vapp(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['discard-suspended-state', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0028_enter_maintenance_mode(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['enter-maintenance-mode', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0029_exit_maintenance_mode(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['exit-maintenance-mode', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0030_reset_vapp_network(self):
         """Reset a vapp network."""
         result = VAppTest._runner.invoke(
@@ -222,10 +242,9 @@ class VAppTest(BaseTestCase):
         VAppTest._logout(self)
 
     def _login(self):
-        org = VAppTest._config['vcd']['default_org_name']
-        user = Environment.get_username_for_role_in_test_org(
-            CommonRoles.ORGANIZATION_ADMINISTRATOR)
-        password = VAppTest._config['vcd']['default_org_user_password']
+        org = VAppTest._config['vcd']['sys_org_name']
+        user = self._config['vcd']['sys_admin_username']
+        password = VAppTest._config['vcd']['sys_admin_pass']
         login_args = [
             VAppTest._config['vcd']['host'], org, user, "-i", "-w",
             "--password={0}".format(password)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -57,6 +57,7 @@ class VAppTest(BaseTestCase):
 
         VAppTest._runner = CliRunner()
         default_org = VAppTest._config['vcd']['default_org_name']
+        VAppTest._default_org = default_org
         VAppTest._login(self)
         VAppTest._runner.invoke(org, ['use', default_org])
         VAppTest._test_vdc = Environment.get_test_vdc(VAppTest._client)
@@ -110,6 +111,9 @@ class VAppTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_0028_enter_maintenance_mode(self):
+        VAppTest._logout(self)
+        VAppTest._sys_admin_login(self)
+        VAppTest._runner.invoke(org, ['use', VAppTest._default_org])
         result = VAppTest._runner.invoke(
             vapp, args=['enter-maintenance-mode', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
@@ -118,6 +122,9 @@ class VAppTest(BaseTestCase):
         result = VAppTest._runner.invoke(
             vapp, args=['exit-maintenance-mode', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
+        VAppTest._logout(self)
+        VAppTest._login(self)
+        VAppTest._runner.invoke(org, ['use', VAppTest._default_org])
 
     def test_0030_reset_vapp_network(self):
         """Reset a vapp network."""
@@ -242,6 +249,19 @@ class VAppTest(BaseTestCase):
         VAppTest._logout(self)
 
     def _login(self):
+        org = VAppTest._config['vcd']['default_org_name']
+        user = Environment.get_username_for_role_in_test_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        password = VAppTest._config['vcd']['default_org_user_password']
+        login_args = [
+            VAppTest._config['vcd']['host'], org, user, "-i", "-w",
+            "--password={0}".format(password)
+        ]
+        result = VAppTest._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _sys_admin_login(self):
         org = VAppTest._config['vcd']['sys_org_name']
         user = self._config['vcd']['sys_admin_username']
         password = VAppTest._config['vcd']['sys_admin_pass']

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -211,7 +211,7 @@ def vapp(ctx):
 
 \b
         vcd vapp enter-maintenance-mode vapp1
-            Enter maintenance mode a vapp.
+            Place a vApp in Maintenance Mode.
 
 \b
         vcd vapp exit-maintenance-mode vapp1
@@ -694,7 +694,7 @@ def undeploy(ctx, name, vm_names, action):
 
 @vapp.command('stop', short_help='stop a vApp')
 @click.pass_context
-@click.argument('vapp_name', required=True, metavar='<vapp-name>')
+@click.argument('vapp_name', required=True, metavar='<vapp_name>')
 def stop_vapp(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)
@@ -764,7 +764,7 @@ def shutdown(ctx, name, vm_names):
 
 @vapp.command('suspend', short_help='suspend a vApp')
 @click.pass_context
-@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+@click.argument('vapp_name', required=True, metavar='<vapp_name>')
 def suspend_vapp(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)
@@ -778,7 +778,7 @@ def suspend_vapp(ctx, vapp_name):
 @vapp.command(
     'discard-suspended-state', short_help='discard suspended state of vApp')
 @click.pass_context
-@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+@click.argument('vapp_name', required=True, metavar='<vapp_name>')
 def discard_suspended_state_vapp(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)
@@ -790,9 +790,9 @@ def discard_suspended_state_vapp(ctx, vapp_name):
 
 
 @vapp.command(
-    'enter-maintenance-mode', short_help='enter maintenance mode a vApp')
+    'enter-maintenance-mode', short_help='Place a vApp in Maintenance Mode')
 @click.pass_context
-@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+@click.argument('vapp_name', required=True, metavar='<vapp_name>')
 def enter_maintenance_mode(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)
@@ -806,7 +806,7 @@ def enter_maintenance_mode(ctx, vapp_name):
 @vapp.command(
     'exit-maintenance-mode', short_help='exit maintenance mode a vApp')
 @click.pass_context
-@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+@click.argument('vapp_name', required=True, metavar='<vapp_name>')
 def exit_maintenance_mode(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -200,6 +200,22 @@ def vapp(ctx):
 \b
         vdc vapp disconnect vapp1 org-vdc-network1
             Disconnects the network org-vdc-network1 from vapp1.
+
+\b
+        vcd vapp suspend vapp1
+            Suspend a vapp.
+
+\b
+        vcd vapp discard-suspended-state vapp1
+            Discard suspended state of vapp.
+
+\b
+        vcd vapp enter-maintenance-mode vapp1
+            Enter maintenance mode a vapp.
+
+\b
+        vcd vapp exit-maintenance-mode vapp1
+            Exit maintenance mode a vapp.
     """
     pass
 
@@ -678,15 +694,11 @@ def undeploy(ctx, name, vm_names, action):
 
 @vapp.command('stop', short_help='stop a vApp')
 @click.pass_context
-@click.argument('name', required=True)
-def stopVapp(ctx, name):
+@click.argument('vapp_name', required=True, metavar='<vapp-name>')
+def stop_vapp(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        vdc_href = ctx.obj['profiles'].get('vdc_href')
-        vdc = VDC(client, href=vdc_href)
-        vapp_resource = vdc.get_vapp(name)
-        vapp = VApp(client, resource=vapp_resource)
+        vapp = get_vapp(ctx, vapp_name)
         task = vapp.undeploy()
         stdout(task, ctx)
     except Exception as e:
@@ -746,6 +758,61 @@ def shutdown(ctx, name, vm_names):
                 vm.reload()
                 task = vm.shutdown()
                 stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('suspend', short_help='suspend a vApp')
+@click.pass_context
+@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+def suspend_vapp(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.suspend_vapp()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command(
+    'discard-suspended-state', short_help='discard suspended state of vApp')
+@click.pass_context
+@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+def discard_suspended_state_vapp(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.discard_suspended_state_vapp()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command(
+    'enter-maintenance-mode', short_help='enter maintenance mode a vApp')
+@click.pass_context
+@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+def enter_maintenance_mode(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        vapp.enter_maintenance_mode()
+        stdout('Entered maintenance mode successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command(
+    'exit-maintenance-mode', short_help='exit maintenance mode a vApp')
+@click.pass_context
+@click.argument('vapp-name', required=True, metavar='<vapp-name>')
+def exit_maintenance_mode(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        vapp.exit_maintenance_mode()
+        stdout('exited maintenance mode successfully', ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP-2087:[VcdCLI]Discard suspended state.
VP-2091:[VcdCLI] Enter maintenance mode.
VP-2093:VcdCLI] Exit maintenance mode.
VP-2199:[VcdCLI]suspend vapp.

Adding  commands to suspend , discard suspended state,  enter maintenance mode, exit maintenance mode a vapp.

To suspend a vapp, following command can be used:
vcd vapp suspend vapp_name

To discard suspended state of vapp, following command can be used:
vcd vapp exit-maintenance-mode vapp_name

To enter maintenance mode a vapp, following command can be used:
vcd vapp enter-maintenance-mode vapp_name

To exit maintenance mode a vapp, following command can be used:
vcd vapp exit-maintenance-mode vapp_name

Testing Done:
Added test_0026_suspend_vapp,  test_0027_discard_suspended_state_vapp, test_0028_enter_maintenance_mode, test_0029_exit_maintenance_mode to vapp_tests.py. 

All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/398)
<!-- Reviewable:end -->
