### PR TITLE
VP-2095 : [VcdCLI] Upgrade Virtual Hardware version a vapp

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -273,6 +273,19 @@ class VAppTest(BaseTestCase):
         # Remove downloaded vapp file
         os.remove(VAppTest._ova_file_name)
 
+    def test_0070_upgrade_virtual_hardware(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['stop', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+        result = VAppTest._runner.invoke(
+            vapp, args=['upgrade-virtual-hardware', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+        result = VAppTest._runner.invoke(
+            vapp, args=['deploy', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0098_tearDown(self):
         """Delete vApp and logout from the session."""
         result_delete = VAppTest._runner.invoke(

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -221,6 +221,10 @@ def vapp(ctx):
 \b
         vcd vapp exit-maintenance-mode vapp1
             Exit maintenance mode a vapp.
+
+\b
+        vcd vapp upgrade-virtual-hardware vapp1
+            Upgrade virtual hardware of vapp.
     """
     pass
 
@@ -818,6 +822,22 @@ def exit_maintenance_mode(ctx, vapp_name):
         vapp = get_vapp(ctx, vapp_name)
         vapp.exit_maintenance_mode()
         stdout('exited maintenance mode successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command(
+    'upgrade-virtual-hardware',
+    short_help='upgrade virtual hardware of a vApp')
+@click.pass_context
+@click.argument('vapp_name', required=True, metavar='<vapp_name>')
+def upgrade_virtual_hardware(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        no_of_vm_upgraded = vapp.upgrade_virtual_hardware()
+        result = {'No of vm upgraded': no_of_vm_upgraded}
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP-2095 : [VcdCLI] Upgrade Virtual Hardware version a vapp

Adding a command to upgrade virtual hardware of vapp.

To  to upgrade virtual hardware , following command can be used:
vcd vapp  upgrade-virtual-hardware vapp_name

Testing Done:
Added test_0070_upgrade_virtual_hardware to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/402)
<!-- Reviewable:end -->
