### PR TITLE
VP-2062: Reboot the VM

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -86,6 +86,12 @@ class VmTest(BaseTestCase):
             vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0032_reboot(self):
+        """Reboot the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['reboot', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0040_power_off(self):
         """Power off the VM."""
         result = VmTest._runner.invoke(

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -83,6 +83,10 @@ def vm(ctx):
             Power off the VM.
 
 \b
+        vcd vm reboot vapp1 vm1
+            reboot the VM.
+
+\b
         vcd vm suspend vapp1 vm1
             Suspend the VM.
 
@@ -152,7 +156,6 @@ def info(ctx, vapp_name, vm_name):
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
-
 
 @vm.command('update', short_help='Update the VM properties and configurations')
 @click.pass_context
@@ -323,6 +326,18 @@ def power_on(ctx, vapp_name, vm_name):
     except Exception as e:
         stderr(e, ctx)
 
+@vm.command('reboot', short_help='reboot a VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def reboot(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.reboot()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
 
 @vm.command('suspend', short_help='suspend a VM')
 @click.pass_context

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -84,7 +84,7 @@ def vm(ctx):
 
 \b
         vcd vm reboot vapp1 vm1
-            reboot the VM.
+            Reboot the VM.
 
 \b
         vcd vm suspend vapp1 vm1


### PR DESCRIPTION
VP-2062: Reboot the VM

This CLN contains functionality of reboot VM and corresponding test
case. It can be called as :

vcd vm reboot vapp1 vm1

Testing Done: Test class vapp_tests.py contains test method
test_0032_reboot and it executes successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/409)
<!-- Reviewable:end -->
