### PR TITLE
VP-2395 : Fix - click version issue of VCD-CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click >= 6.7
+click >= 7.0
 colorama >= 0.3.9
 keyring >= 10.6.0, <= 12.0.0
 # Pycryptodome 3.5.0 does not compile on Mac OS X.


### PR DESCRIPTION
VP-2395 : Fix - click version issue of VCD-CLI.

This CLN contains changes according to 
vcd-cli 21.1.0 have issue.
If this will run on click version of 6.7 or less then it will not work.
It will work perfectly with click version 7.0 because
code changes in https://jira.eng.vmware.com/browse/VP-2153 contain hidden attribute of click that was added in 7.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/416)
<!-- Reviewable:end -->
