### PR TITLE
VP-2036: [Vcd-CLI]Copy to VM from one vapp to another

### DIFF
--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -127,6 +127,10 @@ def vm(ctx):
 \b
         vcd vm revert-to-snapshot vapp1 vm1
             Revert VM to current snapshot.
+
+\b
+        vcd vm copy vapp1 vm1 vapp2 vm2
+            Copy VM from one vapp to another vapp.
     """
     pass
 
@@ -518,3 +522,29 @@ def revert_to_snapshot(ctx, vapp_name, vm_name):
     except Exception as e:
         stderr(e, ctx)
 
+@vm.command('copy', short_help='copy vm from one vapp to another vapp')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'target_vapp_name',
+    '--target-vapp-name',
+    required=True,
+    metavar='<target-vapp>',
+    help='target vapp name')
+@click.option(
+    'target_vm_name',
+    '--target-vm-name',
+    required=True,
+    metavar='<target-vm>',
+    help='target vm name')
+def copy_to(ctx, vapp_name, vm_name, target_vapp_name, target_vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.copy_to(source_vapp_name=vapp_name,
+                          target_vapp_name=target_vapp_name,
+                          target_vm_name=target_vm_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)


### PR DESCRIPTION
[Vcd-CLI]Copy To VM from one vapp to another

This CLN contains functionality and test case for copying VM from one
vapp to another. It can be involked in vcd-cli as:

vcd vm copy vapp1 vm1 vapp2 vm2

Testing Done: Test method test_0025_copy_to() is added to vm_tests.py
class. It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/414)
<!-- Reviewable:end -->
