### PR TITLE
VP-2053: [VcDCLI] create snapshots

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -110,13 +110,6 @@ class VmTest(BaseTestCase):
         result = VmTest._runner.invoke(
             vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
 
-    def test_0042_create_snapshot(self):
-        """Create snapshot of VM"""
-        result = VmTest._runner.invoke(
-            vm, args=['create-snapshot', VAppConstants.name,
-                      VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
     def test_0050_reset(self):
         """Reset the VM."""
         result = VmTest._runner.invoke(
@@ -188,6 +181,13 @@ class VmTest(BaseTestCase):
                 'delete-nic', VAppConstants.name, VAppConstants.vm1_name,
                 '--index', 0
             ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0140_create_snapshot(self):
+        """Create snapshot of VM"""
+        result = VmTest._runner.invoke(
+            vm, args=['create-snapshot', VAppConstants.name,
+                      VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -110,6 +110,13 @@ class VmTest(BaseTestCase):
         result = VmTest._runner.invoke(
             vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
 
+    def test_0042_create_snapshot(self):
+        """Create snapshot of VM"""
+        result = VmTest._runner.invoke(
+            vm, args=['create-snapshot', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0050_reset(self):
         """Reset the VM."""
         result = VmTest._runner.invoke(

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -119,6 +119,10 @@ def vm(ctx):
 \b
         vcd vm consolidate vapp1 vm1
             Consolidate the VM.
+
+\b
+        vcd vm create-snapshot vapp1 vm1
+            Create snapshot of the VM.
     """
     pass
 
@@ -457,6 +461,42 @@ def consolidate(ctx, vapp_name, vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.consolidate()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('create-snapshot', short_help='create snapshot of a VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'is_memory',
+    '--is-include-memory',
+    required=False,
+    metavar='<is_memory>',
+    type=click.BOOL,
+    help='Include the virtual machine memory')
+@click.option(
+    'quiesce',
+    '--quiesce',
+    required=False,
+    metavar='<quiesce>',
+    type=click.BOOL,
+    help='file system of the vm should be quiesced')
+@click.option(
+    'name',
+    '--name',
+    required=False,
+    metavar='<name>',
+    type=click.STRING,
+    help='snapshot name')
+def create_snapshot(ctx, vapp_name, vm_name, is_memory, quiesce, name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.snapshot_create(memory = is_memory,
+                                  quiesce = quiesce,
+                                  name = name)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2053: [VcDCLI] create snapshots.

This CLN contains VM functionality to create snapshot of a VM. It also
has reltaed test case in file vm_tests.py.
It can be called as

vcd vm create-snapshot vapp1 vm1

Testing Done: Test case test_0140_create_snapshot is added in
vm_tests.py file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/412)
<!-- Reviewable:end -->
