### PR TITLE
VP-2055: [VcDCLI] remove snapshots to current

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -190,6 +190,13 @@ class VmTest(BaseTestCase):
                       VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0150_revert_to_snapshot(self):
+        """Revert VM to current snapshot."""
+        result = VmTest._runner.invoke(
+            vm, args=['revert-to-snapshot', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """logout from the session."""
         VmTest._logout(self)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -123,6 +123,10 @@ def vm(ctx):
 \b
         vcd vm create-snapshot vapp1 vm1
             Create snapshot of the VM.
+
+\b
+        vcd vm revert-to-snapshot vapp1 vm1
+            Revert VM to current snapshot.
     """
     pass
 
@@ -500,3 +504,17 @@ def create_snapshot(ctx, vapp_name, vm_name, is_memory, quiesce, name):
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
+@vm.command('revert-to-snapshot', short_help='revert VM to current snapshot')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def revert_to_snapshot(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.snapshot_revert_to_current()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+


### PR DESCRIPTION
VP-2055: [VcDCLI] remove snapshots to current

This CLN contains functionality to revert snapshots to current and it's
test case is added in test class vm_tests.py.

It can be called as
vcd vm revert-to-snapshot vapp1 vm1

Testing Done:
Test method test_0150_revert_to_snapshot is added in vm_tests.py which
is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/413)
<!-- Reviewable:end -->
