### PR TITLE
VP-2681,VP-2683: List and update VM capabilities

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -583,6 +583,21 @@ class VmTest(BaseTestCase):
                       VmTest._test_vapp_vmtools_vm_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0380_list_vm_capabilities(self):
+        # list vm capabilities section properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-vm-capabilities',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0390_update_vm_capabilities(self):
+        # update vm capabilities section properties
+        result = VmTest._runner.invoke(
+            vm, args=['update-vm-capabilities',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--disable-memory-hot-add'])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -268,6 +268,14 @@ def vm(ctx):
         vcd vm check-post-gc-script vapp1 vm1
             Check post guest customization script status of VM.
 
+\b
+        vcd vm list-vm-capabilities vapp1 vm1
+            List VM capabilities section properties of VM.
+
+\b
+        vcd vm update-vm-capabilities
+                --enable-memory-hot-add
+            Update VM capabilities section properties of VM.
     """
     pass
 
@@ -1423,5 +1431,53 @@ def check_post_gc_script(ctx, vapp_name, vm_name):
         vm = _get_vm(ctx, vapp_name, vm_name)
         result = vm.list_check_post_gc_status()
         stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('list-vm-capabilities', short_help='list VM capabilities section '
+                                               'properties')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_vm_capabilities(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_vm_capabilities()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command(
+    'update-vm-capabilities', short_help='update VM capabilities properties')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'enable_memory_hot_add',
+    '--enable-memory-hot-add/--disable-memory-hot-add',
+    required=False,
+    default=None,
+    metavar='<bool>',
+    help='enable memory hot add')
+@click.option(
+    'enable_cpu_hot_add',
+    '--enable-cpu-hot-add/--disable-cpu-hot-add',
+    required=False,
+    default=None,
+    metavar='<bool>',
+    help='enable CPU hot add')
+def update_vm_capabilities_section(ctx, vapp_name, vm_name,
+                                   enable_memory_hot_add, enable_cpu_hot_add):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm. \
+            update_vm_capabilities_section(
+            memory_hot_add_enabled=enable_memory_hot_add,
+            cpu_hot_add_enabled=enable_cpu_hot_add)
+        stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2681:[VCD-CLI] Get VmCapabilities
VP-2683:[VCD-CLI] Update VmCapabilities

This CLN contains list and update VM capabilities. It can be called from
command line as :

vcd vm list-vm-capabilities vapp1 vm1
vcd vm update-vm-capabilities
                --enable-memory-hot-add

Testing Done:
Test methods test_0380_list_vm_capabilities and
test_0390_update_vm_capabilities are added in vm_tests.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/466)
<!-- Reviewable:end -->
