### PR TITLE
VP-2072: [VcdCLI] Reload from VC

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -321,6 +321,13 @@ class VmTest(BaseTestCase):
             ])
         self.assertEqual(0, result.exit_code)
 
+    def test_0220_reload_from_vc(self):
+        # Reload VM from VC
+        result = VmTest._runner.invoke(
+            vm, args=['reload-from-vc',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -171,6 +171,10 @@ def vm(ctx):
         vcd vm list-storage-profile vapp1 vm1
             List all storage profiles of VM.
 
+\b
+        vcd vm reload-from-vc vapp1 vm1
+            Reload VM from VC.
+
     """
     pass
 
@@ -744,6 +748,19 @@ def list_storage_profile(ctx, vapp_name, vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.list_storage_profile()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('reload-from-vc', short_help='reload VM from VC')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def reload_from_vc(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.reload_from_vc()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
[VcdCLI] Reload from VC

This CLN contains VM functionality to reload from VC. It can be called
from command line as:

vcd vm reload-from-vc vapp1 vm1

Testing Done: Test method test_0220_reload_from_vc is added in
vm_tests.py file and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/442)
<!-- Reviewable:end -->
