### PR TITLE
VP-2099 : [VcdCLI] Download vapp

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from uuid import uuid1
 from click.testing import CliRunner
 
@@ -48,6 +50,7 @@ class VAppTest(BaseTestCase):
     _new_vapp_network_dns2 = '8.8.8.11'
     _new_vapp_network_dns_suffix = 'example1.com'
     _description = 'capturing vapp in catalog'
+    _ova_file_name = 'test.ova'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -258,11 +261,17 @@ class VAppTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
         result = VAppTest._runner.invoke(
             vapp,
-            args=['download', VAppTest._test_vapp_name, 'test.ova', '-o'])
+            args=[
+                'download', VAppTest._test_vapp_name, VAppTest._ova_file_name,
+                '-o'
+            ])
         self.assertEqual(0, result.exit_code)
         result = VAppTest._runner.invoke(
             vapp, args=['deploy', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
+
+        # Remove downloaded vapp file
+        os.remove(VAppTest._ova_file_name)
 
     def test_0098_tearDown(self):
         """Delete vApp and logout from the session."""

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -252,6 +252,18 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0060_download_ova(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['stop', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=['download', VAppTest._test_vapp_name, 'test.ova', '-o'])
+        self.assertEqual(0, result.exit_code)
+        result = VAppTest._runner.invoke(
+            vapp, args=['deploy', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_tearDown(self):
         """Delete vApp and logout from the session."""
         result_delete = VAppTest._runner.invoke(

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -177,7 +177,7 @@ def vapp(ctx):
             Capture a vApp as a template in a catalog.
 
 \b
-        vcd vapp download vapp1
+        vcd vapp download vapp1 file.ova
             Download a vapp.
 
 \b
@@ -829,8 +829,7 @@ def exit_maintenance_mode(ctx, vapp_name):
     'file_name',
     type=click.Path(exists=False),
     metavar='[file-name]',
-    default=None,
-    required=False)
+    required=True)
 @click.option(
     '-o',
     '--overwrite',


### PR DESCRIPTION
VP-2099 : [VcdCLI] Download vapp.

Adding a command to download a vapp.

To download a vapp, following command can be used:
vcd vapp download vapp_name

Testing Done:
Added test_0060_download_ova to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/401)
<!-- Reviewable:end -->
