### PR TITLE
VP-2101 : [VcdCLI] Copy to vapp

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -309,7 +309,7 @@ class VAppTest(BaseTestCase):
         result = VAppTest._runner.invoke(
             vapp,
             args=[
-                'copy-to', VAppTest._test_vapp_name, '-n',
+                'copy', VAppTest._test_vapp_name, '-n',
                 VAppTest._vapp_copy_name, '-d', VAppTest._copy_description
             ])
         self.assertEqual(0, result.exit_code)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -52,6 +52,8 @@ class VAppTest(BaseTestCase):
     _new_vapp_network_dns_suffix = 'example1.com'
     _description = 'capturing vapp in catalog'
     _ova_file_name = 'test.ova'
+    _vapp_copy_name = 'customized_vApp_copy_' + str(uuid1())
+    _copy_description = 'Copying a vapp'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -302,6 +304,19 @@ class VAppTest(BaseTestCase):
         result = VAppTest._runner.invoke(
             vapp, args=['deploy', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
+
+    def test_0080_copy_to(self):
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'copy-to', VAppTest._test_vapp_name, '-n',
+                VAppTest._vapp_copy_name, '-d', VAppTest._copy_description
+            ])
+        self.assertEqual(0, result.exit_code)
+        result_delete = VAppTest._runner.invoke(
+            vapp,
+            args=['delete', VAppTest._vapp_copy_name, '--yes', '--force'])
+        self.assertEqual(0, result_delete.exit_code)
 
     def test_0098_tearDown(self):
         """Delete vApp and logout from the session."""

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -15,6 +15,8 @@
 import os
 import click
 import re
+from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import get_links
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.org import Org
@@ -242,6 +244,10 @@ def vapp(ctx):
 \b
         vcd vapp upgrade-virtual-hardware vapp1
             Upgrade virtual hardware of vapp.
+
+\b
+        vcd vapp copy-to vapp1 -n new_vapp_name -v target_vdc -d description
+            Copy a vapp to target vdc.
     """
     pass
 
@@ -1326,6 +1332,47 @@ def update_vapp(ctx, vapp_name, name, description):
         vapp = get_vapp(ctx, vapp_name)
 
         task = vapp.edit_name_and_description(name, description)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('copy-to', short_help='copy a vapp')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp_name>')
+@click.option(
+    '-n',
+    '--name',
+    'vapp_new_name',
+    required=True,
+    metavar='<vapp_new_name>',
+    help='name of copy vapp')
+@click.option(
+    '-v',
+    '--vdc',
+    'vdc',
+    default=None,
+    metavar='<vdc>',
+    help='virtual datacenter name where need to copy vapp')
+@click.option(
+    '-d',
+    '--description',
+    'description',
+    metavar='<description>',
+    help='description of copy vapp')
+def copy_to(ctx, vapp_name, vapp_new_name, vdc, description):
+    try:
+        restore_session(ctx, vdc_required=True)
+        client = ctx.obj['client']
+        logged_in_org = client.get_org()
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        if vdc is not None:
+            for v in get_links(logged_in_org, media_type=EntityType.VDC.value):
+                if vdc == v.name:
+                    vdc_href = v.href
+                    break
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.copy_to(vdc_href, vapp_new_name, description)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -246,7 +246,7 @@ def vapp(ctx):
             Upgrade virtual hardware of vapp.
 
 \b
-        vcd vapp copy-to vapp1 -n new_vapp_name -v target_vdc -d description
+        vcd vapp copy vapp1 -n new_vapp_name -v target_vdc -d description
             Copy a vapp to target vdc.
     """
     pass
@@ -1337,7 +1337,7 @@ def update_vapp(ctx, vapp_name, name, description):
         stderr(e, ctx)
 
 
-@vapp.command('copy-to', short_help='copy a vapp')
+@vapp.command('copy', short_help='copy a vapp')
 @click.pass_context
 @click.argument('vapp_name', metavar='<vapp_name>')
 @click.option(


### PR DESCRIPTION
VP-2101 : [VcdCLI] Copy to vapp.

This CLN contains copy to  vapp functionality and corresponding test case.
It can be called as

vcd vapp copy-to vapp1 -n new_vapp_name -v target_vdc_name -d description

Testing Done:
Test method test_0080_copy_to() is added in class vapp_tests.py and it is
executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/411)
<!-- Reviewable:end -->
