### PR TITLE
VP-2595: Fix for Pypi issue: HTTPError: 400 Client Error: The descrip…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ from setuptools import setup
 setup(
     setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
     pbr=True,
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
VP-2595: Fix for Pypi issue: HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText

Fix for Pypi issue: HTTPError: 400 Client Error: The description failed
to render in the default format of reStructuredText

Testing Done: Generated Pypi dev build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/439)
<!-- Reviewable:end -->
