### PR TITLE
VP-2040: [Vcd-CLI] Delete VM

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -106,6 +106,13 @@ class VmTest(BaseTestCase):
                       '--target-vm-name', VmTest._target_vm_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0028_delete(self):
+        """Delete VM from empty vApp"""
+        result = VmTest._runner.invoke(
+            vm, args=['delete', VmTest._empty_vapp_name,
+                      VmTest._target_vm_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0030_power_on(self):
         """Power on the VM."""
         result = VmTest._runner.invoke(

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -131,6 +131,10 @@ def vm(ctx):
 \b
         vcd vm copy vapp1 vm1 vapp2 vm2
             Copy VM from one vapp to another vapp.
+
+\b
+        vcd vm delete vapp1 vm1
+            Delete VM.
     """
     pass
 
@@ -545,6 +549,19 @@ def copy_to(ctx, vapp_name, vm_name, target_vapp_name, target_vm_name):
         task = vm.copy_to(source_vapp_name=vapp_name,
                           target_vapp_name=target_vapp_name,
                           target_vm_name=target_vm_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('delete', short_help='delete VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def delete(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.delete()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2040: [Vcd-CLI] Delete VM

This CLN has delete VM functionality and corresponding test case
test_0028_delete. From cli, it can be called as :

vcd vm delete vapp1 vm1

Testing Done:
test_0028_delete method is added for testing delete VM and it is
executed successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/415)
<!-- Reviewable:end -->
