### PR TITLE
VP-2791,VP-2709,VP-2707 Update nic

### DIFF
--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -1,0 +1,77 @@
+# VMware vCloud Director vCD CLI
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from click.testing import CliRunner
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import CommonRoles
+from pyvcloud.system_test_framework.environment import Environment
+
+from vcd_cli.login import login, logout
+from vcd_cli.org import org
+from vcd_cli.vdc import vdc
+
+class TestOrgVDC(BaseTestCase):
+    """Test OrgVDC functionalities implemented in pyvcloud."""
+
+    # All tests in this module should run as System Administrator.
+    _client = None
+
+    def test_0000_setup(self):
+        """Setup the org vdc required for the other tests in this module.
+        """
+        TestOrgVDC._config = Environment.get_config()
+        logger = Environment.get_default_logger()
+        TestOrgVDC._client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        TestOrgVDC._runner = CliRunner()
+        default_org = TestOrgVDC._config['vcd']['default_org_name']
+        TestOrgVDC._login(self)
+        TestOrgVDC._runner.invoke(org, ['use', default_org])
+        TestOrgVDC._vdc_resource = Environment.get_test_vdc(
+            TestOrgVDC._client).get_resource()
+
+    def test_0010_list_media(self):
+        """Test the method VDC.list_media()."""
+        vdc_name = TestOrgVDC._vdc_resource.get('name')
+        """Get list of media."""
+        result = TestOrgVDC._runner.invoke(
+            vdc, args=['list-media', vdc_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_9998_teardown(self):
+        """Test the method VDC.delete_vdc().
+
+        Invoke the method for the vdc created by setup.
+
+        This test passes if the task for deleting the vdc succeeds.
+        """
+        pass
+
+    def test_9999_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestOrgVDC._client.logout()
+
+    def _login(self):
+        org = TestOrgVDC._config['vcd']['default_org_name']
+        user = Environment.get_username_for_role_in_test_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        password = TestOrgVDC._config['vcd']['default_org_user_password']
+        login_args = [
+            TestOrgVDC._config['vcd']['host'], org, user, "-i", "-w",
+            "--password={0}".format(password)
+        ]
+        result = TestOrgVDC._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -283,7 +283,7 @@ class VmTest(BaseTestCase):
         media_id = media_id.split(':')[3]
         result = VmTest._runner.invoke(
             vm, args=['insert-cd', VAppConstants.name, VAppConstants.vm1_name,
-                      '--media-href', media_id])
+                      '--media-id', media_id])
         self.assertEqual(0, result.exit_code)
 
     def test_0100_eject_cd(self):
@@ -292,7 +292,7 @@ class VmTest(BaseTestCase):
         media_id = media_id.split(':')[3]
         result = VmTest._runner.invoke(
             vm, args=['eject-cd', VAppConstants.name, VAppConstants.vm1_name,
-                      '--media-href', media_id])
+                      '--media-id', media_id])
         self.assertEqual(0, result.exit_code)
 
     def test_0110_add_nic(self):

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -279,18 +279,20 @@ class VmTest(BaseTestCase):
 
     def test_0090_insert_cd(self):
         """Insert CD in the VM."""
-        media_href = VmTest._media_resource.Entity.get('href')
+        media_id = VmTest._media_resource.Entity.get('id')
+        media_id = media_id.split(':')[3]
         result = VmTest._runner.invoke(
             vm, args=['insert-cd', VAppConstants.name, VAppConstants.vm1_name,
-                      '--media-href', media_href])
+                      '--media-href', media_id])
         self.assertEqual(0, result.exit_code)
 
     def test_0100_eject_cd(self):
         """Eject CD from the VM."""
-        media_href = VmTest._media_resource.Entity.get('href')
+        media_id = VmTest._media_resource.Entity.get('id')
+        media_id = media_id.split(':')[3]
         result = VmTest._runner.invoke(
             vm, args=['eject-cd', VAppConstants.name, VAppConstants.vm1_name,
-                      '--media-href', media_href])
+                      '--media-href', media_id])
         self.assertEqual(0, result.exit_code)
 
     def test_0110_add_nic(self):
@@ -302,6 +304,16 @@ class VmTest(BaseTestCase):
                 '--adapter-type', VmTest.DEFAULT_ADAPTER_TYPE, '--connect',
                 '--primary', '--network', VAppConstants.network1_name,
                 '--ip-address-mode', VmTest.DEFAULT_IP_MODE
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0115_update_nic(self):
+        """update nic of the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'update-nic', VAppConstants.name, VAppConstants.vm1_name,
+                '--network', VAppConstants.network1_name
             ])
         self.assertEqual(0, result.exit_code)
 

--- a/vcd_cli/vdc.py
+++ b/vcd_cli/vdc.py
@@ -59,6 +59,9 @@ def vdc(ctx):
 \b
         vcd vdc delete -y dev-vdc
             Delete virtual datacenter.
+\b
+        vcd vdc list-media
+            Get list of media in virtual datacenters.
     """
     pass
 
@@ -479,5 +482,23 @@ def list_acl(ctx, vdc_name):
         stdout(
             access_settings_to_list(
                 acl, ctx.obj['profiles'].get('org_in_use')), ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vdc.command('list-media', short_help='list media from VDC')
+@click.pass_context
+@click.argument('vdc-name', metavar='<vdc-name>')
+def list_media(ctx, vdc_name):
+    try:
+        restore_session(ctx)
+        client = ctx.obj['client']
+        in_use_org_href = ctx.obj['profiles'].get('org_href')
+        org = Org(client, in_use_org_href)
+        vdc_resource = org.get_vdc(vdc_name)
+        vdc = VDC(client, resource=vdc_resource)
+
+        media_list = vdc.list_media_id()
+        stdout(media_list, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -396,7 +396,7 @@ def add_nic(ctx, vapp_name, vm_name, adapter_type, primary, connect, network,
     except Exception as e:
         stderr(e, ctx)
 
-@vm.command('update-nic', short_help='Add a nic to the VM')
+@vm.command('update-nic', short_help='Update a nic to the VM')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
 @click.argument('vm-name', metavar='<vm-name>', required=True)


### PR DESCRIPTION
VP-2791:[VcdCLI]UPdate nic
VP-2707:[VcdCLI]List media file in VDC
VP-2709:[VcdCLI]Remove href from insert-cd and eject-cd command

Above functionalities are part of the CLN. It can be called from command
line as :

vcd vm update-nic vapp1 vm1
                --adapter-type VMXNET3
                --primary
                --connect
                --network network_name
                --ip-address-mode MANUAL
                --ip-address 192.168.1.10

vcd vdc list-media

Testing Done:
Test method test_0010_list_media in vdc_tests.py and
test_0115_update_nic in vm_tests.py is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/460)
<!-- Reviewable:end -->
