### PR TITLE
VP-2109 and VP-2111

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -381,6 +381,11 @@ class VAppTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
         VAppTest._runner.invoke(vdc, ['use', VAppTest._default_ovdc])
 
+    def test_0100_create_snapshot(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['create-snapshot', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete vApp and logout from the session."""
         result_delete = VAppTest._runner.invoke(

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -388,18 +388,12 @@ class VAppTest(BaseTestCase):
 
     def test_0110_revert_to_snapshot(self):
         result = VAppTest._runner.invoke(
-            vapp, args=['create-snapshot', VAppTest._test_vapp_name])
-        self.assertEqual(0, result.exit_code)
-        result = VAppTest._runner.invoke(
             vapp, args=['revert-to-snapshot', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
-    def test_0120_snapshot_remove_all(self):
+    def test_0120_snapshot_remove(self):
         result = VAppTest._runner.invoke(
-            vapp, args=['create-snapshot', VAppTest._test_vapp_name])
-        self.assertEqual(0, result.exit_code)
-        result = VAppTest._runner.invoke(
-            vapp, args=['remove-all-snapshot', VAppTest._test_vapp_name])
+            vapp, args=['remove-snapshot', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -386,6 +386,22 @@ class VAppTest(BaseTestCase):
             vapp, args=['create-snapshot', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0110_revert_to_snapshot(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['create-snapshot', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+        result = VAppTest._runner.invoke(
+            vapp, args=['revert-to-snapshot', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0120_snapshot_remove_all(self):
+        result = VAppTest._runner.invoke(
+            vapp, args=['create-snapshot', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+        result = VAppTest._runner.invoke(
+            vapp, args=['remove-all-snapshot', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete vApp and logout from the session."""
         result_delete = VAppTest._runner.invoke(

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -252,6 +252,10 @@ def vapp(ctx):
 \b
         vcd vapp move vapp1 -v target_vdc
             Move a vapp to target vdc.
+
+\b
+        vcd vapp create-snapshot vapp1
+            Create snapshot of the vapp.
     """
     pass
 
@@ -1408,6 +1412,35 @@ def move_to(ctx, vapp_name, vdc):
             stdout(task, ctx)
         else:
             stdout('Org vdc not found', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('create-snapshot', short_help='create snapshot of a vapp')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.option(
+    'is_memory',
+    '--is-include-memory',
+    default=False,
+    required=False,
+    metavar='<is_memory>',
+    type=click.BOOL,
+    help='Include the virtual machine memory')
+@click.option(
+    'quiesce',
+    '--quiesce',
+    default=False,
+    required=False,
+    metavar='<quiesce>',
+    type=click.BOOL,
+    help='file system of the vm should be quiesced')
+def create_snapshot(ctx, vapp_name, is_memory, quiesce):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.create_snapshot(memory=is_memory, quiesce=quiesce)
+        stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -262,8 +262,8 @@ def vapp(ctx):
             Revert to to current snapshot of the vapp.
 
 \b
-        vcd vapp remove-all-snapshot vapp1
-            Remove all snapshot of the vapp.
+        vcd vapp remove-snapshot vapp1
+            Remove snapshot of the vapp.
     """
     pass
 
@@ -1467,14 +1467,14 @@ def revert_to_snapshot(ctx, vapp_name):
         stderr(e, ctx)
 
 
-@vapp.command('remove-all-snapshot', short_help='rmove all snapshot of vapp')
+@vapp.command('remove-snapshot', short_help='rmove snapshot of vapp')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
-def snapshot_remove_all(ctx, vapp_name):
+def snapshot_remove(ctx, vapp_name):
     try:
         restore_session(ctx, vdc_required=True)
         vapp = get_vapp(ctx, vapp_name)
-        task = vapp.snapshot_remove_all()
+        task = vapp.snapshot_remove()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -256,6 +256,14 @@ def vapp(ctx):
 \b
         vcd vapp create-snapshot vapp1
             Create snapshot of the vapp.
+
+\b
+        vcd vapp revert-to-snapshot vapp1
+            Revert to to current snapshot of the vapp.
+
+\b
+        vcd vapp remove-all-snapshot vapp1
+            Remove all snapshot of the vapp.
     """
     pass
 
@@ -1440,6 +1448,33 @@ def create_snapshot(ctx, vapp_name, is_memory, quiesce):
         restore_session(ctx, vdc_required=True)
         vapp = get_vapp(ctx, vapp_name)
         task = vapp.create_snapshot(memory=is_memory, quiesce=quiesce)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command(
+    'revert-to-snapshot', short_help='revert vapp to current snapshot')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+def revert_to_snapshot(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.snapshot_revert_to_current()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('remove-all-snapshot', short_help='rmove all snapshot of vapp')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+def snapshot_remove_all(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.snapshot_remove_all()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION


VP-2109 : [VcdCLI] Revert to snapshot of vapp
VP-2111 : [VcdCLI] Remove the snapshot of vapp

This CLN contains revert to snapshot and  remove all the snapshot of a vapp functionality and corresponding test case.  
It can be called as
vcd vapp revert-to-snapshot vapp1
vcd vapp remove-all-snapshot vapp1 

Testing Done:  
Test methods test_0110_revert_to_snapshot() and test_0120_snapshot_remove_all is added in class vapp_tests.py and it is  
executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/424)
<!-- Reviewable:end -->
