### PR TITLE
VP-2080: [VcdCLI] CUstomize at Next Power ON

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -335,6 +335,13 @@ class VmTest(BaseTestCase):
                       VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0240_customize_on_next_power_on(self):
+        # Customize on next power on
+        result = VmTest._runner.invoke(
+            vm, args=['customize-on-next-poweron',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -179,6 +179,10 @@ def vm(ctx):
         vcd vm check-compliance vapp1 vm1
             Check compliance of VM.
 
+\b
+        vcd vm customize-on-next-poweron vapp1 vm1
+            Customize on next power on of VM.
+
     """
     pass
 
@@ -778,6 +782,20 @@ def check_compliance(ctx, vapp_name, vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.check_compliance()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('customize-on-next-poweron', short_help='customize on '
+                                                    'next power on of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def customize_on_next_poweron(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.customize_at_next_power_on()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
[VcdCLI] CUstomize at Next Power ON

This CLN contains VM functionality customize at next power on. It can be
called from command line as :

vcd vm customize-on-next-poweron vapp1 vm1

Testing Done:
Test case is not included because corresponding API returns 204 no
content.Manual testing done. In VCD host, guest customization logs
tested manually while powering on the VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/444)
<!-- Reviewable:end -->
