### PR TITLE
VP-2052,VP-2076: [VcDCLI] relocate

### DIFF
--- a/system_tests/datastore_tests.py
+++ b/system_tests/datastore_tests.py
@@ -1,0 +1,70 @@
+# VMware vCloud Director vCD CLI
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+from vcd_cli.login import login, logout
+from vcd_cli.datastore import datastore
+
+
+class DatastoreTest(BaseTestCase):
+    """Test datastore-related commands
+
+    Tests cases in this module do not have ordering dependencies,
+    so setup is accomplished using Python unittest setUp and tearDown
+    methods.
+
+    Be aware that this test will delete existing vcd-cli sessions.
+    """
+
+    def setUp(self):
+        """Load configuration and create a click runner to invoke CLI."""
+        self._config = Environment.get_config()
+        self._logger = Environment.get_default_logger()
+
+        self._runner = CliRunner()
+        self._login()
+
+    def test10_list_datastores(self):
+        """Fetches the list of datastores
+        Invoke the command 'datastore list'.
+        """
+        result = self._runner.invoke(datastore, args=['list'])
+        self.assertEqual(0, result.exit_code)
+
+    def tearDown(self):
+        """Logout ignoring any errors to ensure test session is gone."""
+        self._logout()
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = self._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        self._runner.invoke(logout)

--- a/vcd_cli/datastore.py
+++ b/vcd_cli/datastore.py
@@ -1,0 +1,46 @@
+# VMware vCloud Director CLI
+#
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the
+# Apache License, Version 2.0 (the "License").
+# You may not use this product except in compliance with the License.
+#
+# This product may include a number of subcomponents with
+# separate copyright notices and license terms. Your use of the source
+# code for the these subcomponents is subject to the terms and
+# conditions of the subcomponent's license, as noted in the LICENSE file.
+#
+
+import click
+from pyvcloud.vcd.platform import Platform
+
+from vcd_cli.utils import restore_session
+from vcd_cli.utils import stderr
+from vcd_cli.utils import stdout
+from vcd_cli.vcd import vcd  # NOQA
+
+@vcd.group(short_help='manage datastores')
+@click.pass_context
+def datastore(ctx):
+    """Manage datastores in vCloud Director.
+
+\b
+    Examples
+        vcd datastore list
+            Get list of datastores attached to the vCD system.
+
+    """
+    pass
+
+
+@datastore.command('list', short_help='list datastores')
+@click.pass_context
+def list_datastores(ctx):
+    try:
+        restore_session(ctx)
+        platform = Platform(ctx.obj['client'])
+        result = platform.list_datastores()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -111,6 +111,7 @@ else:
     from vcd_cli import catalog  # NOQA
     from vcd_cli import ca_certificates  # NOQA
     from vcd_cli import crl_certificates  # NOQA
+    from vcd_cli import datastore  # NOQA
     from vcd_cli import disk  # NOQA
     from vcd_cli import dhcp_pool  # NOQA
     from vcd_cli import firewall_rule  # NOQA

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -15,6 +15,7 @@
 import click
 from pyvcloud.vcd.client import IpAddressMode
 from pyvcloud.vcd.client import NetworkAdapterType
+from pyvcloud.vcd.platform import Platform
 from pyvcloud.vcd.utils import vm_to_dict
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.vdc import VDC
@@ -227,6 +228,11 @@ def vm(ctx):
             --d vm_new_description --cn new_computer_name --bd 60
             --ebs True
             Update general setting details of VM.
+
+\b
+        vcd vm relocate vapp1 vm1
+                --datastore-id 0d8c7358-3e8d-4862-9364-68155069d252
+            Relocate VM to given datastore.
 
     """
     pass
@@ -1092,6 +1098,27 @@ def update_general_setting(ctx, vapp_name, vm_name, name, description,
             boot_delay=boot_delay,
             enter_bios_setup=enter_bios_setup,
             storage_policy_href=storage_policy_href)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('relocate', short_help='relocate VM to given datastore')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'datastore_id',
+    '--datastore-id',
+    required=True,
+    metavar='<datastore-id>',
+    help='datastore id')
+def relocate(ctx, vapp_name, vm_name, datastore_id):
+    try:
+        restore_session(ctx, vdc_required=True)
+        platform = Platform(ctx.obj['client'])
+        datastore_href = platform.get_datastore_href_by_id(id=datastore_id)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.relocate(datastore_href=datastore_href)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2052: [VcDCLI] relocate
VP-2076: [VCD-CLI] List datastores in VCD
Fix for teardown failure.

THis CLN contains above cli commands and fix. These commands can be
called from the command line as :

vcd vm relocate vapp1 vm1 --datastore-id
0d8c7358-3e8d-4862-9364-68155069d252

vcd datastore list

Testing Done:
Test method test_0330_relocate in vm_tests.py and test10_list_datastores
in datastore_tests.py are added.
