### PR TITLE
VP-2631, VP-2632

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -60,6 +60,7 @@ class VAppTest(BaseTestCase):
     _copy_description = 'Copying a vapp'
     _ovdc_name = 'test_vdc2_ ' + str(uuid1())
     _ovdc_network_name = 'test-direct-vdc-network'
+    _test_vm = 'testvm1'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -490,6 +491,18 @@ class VAppTest(BaseTestCase):
         # Show metadata of Vapp
         result = VAppTest._runner.invoke(
             vapp, args=['show-metadata', VAppTest._test_vapp_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0180_update_startup_section(self):
+        # Disable download of Vapp
+        result = VAppTest._runner.invoke(
+            vapp,
+            args=[
+                'update-startup-section', VAppTest._test_vapp_name,
+                VAppTest._test_vm, '--o', 2, '--start-action', 'powerOn',
+                '--start-delay', 2, '--stop-action', 'powerOff',
+                '--stop-delay', 4
+            ])
         self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -279,6 +279,10 @@ def vapp(ctx):
 \b
         vcd vapp show-metadata vapp1
             Show metadata of vapp.
+
+\b
+        vcd vapp update-startup-section vapp1 testvm1 --o 1 --start-action
+            powerOn --start-delay 4 --stop-action guestShutdown --stop-delay 3
     """
     pass
 
@@ -1563,6 +1567,62 @@ def show_metadata(ctx, vapp_name):
             for me in metadata.MetadataEntry:
                 result['metadata: %s' % me.Key.text] = me.TypedValue.Value.text
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vapp.command(
+    'update-startup-section',
+    short_help='update startup section of vapp for vm')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp_name>')
+@click.argument('vm_name', metavar='<vm_name>')
+@click.option(
+    '--o',
+    'order',
+    default=None,
+    metavar='<order>',
+    type=click.INT,
+    help='start order of vm')
+@click.option(
+    '--start-action',
+    'start_action',
+    default=None,
+    metavar='<start_action>',
+    help='start action on VM')
+@click.option(
+    '--start-delay',
+    'start_delay',
+    default=None,
+    metavar='<start_delay>',
+    type=click.INT,
+    help='start delay on VM')
+@click.option(
+    '--stop-action',
+    'stop_action',
+    default=None,
+    metavar='<stop_action>',
+    help='stop action on VM')
+@click.option(
+    '--stop-delay',
+    'stop_delay',
+    default=None,
+    metavar='<stop_delay>',
+    type=click.INT,
+    help='stop delay on VM')
+def update_startup_section(ctx, vapp_name, vm_name, order, start_action,
+                           start_delay, stop_action, stop_delay):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vapp = get_vapp(ctx, vapp_name)
+        task = vapp.update_startup_section(
+            vm_name=vm_name,
+            order=order,
+            start_action=start_action,
+            start_delay=start_delay,
+            stop_action=stop_action,
+            stop_delay=stop_delay)
+        stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
VP-2631: [VcdCli]Start time action in vapp
VP-2632: [VcdCli]Stop time action in vapp

This CLN contains a command for update startup section of vapp for given vm and corresponding test case.
It can be called as
vcd vapp update-startup-section vapp1 vm1  --o 2 --start-action powerOn
 --start-delay 2 --stop-action powerOff -stop-delay 4


Testing Done:
Test methods test_0180_update_startup_section() is added in class vapp_tests.py and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/451)
<!-- Reviewable:end -->
