### PR TITLE
VP-2636, VP-2729, VP-2731: List VM Metrics

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -55,6 +55,7 @@ class VmTest(BaseTestCase):
 
     _test_vapp_vmtools_name = 'test_vApp_vmtools_' + str(uuid1())
     _test_vapp_vmtools_vm_name = 'yVM'
+    _metric_pattern = '*.average'
 
 
     def test_0000_setup(self):
@@ -445,6 +446,21 @@ class VmTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
         self._logout()
         self._login()
+
+    def test_0300_list_current_metrics(self):
+        #list current metrics
+        result = VmTest._runner.invoke(
+            vm, args=['list-current-metrics',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0310_list_subset_current_metrics(self):
+        #list subset of current metrics based on metric pattern
+        result = VmTest._runner.invoke(
+            vm, args=['list-subset-current-metrics',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--metric-pattern', VmTest._metric_pattern ])
+        self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -209,7 +209,7 @@ def vm(ctx):
             List current metrics of VM.
 
 \b
-        vcd vm list_subset_currennt_metrics vapp1 vm1
+        vcd vm list-subset-current_metrics vapp1 vm1
                 --metric-pattern *.average
             List subset of current metrics of VM based on metric pattern.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -209,7 +209,7 @@ def vm(ctx):
             List current metrics of VM.
 
 \b
-        vcd vm list-subset-current_metrics vapp1 vm1
+        vcd vm list-subset-current-metrics vapp1 vm1
                 --metric-pattern *.average
             List subset of current metrics of VM based on metric pattern.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -204,6 +204,19 @@ def vm(ctx):
         vcd vm get-compliance-result vapp1 vm1
             Get compliance result of VM.
 
+\b
+        vcd vm list-current-metrics vapp1 vm1
+            List current metrics of VM.
+
+\b
+        vcd vm list_subset_currennt_metrics vapp1 vm1
+                --metric-pattern *.average
+            List subset of current metrics of VM based on metric pattern.
+
+\b
+        vcd vm list-historic-metrics vapp1 vm1
+            List historic metrics of VM.
+
     """
     pass
 
@@ -931,5 +944,51 @@ def get_compliance_result(ctx, vapp_name, vm_name):
         result = vm.get_compliance_result()
         compliance_result = result.ComplianceStatus
         stdout(compliance_result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('list-current-metrics', short_help='list current metrics of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_all_currennt_metrics(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_all_current_metrics()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('list-subset-current-metrics', short_help='list subset of '
+                                                      'current metrics of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'metric_pattern',
+    '--metric-pattern',
+    required=True,
+    metavar='<metric_pattern>',
+    help='list subset of current metrics based on metric pattern')
+def list_subset_currennt_metrics(ctx, vapp_name, vm_name, metric_pattern):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_current_metrics_subset(metric_pattern=metric_pattern)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('list-historic-metrics', short_help='list historic metrics of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_all_historic_metrics(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_all_historic_metrics()
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2636:[VCD-CLI] Get current metrics
VP-2729:[VCD-CLI] List subset of current metrics
VP-2731:[VCD-CLI] List historic metrics

This CLN contains listing VM Metrics. It can be called from command line
as :

vcd vm list-current-metrics vapp1 vm1
vcd vm list_subset_currennt_metrics vapp1 vm1
                --metric-pattern *.average
vcd vm list-historic-metrics vapp1 vm1

Testing Done:
Test method test_0300_list_current_metrics and
test_0310_list_subset_current_metrics are added for current metrics.
Historic metrics need VM monitoring set-up which is not in our test lab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/455)
<!-- Reviewable:end -->
