### PR TITLE
VP-1909, VP-1922, VP-2621

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -444,6 +444,42 @@ class VAppTest(BaseTestCase):
             vapp, args=['remove-snapshot', VAppTest._test_vapp_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0130_create_vapp_network_from_ovdc_network(self):
+        # Create Vapp Network
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'create-ovdc-network', VAppTest._test_vapp_name,
+                VAppTest._ovdc_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0131_enable_fence_mode(self):
+        # Create Vapp Network
+        result = VAppTest._runner.invoke(
+            vapp, args=['network', 'enable-fence', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+        # Delete a vapp network.
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'network', 'delete', VAppTest._test_vapp_name,
+                VAppTest._ovdc_network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0140_enable_download(self):
+        # Enable download of Vapp
+        result = VAppTest._runner.invoke(
+            vapp, args=['enable-download', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0150_disable_download(self):
+        # Disable download of Vapp
+        result = VAppTest._runner.invoke(
+            vapp, args=['disable-download', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete vApp and logout from the session."""
         result_delete = VAppTest._runner.invoke(

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -263,6 +263,14 @@ def vapp(ctx):
 \b
         vcd vapp remove-snapshot vapp1
             Remove snapshot of the vapp.
+
+\b
+        vcd vapp enable-download vapp1
+            Enable download of the vapp.
+
+\b
+        vcd vapp disable-download vapp1
+            Disable download of the vapp.
     """
     pass
 
@@ -1491,6 +1499,32 @@ def snapshot_remove(ctx, vapp_name):
         vapp = get_vapp(ctx, vapp_name)
         task = vapp.snapshot_remove()
         stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('enable-download', short_help='enable a vapp for download')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+def enable_download(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        vapp.enable_download()
+        stdout('Enabled download successfully', ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command('disable-download', short_help='disbale a vapp for download')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+def disable_download(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        vapp.disable_download()
+        stdout('Disabled download successfully', ctx)
     except Exception as e:
         stderr(e, ctx)
 

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -108,7 +108,7 @@ def network(ctx):
 
 \b
         vdc vapp network enable-fence vapp1
-            Enable fence mode of vApp.
+            Enable fence mode of vApp network.
     """
     pass
 
@@ -452,7 +452,8 @@ def create_vapp_network_from_ovdc_network(ctx, vapp_name, ovdc_network_name):
         stderr(e, ctx)
 
 
-@network.command('enable-fence', short_help='enable fence mode of vapp')
+@network.command(
+    'enable-fence', short_help='enable fence mode of vapp network')
 @click.pass_context
 @click.argument('vapp_name', metavar='<vapp-name>', required=True)
 def enable_fence_mode(ctx, vapp_name):

--- a/vcd_cli/vapp_network.py
+++ b/vcd_cli/vapp_network.py
@@ -101,6 +101,14 @@ def network(ctx):
 \b
         vcd vapp network sync-syslog-settings vapp1 vapp-network1
             Sync syslog settings of vapp network
+
+\b
+        vdc vapp network create-ovdc-network vapp1 ovdc-network1
+            Create a vApp network using org vdc network.
+
+\b
+        vdc vapp network enable-fence vapp1
+            Enable fence mode of vApp.
     """
     pass
 
@@ -422,6 +430,36 @@ def connect_vapp_network_to_ovdc_network(ctx, vapp_name, network_name,
         vapp = get_vapp(ctx, vapp_name)
         result = vapp.connect_vapp_network_to_ovdc_network(
             network_name, ovdc_network_name)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command(
+    'create-ovdc-network',
+    short_help='create a vapp network using org vdc network')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument(
+    'ovdc_network_name', metavar='<ovdc-network-name>', required=True)
+def create_vapp_network_from_ovdc_network(ctx, vapp_name, ovdc_network_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        result = vapp.create_vapp_network_from_ovdc_network(ovdc_network_name)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@network.command('enable-fence', short_help='enable fence mode of vapp')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+def enable_fence_mode(ctx, vapp_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        result = vapp.enable_fence_mode()
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-1909: [VCDCLI] Create vApp network using OrgvDC Network
VP-1922: [VCDCLI] Enable Fence vApp
VP-2621: [VcdCli] Enable disable download in vapp

This CLN contains a command for Create vApp network using OrgvDC Network, Enable Fence vApp and Enable disable download of vapp functionality and corresponding test case.
It can be called as
vcd vapp enable-download vapp1
vcd vapp disable-download vapp1
vdc vapp network create-ovdc-network vapp1 ovdc-network1
 vdc vapp network enable-fence vapp1

Testing Done:
Test methods test_0130_create_vapp_network_from_ovdc_network(), test_0131_enable_fence_mode(),  test_0140_enable_download() and test_0150_disable_download() are added in class vapp_tests.py and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/448)
<!-- Reviewable:end -->
