### PR TITLE
VP-2107 : [VcdCLI] create snapshot vapp

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -381,6 +381,11 @@ class VAppTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
         VAppTest._runner.invoke(vdc, ['use', VAppTest._default_ovdc])
 
+    def test_0100_create_snapshot(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['create-snapshot', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete vApp and logout from the session."""
         result_delete = VAppTest._runner.invoke(

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -252,6 +252,10 @@ def vapp(ctx):
 \b
         vcd vapp move vapp1 -v target_vdc
             Move a vapp to target vdc.
+
+\b
+        vcd vapp create-snapshot vapp1
+            Create snapshot of the vapp.
     """
     pass
 
@@ -1408,6 +1412,35 @@ def move_to(ctx, vapp_name, vdc):
             stdout(task, ctx)
         else:
             stdout('Org vdc not found', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('create-snapshot', short_help='create snapshot of a vapp')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.option(
+    'is_memory',
+    '--is-include-memory',
+    default=False,
+    required=False,
+    metavar='<is_memory>',
+    type=click.BOOL,
+    help='Include the virtual machine memory')
+@click.option(
+    'quiesce',
+    '--quiesce',
+    default=False,
+    required=False,
+    metavar='<quiesce>',
+    type=click.BOOL,
+    help='file system of the vm should be quiesced')
+def create_snapshot(ctx, vapp_name, is_memory, quiesce):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.create_snapshot(memory=is_memory, quiesce=quiesce)
+        stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP-2107 : [VcdCLI] create snapshot vapp.

This CLN contains create snapshot of a vapp functionality and corresponding test case.  
It can be called as

vcd vapp create-snapshot vapp1  --is-include-memory True --quiesce True
Testing Done:  
Test method test_0100_create_snapshot() is added in class vapp_tests.py and it is  
executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/422)
<!-- Reviewable:end -->
