### PR TITLE
VP-2673, VP-2796: List and update VM Operating system section

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -67,6 +67,7 @@ class VmTest(BaseTestCase):
     _computer_name_update = 'mycom'
     _boot_delay_update = 60
     _enter_bios_setup_update = True
+    _new_ovf_info = 'new info'
 
     def test_0000_setup(self):
         """Load configuration and create a click runner to invoke CLI."""
@@ -541,6 +542,21 @@ class VmTest(BaseTestCase):
             VmTest._client.get_task_monitor().wait_for_success(task)
             task = vapp.undeploy()
             VmTest._client.get_task_monitor().wait_for_success(task)
+
+    def test_0340_list_os_section(self):
+        # list os section properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-os-section',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0340_update_os_section(self):
+        # list os section properties
+        result = VmTest._runner.invoke(
+            vm, args=['update-os-section',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--ovf-info', VmTest._new_ovf_info])
+        self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -551,7 +551,7 @@ class VmTest(BaseTestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_0340_update_os_section(self):
-        # list os section properties
+        # update os section properties
         result = VmTest._runner.invoke(
             vm, args=['update-os-section',
                       VAppConstants.name, VAppConstants.vm1_name,

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -253,7 +253,7 @@ def vm(ctx):
         vcd vm update-os-section vapp1 vm1
                 --ovf-info newInfo
                 --description newDescription
-            List OS section properties of VM.
+            Update OS section properties of VM.
     """
     pass
 
@@ -1221,8 +1221,9 @@ def list_os_section(ctx, vapp_name, vm_name):
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)
+
 @vm.command(
-    'update-os-section', short_help='update od section properties of VM')
+    'update-os-section', short_help='update os section properties of VM')
 @click.pass_context
 @click.argument('vapp-name', metavar='<vapp-name>', required=True)
 @click.argument('vm-name', metavar='<vm-name>', required=True)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -245,6 +245,15 @@ def vm(ctx):
                 --datastore-id 0d8c7358-3e8d-4862-9364-68155069d252
             Relocate VM to given datastore.
 
+\b
+        vcd vm list-os-section vapp1 vm1
+            List OS section properties of VM.
+
+\b
+        vcd vm update-os-section vapp1 vm1
+                --ovf-info newInfo
+                --description newDescription
+            List OS section properties of VM.
     """
     pass
 
@@ -1195,6 +1204,48 @@ def relocate(ctx, vapp_name, vm_name, datastore_id):
         datastore_href = platform.get_datastore_href_by_id(id=datastore_id)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.relocate(datastore_href=datastore_href)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('list-os-section', short_help='list operating system section '
+                                          'properties of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_os_section(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_os_section()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+@vm.command(
+    'update-os-section', short_help='update od section properties of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'ovf_info',
+    '--ovf-info',
+    required=False,
+    default=None,
+    metavar='<ovf_info>',
+    help='ovf info')
+@click.option(
+    'description',
+    '--d',
+    required=False,
+    default=None,
+    metavar='<description>',
+    help='description')
+def update_os_section(ctx, vapp_name, vm_name, ovf_info, description):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.update_operating_system_section(ovf_info=ovf_info,
+                                                  description=description)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2673: [VCD-CLI] Update OperatingSystemSection
VP-2796: [VCD-CLI] List Operating system section

This CLN conatins list and update operating system section. It can be
called from command line as :

vcd vm list-os-section vapp1 vm1
vcd vm update-os-section vapp1 vm1
                --ovf-info newInfo
                --description newDescription

Testing Done:
Test method test_0340_list_os_section and test_0340_update_os_section
added in vm_tests.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/462)
<!-- Reviewable:end -->
