### PR TITLE
VP-2038: [Vcd-CLI] Move To VM from one VAPP to another vapp.

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -106,10 +106,21 @@ class VmTest(BaseTestCase):
                       '--target-vm-name', VmTest._target_vm_name])
         self.assertEqual(0, result.exit_code)
 
-    def test_0028_delete(self):
-        """Delete VM from empty vApp"""
+    def test_0026_move_to(self):
+        """Move VM from one vApp to another."""
+        test_vapp = VmTest._test_vapp
+        test_vapp_resource = test_vapp.get_resource()
+        VmTest._test_vapp_name = test_vapp_resource.get('name')
         result = VmTest._runner.invoke(
-            vm, args=['delete', VmTest._empty_vapp_name,
+            vm, args=['move', VAppConstants.name, VAppConstants.vm1_name,
+                      '--target-vapp-name', VmTest._test_vapp_name,
+                      '--target-vm-name', VmTest._target_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0028_delete(self):
+        """Delete VM from vApp"""
+        result = VmTest._runner.invoke(
+            vm, args=['delete', VmTest._test_vapp_name,
                       VmTest._target_vm_name])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -133,6 +133,10 @@ def vm(ctx):
             Copy VM from one vapp to another vapp.
 
 \b
+        vcd vm move vapp1 vm1 vapp2 vm2
+            Move VM from one vapp to another vapp.
+
+\b
         vcd vm delete vapp1 vm1
             Delete VM.
     """
@@ -547,6 +551,33 @@ def copy_to(ctx, vapp_name, vm_name, target_vapp_name, target_vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.copy_to(source_vapp_name=vapp_name,
+                          target_vapp_name=target_vapp_name,
+                          target_vm_name=target_vm_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('move', short_help='move VM from one vapp to another vapp')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'target_vapp_name',
+    '--target-vapp-name',
+    required=True,
+    metavar='<target-vapp>',
+    help='target vapp name')
+@click.option(
+    'target_vm_name',
+    '--target-vm-name',
+    required=True,
+    metavar='<target-vm>',
+    help='target vm name')
+def move_to(ctx, vapp_name, vm_name, target_vapp_name, target_vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.move_to(source_vapp_name=vapp_name,
                           target_vapp_name=target_vapp_name,
                           target_vm_name=target_vm_name)
         stdout(task, ctx)


### PR DESCRIPTION
VP-2038: [Vcd-CLI] Move To VM from one VAPP to another vapp.

This CLN contains functionality to move VM from one vapp to another. It
can be called as :

vcd vm move vapp1 vm1 vapp2 vm2

Testing Done:
Test case test_0026_move_to is added in vm_tests.py and it is executing
successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/423)
<!-- Reviewable:end -->
