### PR TITLE
VP-2061 : [VcDCLI] shutdown VM

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -92,6 +92,15 @@ class VmTest(BaseTestCase):
             vm, args=['reboot', VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0034_shutdown(self):
+        """Shutdown the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['shutdown', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # Again power on VM for further test cases.
+        result = VmTest._runner.invoke(
+            vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
+
     def test_0040_power_off(self):
         """Power off the VM."""
         result = VmTest._runner.invoke(

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -86,6 +86,12 @@ class VmTest(BaseTestCase):
             vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0032_reboot(self):
+        """Reboot the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['reboot', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0040_power_off(self):
         """Power off the VM."""
         result = VmTest._runner.invoke(

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -83,6 +83,10 @@ def vm(ctx):
             Power off the VM.
 
 \b
+        vcd vm reboot vapp1 vm1
+            reboot the VM.
+
+\b
         vcd vm suspend vapp1 vm1
             Suspend the VM.
 
@@ -152,7 +156,6 @@ def info(ctx, vapp_name, vm_name):
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
-
 
 @vm.command('update', short_help='Update the VM properties and configurations')
 @click.pass_context
@@ -323,6 +326,18 @@ def power_on(ctx, vapp_name, vm_name):
     except Exception as e:
         stderr(e, ctx)
 
+@vm.command('reboot', short_help='reboot a VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def reboot(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.reboot()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
 
 @vm.command('suspend', short_help='suspend a VM')
 @click.pass_context

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -87,6 +87,10 @@ def vm(ctx):
             Reboot the VM.
 
 \b
+        vcd vm shutdown vapp1 vm1
+            Shutdown the VM.
+
+\b
         vcd vm suspend vapp1 vm1
             Suspend the VM.
 
@@ -335,6 +339,19 @@ def reboot(ctx, vapp_name, vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.reboot()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('shutdown', short_help='shutdown a VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def shutdown(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.shutdown()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -84,7 +84,7 @@ def vm(ctx):
 
 \b
         vcd vm reboot vapp1 vm1
-            reboot the VM.
+            Reboot the VM.
 
 \b
         vcd vm suspend vapp1 vm1


### PR DESCRIPTION
VP-2061 : [VcDCLI] shutdown VM
    
This CLN contains shutdown VM functionality and corresponding test case.
It can be called as

vcd vm shutdown vapp1 vm1
    
Testing Done:
Test method test_0034_shutdown() is added in class vm_tests.py and it is
executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/410)
<!-- Reviewable:end -->
