### PR TITLE
VP-2649, VP-2660, VP-2663: List virtual hardware section

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -426,6 +426,14 @@ class VmTest(BaseTestCase):
                       VmTest._test_vapp_vmtools_vm_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0280_list_virtual_hardware_section(self):
+        #list virtual hardware section
+        result = VmTest._runner.invoke(
+            vm, args=['list-virtual-hardware-section',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -196,6 +196,10 @@ def vm(ctx):
         vcd vm poweron-force-recustomize vapp1 vm1
             Power on and force re-customize VM.
 
+\b
+        vcd vm list-virtual-hardware-section vapp1 vm1
+            List virtual hadware section of VM.
+
     """
     pass
 
@@ -855,5 +859,59 @@ def power_on_and_force_recustomize(ctx, vapp_name, vm_name):
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.power_on_and_force_recustomization()
         stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('list-virtual-hardware-section', short_help='list virtual hardware '
+                                                        'section of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'is_cpu',
+    '--is-include-cpu',
+    required=False,
+    metavar='<is_cpu>',
+    type=click.BOOL,
+    help='list the virtual machine CPU')
+@click.option(
+    'is_memory',
+    '--is-include-memory',
+    required=False,
+    metavar='<is_memory>',
+    type=click.BOOL,
+    help='list the virtual machine memory')
+@click.option(
+    'is_disk',
+    '--is-include-disk',
+    required=False,
+    metavar='<is_disk>',
+    type=click.BOOL,
+    help='list the virtual machine disk')
+@click.option(
+    'is_media',
+    '--is-include-media',
+    required=False,
+    metavar='<is_media>',
+    type=click.BOOL,
+    help='list the virtual machine media')
+@click.option(
+    'is_network',
+    '--is-include-network',
+    required=False,
+    metavar='<is_network>',
+    type=click.BOOL,
+    help='list the virtual machine network')
+def list_virtual_hardware_section(ctx, vapp_name, vm_name, is_cpu, is_memory,
+                                  is_disk, is_media, is_network):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_virtual_hardware_section(is_cpu=is_cpu,
+                                                is_memory=is_memory,
+                                                is_disk=is_disk,
+                                                is_media=is_media,
+                                                is_networkCards=is_network)
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2649: [VCD-CLI] GET virtualHardwareSection-disks
VP-2660: [VCD-CLI] get virtualHardwareSection/media
VP-2663: [VCD-CLI] Get virtualHardwareSection/networkCards

This CLN contains above functionalities and it can be called with
default options from command line as :

vcd vm list-virtual-hardware-section vapp1 vm1

Testing Done:
Test method test_0280_list_virtual_hardware_section is added in
vm_tests.py file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/452)
<!-- Reviewable:end -->
