### PR TITLE
Add --network-quota to vdc create

### DIFF
--- a/vcd_cli/vdc.py
+++ b/vcd_cli/vdc.py
@@ -212,8 +212,15 @@ def use(ctx, name):
     metavar='<cpu-limit>',
     type=click.INT,
     help='Capacity limit relative to the value specified for Allocation.')
+@click.option(
+    '--network-quota',
+    required=False,
+    default=0,
+    metavar='<network-quota>',
+    type=click.INT,
+    help='Maximum number of network objects that can be deployed in this vdc.')
 def create(ctx, name, pvdc_name, network_pool_name, allocation_model, sp_name,
-           sp_limit, description, cpu_allocated, cpu_limit):
+           sp_limit, description, cpu_allocated, cpu_limit, network_quota):
     try:
         restore_session(ctx)
         client = ctx.obj['client']
@@ -235,6 +242,7 @@ def create(ctx, name, pvdc_name, network_pool_name, allocation_model, sp_name,
             cpu_allocated=cpu_allocated,
             cpu_limit=cpu_limit,
             storage_profiles=storage_profiles,
+            network_quota=network_quota,
             uses_fast_provisioning=True,
             is_thin_provision=True)
         stdout(vdc_resource.Tasks.Task[0], ctx)


### PR DESCRIPTION
Adds --network-quota integer option to the `vcd vdc create`
command, which sets the network_quota setting in the
underlying call to org.create_org_vdc - this is the Maximum
number of network objects that can be deployed in this vdc.

The default value is zero (like the underlying call), which
(unike all the similar settings) means that *no* network
objects can be created within the vdc.

Signed-off-by: Nigel Metheringham <nigel.metheringham@redcentricplc.com>

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name
