### PR TITLE
VP-2594 : [vcdcli] Show DNS detail of Vapp Network

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -268,6 +268,16 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0041_dns_info(self):
+        """DNS details of vapp network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'dns-info', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
     def test_0044_list_vapp_networks(self):
         """List of vapp networks."""
         result = VAppTest._runner.invoke(

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -257,6 +257,17 @@ class VAppTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0040_update_dns_of_vapp_network(self):
+        """Update DNS details of vapp network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'update-dns', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, '--dns-suffix',
+                VAppTest._vapp_network_dns_suffix
+            ])
+        self.assertEqual(0, result.exit_code)
+
     def test_0044_list_vapp_networks(self):
         """List of vapp networks."""
         result = VAppTest._runner.invoke(

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -77,6 +77,12 @@ def network(ctx):
             Add DNS detail to vApp network.
 
 \b
+        vdc vapp network update-dns vapp1 vapp-network1
+                --dns1 6.6.5.2 --dns2 6.6.5.10-6.6.5.18
+                --dns-suffix example.com
+            Update DNS detail of vApp network.
+
+\b
         vcd vapp network list-allocated-ip vapp1 vapp-network1
             List allocated ip
 
@@ -290,6 +296,40 @@ def update_ip_range(ctx, vapp_name, network_name, ip_range, new_ip_range):
     help='dns suffix')
 def add_dns_to_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
                             secondary_dns_ip, dns_suffix):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.update_dns_vapp_network(network_name, primary_dns_ip,
+                                            secondary_dns_ip, dns_suffix)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command('update-dns', short_help='update DNS detail of vapp network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.option(
+    '--dns1',
+    'primary_dns_ip',
+    default=None,
+    metavar='<ip>',
+    help='IP of the primary dns server')
+@click.option(
+    '--dns2',
+    'secondary_dns_ip',
+    default=None,
+    metavar='<ip>',
+    help='IP of the secondary dns server')
+@click.option(
+    '--dns-suffix',
+    'dns_suffix',
+    default=None,
+    metavar='<name>',
+    help='dns suffix')
+def update_dns_of_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
+                               secondary_dns_ip, dns_suffix):
     try:
         restore_session(ctx, vdc_required=True)
         vapp = get_vapp(ctx, vapp_name)

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -80,7 +80,7 @@ def network(ctx):
         vdc vapp network update-dns vapp1 vapp-network1
                 --dns1 6.6.5.2 --dns2 6.6.5.10-6.6.5.18
                 --dns-suffix example.com
-            Update DNS detail of vApp network.
+            Update DNS details of vApp network.
 
 \b
         vcd vapp network list-allocated-ip vapp1 vapp-network1
@@ -306,7 +306,7 @@ def add_dns_to_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
         stderr(e, ctx)
 
 
-@network.command('update-dns', short_help='update DNS detail of vapp network')
+@network.command('update-dns', short_help='update DNS details of vapp network')
 @click.pass_context
 @click.argument('vapp_name', metavar='<vapp-name>', required=True)
 @click.argument('network_name', metavar='<network-name>', required=True)
@@ -326,7 +326,7 @@ def add_dns_to_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
     '--dns-suffix',
     'dns_suffix',
     default=None,
-    metavar='<name>',
+    metavar='dns-suffix',
     help='dns suffix')
 def update_dns_of_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
                                secondary_dns_ip, dns_suffix):

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -83,6 +83,10 @@ def network(ctx):
             Update DNS details of vApp network.
 
 \b
+        vdc vapp network dns-info vapp1 vapp-network1
+            Show DNS details of vapp network
+
+\b
         vcd vapp network list-allocated-ip vapp1 vapp-network1
             List allocated ip
 
@@ -302,6 +306,20 @@ def add_dns_to_vapp_network(ctx, vapp_name, network_name, primary_dns_ip,
         task = vapp.update_dns_vapp_network(network_name, primary_dns_ip,
                                             secondary_dns_ip, dns_suffix)
         stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command('dns-info', short_help='show DNS details of vapp network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+def dns_info(ctx, vapp_name, network_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        result = vapp.dns_detail_of_vapp_network(network_name)
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP-2594 : [vcdcli] Show DNS detail of Vapp Network.

This CLN contains a command for DNS details of vapp network functionality and corresponding test case.
It can be called as
vdc vapp network dns-info vapp1 vapp-network1

Testing Done:
Test methods test_0041_dns_info is added in class vapp_tests.py and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/440)
<!-- Reviewable:end -->
