### PR TITLE
VP-2625: [VCD-CLI] get compliance result

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -434,6 +434,18 @@ class VmTest(BaseTestCase):
                       VmTest._test_vapp_vmtools_vm_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0290_get_compliance_result(self):
+        # Get compliance result
+        default_org = self._config['vcd']['default_org_name']
+        self._sys_login()
+        VmTest._runner.invoke(org, ['use', default_org])
+        result = VmTest._runner.invoke(
+            vm, args=['get-compliance-result',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        self._logout()
+        self._login()
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -200,6 +200,10 @@ def vm(ctx):
         vcd vm list-virtual-hardware-section vapp1 vm1
             List virtual hadware section of VM.
 
+\b
+        vcd vm get-compliance-result vapp1 vm1
+            Get compliance result of VM.
+
     """
     pass
 
@@ -913,5 +917,19 @@ def list_virtual_hardware_section(ctx, vapp_name, vm_name, is_cpu, is_memory,
                                                 is_media=is_media,
                                                 is_networkCards=is_network)
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('get-compliance-result', short_help='get compliance result of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def get_compliance_result(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.get_compliance_result()
+        compliance_result = result.ComplianceStatus
+        stdout(compliance_result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2625: [VCD-CLI] get compliance result

This CLN contains check compliance functionality of a VM. It can be
called from command line as :

vcd vm get-compliance-result vapp1 vm1

Testing Done:
Test method test_0290_get_compliance_result ia sdded in vm_tests.py
file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/453)
<!-- Reviewable:end -->
