### PR TITLE
Added filter for 'vcd vapp list' command

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -222,6 +222,16 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0040_list_available_vapps(self):
+        """List available vapps.
+        Invoke the command 'vapp list' in
+        """
+        result = self._runner.invoke(vapp, args=['list'])
+        self.assertEqual(0, result.exit_code)
+
+        result = self._runner.invoke(vapp, args=['list', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0045_delete_vapp_network(self):
         """Delete a vapp network."""
         result = VAppTest._runner.invoke(

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -35,6 +35,7 @@ class VAppTest(BaseTestCase):
     Be aware that this test will delete existing vcd-cli sessions.
     """
     _test_vapp_name = 'test_vApp_' + str(uuid1())
+    _test_ownername = 'org_admin'
 
     _vapp_network_name = 'vapp_network_' + str(uuid1())
     _vapp_network_description = 'Test vApp network'
@@ -90,6 +91,22 @@ class VAppTest(BaseTestCase):
                 VAppTest._vapp_network_dns_suffix, '--ip-range',
                 VAppTest._vapp_network_ip_range
             ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0011_list_available_vapps(self):
+        """List available vapps.
+        Invoke the command 'vapp list' in
+        """
+        result = self._runner.invoke(vapp, args=['list'])
+        self.assertEqual(0, result.exit_code)
+
+        result = self._runner.invoke(vapp, args=['list', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+        result = self._runner.invoke(vapp, args=['list', '--filter', 'ownerName==' + VAppTest._test_ownername])
+        self.assertEqual(0, result.exit_code)
+
+        result = self._runner.invoke(vapp, args=['list', '--filter', 'name==' + VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
     def test_0020_poweron_vapp(self):
@@ -220,16 +237,6 @@ class VAppTest(BaseTestCase):
                 'network', 'list-allocated-ip', VAppTest._test_vapp_name,
                 VAppTest._vapp_network_name
             ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0040_list_available_vapps(self):
-        """List available vapps.
-        Invoke the command 'vapp list' in
-        """
-        result = self._runner.invoke(vapp, args=['list'])
-        self.assertEqual(0, result.exit_code)
-
-        result = self._runner.invoke(vapp, args=['list', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
     def test_0045_delete_vapp_network(self):

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -314,52 +314,6 @@ def detach(ctx, vapp_name, vm_name, disk_name):
     except Exception as e:
         stderr(e, ctx)
 
-"""
-@vapp.command('list', short_help='list vApps')
-@click.pass_context
-@click.argument('name', metavar='[name]', required=False)
-def list_vapps(ctx, name):
-    try:
-        restore_session(ctx, vdc_required=True)
-        client = ctx.obj['client']
-        result = []
-        if name is None:
-            if is_sysadmin(ctx):
-                resource_type = ResourceType.ADMIN_VAPP.value
-            else:
-                resource_type = ResourceType.VAPP.value
-            name_filter = None
-            attributes = None
-        else:
-            if is_sysadmin(ctx):
-                resource_type = ResourceType.ADMIN_VM.value
-            else:
-                resource_type = ResourceType.VM.value
-            name_filter = ('containerName', name)
-            attributes = [
-                'name', 'containerName', 'ipAddress', 'status', 'memoryMB',
-                'numberOfCpus'
-            ]
-        q = client.get_typed_query(
-            resource_type,
-            query_result_format=QueryResultFormat.ID_RECORDS,
-            equality_filter=name_filter)
-        records = list(q.execute())
-        if len(records) == 0:
-            if name is None:
-                result = 'No vApps were found.'
-            else:
-                result = 'No vms were found.'
-        else:
-            for r in records:
-                result.append(
-                    to_dict(
-                        r, resource_type=resource_type, attributes=attributes))
-        stdout(result, ctx, show_id=False)
-    except Exception as e:
-        stderr(e, ctx)
-"""
-
 
 @vapp.command('list', short_help='list vApps')
 @click.pass_context

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -68,13 +68,10 @@ def vapp(ctx):
 \b
         vcd vapp list vapp1
             Get list of VMs in vApp 'vapp1'.
+
 \b
         vcd vapp list --filter name==vapp1
             Get list of vApp with name vapp1.
-
-\b
-        vcd vapp list --filter status==POWERED_ON
-            Get list of vApp with VM status POWERED_ON.
 
 \b
         vcd vapp list --filter ownerName==user1
@@ -321,7 +318,7 @@ def detach(ctx, vapp_name, vm_name, disk_name):
 @click.option(
     '--filter',
     'filter',
-    metavar='<ownerName==system*>',
+    metavar='<filter>',
     help='filter for vapp')
 def list_vapps(ctx, name, filter):
     try:


### PR DESCRIPTION
**Added filter for " vcd vapp list" command**

With this change we have added filter in list_vapps() method as with exiting method the "vcd vapp list" only having option to provide vapp name as argument but the command having no filter to get list of vApp based on vApp ownerName, numberOfVMs, status etc., 


**Testing Done :** 
-------------------------------------------------------------

Tested the filter with below options : 

vcd login cassini.eng.vmware.com system administrator -i -w
vcd org use Development
vcd vapp list
vcd vapp list --filter ownerName==pgorlewar:
vcd vapp list --filter numberOfVMs==7
vcd vapp list --filter name==Testbed-Pooja
vcd vapp list --filter vdcName==DevelopmentOrgVdc
vcd vapp list --filter status==POWERED_ON

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/403)
<!-- Reviewable:end -->
