### PR TITLE
VP-2064: [VcdCLI]List selected VM general properties

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -45,7 +45,7 @@ class VmTest(BaseTestCase):
     _empty_vapp_href = None
     _target_vm_name = 'target_vm'
     _idisk_name = 'SCSI'
-    _idisk_size = '5000'
+    _idisk_size = '5242880'
     _idisk_description = '5Mb SCSI disk'
 
     def test_0000_setup(self):
@@ -254,9 +254,39 @@ class VmTest(BaseTestCase):
         vdc = Environment.get_test_vdc(VmTest._client)
         idisk = vdc.get_disk(name=VmTest._idisk_name)
         result = VmTest._runner.invoke(
-            vm, args=['attach-disk', VAppConstants.name,
-                      VAppConstants.vm1_name,
-                      '--idisk-href', idisk.get('href')])
+            vm,
+            args=[
+                'attach-disk', VAppConstants.name, VAppConstants.vm1_name,
+                '--idisk-href',
+                idisk.get('href')
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0170_deploy_undeploy_vm(self):
+        # Undeploy VM
+        result = VmTest._runner.invoke(
+            vm, args=['undeploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        result = VmTest._runner.invoke(
+            vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0180_upgrade_virtual_hardware(self):
+        # Undeploy VM
+        result = VmTest._runner.invoke(
+            vm, args=['undeploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # Upgrade virtual hardware of VM.
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'upgrade-virtual-hardware', VAppConstants.name,
+                VAppConstants.vm1_name
+            ])
+        self.assertEqual(0, result.exit_code)
+        # Again deploy VM for further test cases.
+        result = VmTest._runner.invoke(
+            vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -289,6 +289,15 @@ class VmTest(BaseTestCase):
             vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0190_general_setting_detail(self):
+        # general setting details
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'general-setting', VAppConstants.name, VAppConstants.vm1_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -147,7 +147,7 @@ def vm(ctx):
 
 \b
         vcd vm deploy vapp1 vm1
-            Deploye a VM.
+            Deploy a VM.
 
 \b
         vcd vm undeploy vapp1 vm1

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -144,6 +144,19 @@ def vm(ctx):
         vcd vm attach-disk vapp1 vm1
                --idisk-href https://10.11.200.00/api/disk/76e53c34-1845-43ca-bd5a-759c0d537433
             Attach independent disk to VM.
+
+\b
+        vcd vm deploy vapp1 vm1
+            Deploye a VM.
+
+\b
+        vcd vm undeploy vapp1 vm1
+            Undeploy a VM.
+
+\b
+        vcd vm upgrade-virtual-hardware vapp1 vm1
+            Upgrade virtual hardware of VM.
+
     """
     pass
 
@@ -616,8 +629,50 @@ def attach_disk(ctx, vapp_name, vm_name, idisk_href):
     try:
         restore_session(ctx, vdc_required=True)
         vapp = _get_vapp(ctx, vapp_name)
-        task = vapp.attach_disk_to_vm(disk_href=idisk_href,
-                                      vm_name=vm_name)
+        task = vapp.attach_disk_to_vm(disk_href=idisk_href, vm_name=vm_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('deploy', short_help='deploy a VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def deploy(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.deploy()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('undeploy', short_help='undeploy a VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def undeploy(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.undeploy()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command(
+    'upgrade-virtual-hardware', short_help='upgrade virtual hardware of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def upgrade_virtual_hardware(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.upgrade_virtual_hardware()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -157,6 +157,10 @@ def vm(ctx):
         vcd vm upgrade-virtual-hardware vapp1 vm1
             Upgrade virtual hardware of VM.
 
+\b
+        vcd vm general-setting vapp1 vm1
+            Show general setting details of VM.
+
     """
     pass
 
@@ -673,6 +677,20 @@ def upgrade_virtual_hardware(ctx, vapp_name, vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.upgrade_virtual_hardware()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('general-setting', short_help='general setting detail of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def general_setting_detail(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.general_setting_detail()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2064: [VcdCLI]List selected VM general properties.

This CLN contains a command for show general setting of vm functionality and corresponding test case.
It can be called as
vcd vm general-setting vapp1 vm1


Testing Done:
Test methods test_0190_general_setting_detail is added in class vm_tests.py and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/433)
<!-- Reviewable:end -->
