### PR TITLE
VP-2113 : [VcdCLI] List vApp Networks

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -257,6 +257,12 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0044_list_vapp_networks(self):
+        """List of vapp networks."""
+        result = VAppTest._runner.invoke(
+            vapp, args=['network', 'list', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0045_delete_vapp_network(self):
         """Delete a vapp network."""
         result = VAppTest._runner.invoke(

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -79,6 +79,10 @@ def network(ctx):
 \b
         vcd vapp network list-allocated-ip vapp1 vapp-network1
             List allocated ip
+
+\b
+        vcd vapp network list vapp1
+            List vapp networks
     """
     pass
 
@@ -305,6 +309,19 @@ def list_allocated_ip(ctx, vapp_name, network_name):
         restore_session(ctx, vdc_required=True)
         vapp = get_vapp(ctx, vapp_name)
         task = vapp.list_ip_allocations(network_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command('list', short_help='list vapp networks')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+def list_vapp_networks(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.get_vapp_network_list()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2113 : [VcdCLI] List vApp Networks.

This CLN contains list all vapp networks functionality and corresponding test case.  
It can be called as  
vcd vapp network list vapp1  

Testing Done:  
Test methods test_0044_list_vapp_networks is added in class vapp_tests.py and it is  
executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/429)
<!-- Reviewable:end -->
