### PR TITLE
VP-1400, VP-2599

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -59,6 +59,7 @@ class VAppTest(BaseTestCase):
     _vapp_copy_name = 'customized_vApp_copy_' + str(uuid1())
     _copy_description = 'Copying a vapp'
     _ovdc_name = 'test_vdc2_ ' + str(uuid1())
+    _ovdc_network_name = 'test-direct-vdc-network'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -125,6 +126,26 @@ class VAppTest(BaseTestCase):
         result = self._runner.invoke(
             vapp,
             args=['list', '--filter', 'name==' + VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0012_connect_vapp_network_to_ovdc_network(self):
+        """Connect vapp network to ovdc network."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'connect-ovdc', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name, VAppTest._ovdc_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0013_sync_syslog_settings(self):
+        """Sync syslog settings."""
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'sync-syslog-settings', VAppTest._test_vapp_name,
+                VAppTest._vapp_network_name
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_0020_poweron_vapp(self):

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -93,6 +93,14 @@ def network(ctx):
 \b
         vcd vapp network list vapp1
             List vapp networks
+
+\b
+        vdc vapp network connect-ovdc vapp1 vapp-network1 ovdc_network_name
+            Connect a vapp network to org vdc network
+
+\b
+        vdc vapp network sync-syslog-settings vapp1 vapp-network1
+            Sync syslog settings of vapp network
     """
     pass
 
@@ -381,6 +389,40 @@ def list_vapp_networks(ctx, vapp_name):
         vapp = get_vapp(ctx, vapp_name)
         task = vapp.get_vapp_network_list()
         stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command(
+    'sync-syslog-settings', short_help='sync syslog settings of vapp network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+def sync_syslog_settings(ctx, vapp_name, network_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        result = vapp.sync_syslog_settings(network_name)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command(
+    'connect-ovdc', short_help='connect a vapp network to org vdc network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<vapp-network-name>', required=True)
+@click.argument(
+    'ovdc_network_name', metavar='<ovdc-network-name>', required=True)
+def connect_vapp_network_to_ovdc_network(ctx, vapp_name, network_name,
+                                         ovdc_network_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        result = vapp.connect_vapp_network_to_ovdc_network(
+            network_name, ovdc_network_name)
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -95,11 +95,11 @@ def network(ctx):
             List vapp networks
 
 \b
-        vdc vapp network connect-ovdc vapp1 vapp-network1 ovdc_network_name
+        vcd vapp network connect-ovdc vapp1 vapp-network1 ovdc_network_name
             Connect a vapp network to org vdc network
 
 \b
-        vdc vapp network sync-syslog-settings vapp1 vapp-network1
+        vcd vapp network sync-syslog-settings vapp1 vapp-network1
             Sync syslog settings of vapp network
     """
     pass


### PR DESCRIPTION
VP-1400: [VcdCli] Synchronize syslog server settings
VP-2599 : [VcdCli] Make connection of vapp network

This CLN contains a command for Make connection of vapp network and Synchronize syslog server settings of vapp network functionality and corresponding test case.
It can be called as
 vcd vapp network connect-ovdc vapp1 vapp-network1 ovdc_network_name
 vcd vapp network sync-syslog-settings vapp1 vapp-network1


Testing Done:
Test methods test_0012_connect_vapp_network_to_ovdc_network() and test_0013_sync_syslog_settings are added in class vapp_tests.py and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/445)
<!-- Reviewable:end -->
