### PR TITLE
VP-2622, VP-2849, VP-2851,VP-2856: metadata CRUD operations

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -91,16 +91,19 @@ class VmTest(BaseTestCase):
         VmTest._test_vdc = Environment.get_test_vdc(VmTest._client)
         VmTest._test_vapp = Environment.get_test_vapp_with_network(
             VmTest._client)
-        VmTest._test_old_vapp_href = VmTest._test_vapp.get_resource().get('href')
+        VmTest._test_old_vapp_href = VmTest._test_vapp.get_resource().get(
+            'href')
         self.assertIsNotNone(VmTest._test_old_vapp_href)
         logger.debug("Old vapp href is : " + VmTest._test_old_vapp_href)
 
         VmTest._test_vm = VM(
             VmTest._client,
             href=VmTest._test_vapp.get_vm(VAppConstants.vm1_name).get('href'))
-        self.assertIsNotNone(VmTest._test_vapp.get_vm(VAppConstants.vm1_name).get('href'))
-        logger.debug("Old vapp VM href is : " +
+        self.assertIsNotNone(
             VmTest._test_vapp.get_vm(VAppConstants.vm1_name).get('href'))
+        logger.debug("Old vapp VM href is : " +
+                     VmTest._test_vapp.get_vm(VAppConstants.vm1_name).get(
+                         'href'))
 
         vdc1 = Environment.get_test_vdc(VmTest._client)
         logger.debug('Creating empty vApp.')
@@ -120,7 +123,7 @@ class VmTest(BaseTestCase):
                                                    description=self._idisk_description)
         self.assertIsNotNone(VmTest._idisk_id)
 
-        logger.debug("Independent disk id is: " + VmTest._idisk_id )
+        logger.debug("Independent disk id is: " + VmTest._idisk_id)
 
         # Upload template with vm tools.
         catalog_author_client = Environment.get_client_in_default_org(
@@ -188,14 +191,491 @@ class VmTest(BaseTestCase):
                 break
         self.assertIsNotNone(VmTest._datastore_id)
 
+    def test_0010_info(self):
+        """Get info of the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['info', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # verify output
+        vm_name_regex = r"name\s*%s" % VAppConstants.vm1_name
+        vapp_regex = r"vapp\s*%s" % VAppConstants.name
+        # finall returns a list. checking that list is not empty.
+        self.assertTrue(re.findall(vm_name_regex, result.output))
+        self.assertTrue(re.findall(vapp_regex, result.output))
+
+    def test_0020_consolidate(self):
+        """Consolidate the VM."""
+        default_org = self._config['vcd']['default_org_name']
+        self._sys_login()
+        VmTest._runner.invoke(org, ['use', default_org])
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+        result = VmTest._runner.invoke(
+            vm,
+            args=['consolidate', VAppConstants.name,
+                  VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # logging out sys_client
+        self._logout()
+        # logging with org admin user
+        self._login()
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+
+    def test_0025_copy_to(self):
+        """Copy VM from one vApp to another."""
+        result = VmTest._runner.invoke(
+            vm, args=['copy', VAppConstants.name, VAppConstants.vm1_name,
+                      '--target-vapp-name', VmTest._empty_vapp_name,
+                      '--target-vm-name', VmTest._target_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0026_move_to(self):
+        """Move VM from one vApp to another."""
+        test_vapp = VmTest._test_vapp
+        test_vapp_resource = test_vapp.get_resource()
+        VmTest._test_vapp_name = test_vapp_resource.get('name')
+        result = VmTest._runner.invoke(
+            vm,
+            args=['move', VmTest._empty_vapp_name, VmTest._target_vm_name,
+                  '--target-vapp-name', VmTest._test_vapp_name,
+                  '--target-vm-name', VmTest._target_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0028_delete(self):
+        """Delete VM from vApp"""
+        result = VmTest._runner.invoke(
+            vm, args=['delete', VmTest._test_vapp_name,
+                      VmTest._target_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0030_power_on(self):
+        """Power on the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0032_reboot(self):
+        """Reboot the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['reboot', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0034_shutdown(self):
+        """Shutdown the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=['shutdown', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # Again power on VM for further test cases.
+        result = VmTest._runner.invoke(
+            vm,
+            args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
+
+    def test_0040_power_off(self):
+        """Power off the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=['power-off', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # Again power on VM for further test cases.
+        result = VmTest._runner.invoke(
+            vm,
+            args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
+
+    def test_0050_reset(self):
+        """Reset the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['reset', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0060_suspend(self):
+        """Suspend the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=['suspend', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0070_discard_suspended_state(self):
+        """Discard suspended state of the VM."""
+        result = VmTest._runner.invoke(
+            vm, args=['discard-suspend', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0080_install_vmware_tools(self):
+        """Install vmware tools in the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        result = VmTest._runner.invoke(
+            vm, args=['install-vmware-tools', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0090_insert_cd(self):
+        """Insert CD in the VM."""
+        media_id = VmTest._media_resource.Entity.get('id')
+        media_id = media_id.split(':')[3]
+        result = VmTest._runner.invoke(
+            vm,
+            args=['insert-cd', VAppConstants.name, VAppConstants.vm1_name,
+                  '--media-id', media_id])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0100_eject_cd(self):
+        """Eject CD from the VM."""
+        media_id = VmTest._media_resource.Entity.get('id')
+        media_id = media_id.split(':')[3]
+        result = VmTest._runner.invoke(
+            vm,
+            args=['eject-cd', VAppConstants.name, VAppConstants.vm1_name,
+                  '--media-id', media_id])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0110_add_nic(self):
+        """Add a nic to the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'add-nic', VAppConstants.name, VAppConstants.vm1_name,
+                '--adapter-type', VmTest.DEFAULT_ADAPTER_TYPE, '--connect',
+                '--primary', '--network', VAppConstants.network1_name,
+                '--ip-address-mode', VmTest.DEFAULT_IP_MODE
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0115_update_nic(self):
+        """update nic of the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'update-nic', VAppConstants.name, VAppConstants.vm1_name,
+                '--network', VAppConstants.network1_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0120_list_nics(self):
+        """List all nics of the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=['list-nics', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0130_delete_nic(self):
+        """Delete a nic of the VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'delete-nic', VAppConstants.name, VAppConstants.vm1_name,
+                '--index', 0
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0140_create_snapshot(self):
+        """Create snapshot of VM"""
+        result = VmTest._runner.invoke(
+            vm, args=['create-snapshot', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0150_revert_to_snapshot(self):
+        """Revert VM to current snapshot."""
+        result = VmTest._runner.invoke(
+            vm, args=['revert-to-snapshot', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0160_attach_disk_to_vm(self):
+        """Attach independent disk to VM."""
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'attach-disk', VAppConstants.name, VAppConstants.vm1_name,
+                '--idisk-id',
+                VmTest._idisk_id
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0170_detach_disk_from_vm(self):
+        """Detach independent disk from VM."""
+        vdc = Environment.get_test_vdc(VmTest._client)
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'detach-disk', VAppConstants.name, VAppConstants.vm1_name,
+                '--idisk-id',
+                VmTest._idisk_id
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0180_deploy_undeploy_vm(self):
+        # Undeploy VM
+        result = VmTest._runner.invoke(
+            vm,
+            args=['undeploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        result = VmTest._runner.invoke(
+            vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0190_upgrade_virtual_hardware(self):
+        # Undeploy VM
+        result = VmTest._runner.invoke(
+            vm,
+            args=['undeploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        # Upgrade virtual hardware of VM.
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'upgrade-virtual-hardware', VAppConstants.name,
+                VAppConstants.vm1_name
+            ])
+        self.assertEqual(0, result.exit_code)
+        # Again deploy VM for further test cases.
+        result = VmTest._runner.invoke(
+            vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0200_general_setting_detail(self):
+        # general setting details
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'general-setting', VAppConstants.name,
+                VAppConstants.vm1_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0210_list_storage_profile(self):
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'list-storage-profile', VAppConstants.name,
+                VAppConstants.vm1_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0220_reload_from_vc(self):
+        # Reload VM from VC
+        default_org = self._config['vcd']['default_org_name']
+        self._sys_login()
+        VmTest._runner.invoke(org, ['use', default_org])
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+        result = VmTest._runner.invoke(
+            vm, args=['reload-from-vc',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0230_check_compliance(self):
+        # Check compliance of VM
+        result = VmTest._runner.invoke(
+            vm, args=['check-compliance',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        self._logout()
+        self._login()
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+
+    def test_0240_customize_on_next_power_on(self):
+        # Customize on next power on
+        result = VmTest._runner.invoke(
+            vm, args=['customize-on-next-poweron',
+                      VAppConstants.name, VAppConstants.vm1_name])
+
+    def test_0250_gc_enable(self):
+        # Enable guest customization
+        result = VmTest._runner.invoke(
+            vm, args=['gc-enable',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name, '--enable'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0260_get_gc_status(self):
+        # Get guest customization status
+        result = VmTest._runner.invoke(
+            vm, args=['gc-status',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0270_poweron_and_force_recustomizations(self):
+        # Power off VM.
+        result = VmTest._runner.invoke(
+            vm, args=['undeploy', VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+        # Power on and force recustomize VM.
+        result = VmTest._runner.invoke(
+            vm, args=['poweron-force-recustomize',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0280_list_virtual_hardware_section(self):
+        # list virtual hardware section
+        result = VmTest._runner.invoke(
+            vm, args=['list-virtual-hardware-section',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0290_get_compliance_result(self):
+        # Get compliance result
+        default_org = self._config['vcd']['default_org_name']
+        self._sys_login()
+        VmTest._runner.invoke(org, ['use', default_org])
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+        result = VmTest._runner.invoke(
+            vm, args=['get-compliance-result',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+        self._logout()
+        self._login()
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+
+    def test_0300_list_current_metrics(self):
+        # list current metrics
+        result = VmTest._runner.invoke(
+            vm, args=['list-current-metrics',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0310_list_subset_current_metrics(self):
+        # list subset of current metrics based on metric pattern
+        result = VmTest._runner.invoke(
+            vm, args=['list-subset-current-metrics',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--metric-pattern', VmTest._metric_pattern])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0320_update_general_setting(self):
+        # System admin login
+        self._sys_login()
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+        # update general setting
+        result = VmTest._runner.invoke(
+            vm,
+            args=[
+                'update-general-setting', VmTest._vapp_name,
+                VmTest._vm_name,
+                '--name', VmTest._vm_name_update, '--d',
+                VmTest._description_update, '--cn',
+                VmTest._computer_name_update, '--bd',
+                VmTest._boot_delay_update, '--ebs',
+                VmTest._enter_bios_setup_update
+            ])
+        self.assertEqual(0, result.exit_code)
+        # logging out sys_client
+        self._logout()
+        # logging with org admin user
+        self._login()
+
+    def test_0330_relocate(self):
+        # relocate VM to given datastore
+        default_org = self._config['vcd']['default_org_name']
+        self._sys_login()
+        VmTest._runner.invoke(org, ['use', default_org])
+        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
+        result = VmTest._runner.invoke(
+            vm, args=['relocate',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--datastore-id', VmTest._datastore_id])
+        self.assertEqual(0, result.exit_code)
+
+    def _power_off_and_undeploy(self, vapp):
+        if vapp.is_powered_on():
+            task = vapp.power_off()
+            VmTest._client.get_task_monitor().wait_for_success(task)
+            task = vapp.undeploy()
+            VmTest._client.get_task_monitor().wait_for_success(task)
+
+    def test_0340_list_os_section(self):
+        # list os section properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-os-section',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0340_update_os_section(self):
+        # update os section properties
+        result = VmTest._runner.invoke(
+            vm, args=['update-os-section',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--ovf-info', VmTest._new_ovf_info])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0350_list_gc_section(self):
+        # list gc section properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-gc-section',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0360_update_gc_section(self):
+        # update os section properties
+        result = VmTest._runner.invoke(
+            vm, args=['update-gc-section',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name,
+                      '--disable'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0370_check_post_gc_script_status(self):
+        # check post gc script status
+        result = VmTest._runner.invoke(
+            vm, args=['check-post-gc-script',
+                      VmTest._test_vapp_vmtools_name,
+                      VmTest._test_vapp_vmtools_vm_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0380_list_vm_capabilities(self):
+        # list vm capabilities section properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-vm-capabilities',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0390_update_vm_capabilities(self):
+        # update vm capabilities section properties
+        result = VmTest._runner.invoke(
+            vm, args=['update-vm-capabilities',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--disable-memory-hot-add'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0400_list_runtime_info(self):
+        # list runtime info properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-runtime-info',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0410_list_boot_options(self):
+        # list boot options properties
+        result = VmTest._runner.invoke(
+            vm, args=['list-boot-options',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0420_update_boot_options(self):
+        # update boot options properties
+        result = VmTest._runner.invoke(
+            vm, args=['update-boot-options',
+                      VAppConstants.name, VAppConstants.vm1_name,
+                      '--disable-enter-bios-setup'])
+        self.assertEqual(0, result.exit_code)
+
     def test_0430_set_metadata(self):
         # Set metadata
         result = VmTest._runner.invoke(
             vm, args=['set-metadata',
                       VAppConstants.name, VAppConstants.vm1_name,
-                      '--domain', 'GENERAL', '--visibility', 'READ_WRITE',
+                      '--domain', 'GENERAL', '--visibility', 'READWRITE',
                       '--key', 'key1', '--value',
-                      'value1'])
+                      'value1', '--value-type', 'MetadataStringValue'])
         self.assertEqual(0, result.exit_code)
 
     def test_0440_update_metadata(self):
@@ -203,9 +683,9 @@ class VmTest(BaseTestCase):
         result = VmTest._runner.invoke(
             vm, args=['update-metadata',
                       VAppConstants.name, VAppConstants.vm1_name,
-                      '--domain', 'GENERAL', '--visibility', 'READ_WRITE',
+                      '--domain', 'GENERAL', '--visibility', 'READWRITE',
                       '--key', 'key1', '--value',
-                      'value2'])
+                      'value2', '--value-type', 'MetadataStringValue'])
         self.assertEqual(0, result.exit_code)
 
     def test_0450_list_metadata(self):
@@ -233,11 +713,11 @@ class VmTest(BaseTestCase):
         if VmTest._empty_vapp_href is not None:
             vapps_to_delete.append(VmTest._empty_vapp_name)
         vapp = VApp(VmTest._client, href=VmTest._test_old_vapp_href)
-        self._power_off_and_undeploy(vapp = vapp)
+        self._power_off_and_undeploy(vapp=vapp)
         vapp = VApp(VmTest._client, href=VmTest._test_vapp_vmtools_href)
-        self._power_off_and_undeploy(vapp = vapp)
+        self._power_off_and_undeploy(vapp=vapp)
         vapp = VApp(VmTest._client, href=VmTest._test_vapp_href)
-        self._power_off_and_undeploy(vapp = vapp)
+        self._power_off_and_undeploy(vapp=vapp)
         vapps_to_delete.append(VmTest._vapp_name)
         vapps_to_delete.append(VmTest._test_vapp_vmtools_name)
         vapps_to_delete.append(VAppConstants.name)
@@ -252,7 +732,6 @@ class VmTest(BaseTestCase):
             task = vdc.delete_vapp(name=vapp_name, force=True)
             result = VmTest._client.get_task_monitor().wait_for_success(task)
             self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
-
 
     def _login(self):
         org = VmTest._config['vcd']['default_org_name']

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -188,465 +188,39 @@ class VmTest(BaseTestCase):
                 break
         self.assertIsNotNone(VmTest._datastore_id)
 
-    def test_0010_info(self):
-        """Get info of the VM."""
+    def test_0430_set_metadata(self):
+        # Set metadata
         result = VmTest._runner.invoke(
-            vm, args=['info', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        # verify output
-        vm_name_regex = r"name\s*%s" % VAppConstants.vm1_name
-        vapp_regex = r"vapp\s*%s" % VAppConstants.name
-        # finall returns a list. checking that list is not empty.
-        self.assertTrue(re.findall(vm_name_regex, result.output))
-        self.assertTrue(re.findall(vapp_regex, result.output))
-
-    def test_0020_consolidate(self):
-        """Consolidate the VM."""
-        default_org = self._config['vcd']['default_org_name']
-        self._sys_login()
-        VmTest._runner.invoke(org, ['use', default_org])
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-        result = VmTest._runner.invoke(
-            vm,
-            args=['consolidate', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        # logging out sys_client
-        self._logout()
-        # logging with org admin user
-        self._login()
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-
-    def test_0025_copy_to(self):
-        """Copy VM from one vApp to another."""
-        result = VmTest._runner.invoke(
-            vm, args=['copy', VAppConstants.name, VAppConstants.vm1_name,
-                      '--target-vapp-name', VmTest._empty_vapp_name,
-                      '--target-vm-name', VmTest._target_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0026_move_to(self):
-        """Move VM from one vApp to another."""
-        test_vapp = VmTest._test_vapp
-        test_vapp_resource = test_vapp.get_resource()
-        VmTest._test_vapp_name = test_vapp_resource.get('name')
-        result = VmTest._runner.invoke(
-            vm, args=['move', VmTest._empty_vapp_name, VmTest._target_vm_name,
-                      '--target-vapp-name', VmTest._test_vapp_name,
-                      '--target-vm-name', VmTest._target_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0028_delete(self):
-        """Delete VM from vApp"""
-        result = VmTest._runner.invoke(
-            vm, args=['delete', VmTest._test_vapp_name,
-                      VmTest._target_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0030_power_on(self):
-        """Power on the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0032_reboot(self):
-        """Reboot the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['reboot', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0034_shutdown(self):
-        """Shutdown the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['shutdown', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        # Again power on VM for further test cases.
-        result = VmTest._runner.invoke(
-            vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
-
-    def test_0040_power_off(self):
-        """Power off the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['power-off', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        # Again power on VM for further test cases.
-        result = VmTest._runner.invoke(
-            vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
-
-    def test_0050_reset(self):
-        """Reset the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['reset', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0060_suspend(self):
-        """Suspend the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['suspend', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0070_discard_suspended_state(self):
-        """Discard suspended state of the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['discard-suspend', VAppConstants.name,
-                      VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0080_install_vmware_tools(self):
-        """Install vmware tools in the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['power-on', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        result = VmTest._runner.invoke(
-            vm, args=['install-vmware-tools', VAppConstants.name,
-                      VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0090_insert_cd(self):
-        """Insert CD in the VM."""
-        media_id = VmTest._media_resource.Entity.get('id')
-        media_id = media_id.split(':')[3]
-        result = VmTest._runner.invoke(
-            vm, args=['insert-cd', VAppConstants.name, VAppConstants.vm1_name,
-                      '--media-id', media_id])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0100_eject_cd(self):
-        """Eject CD from the VM."""
-        media_id = VmTest._media_resource.Entity.get('id')
-        media_id = media_id.split(':')[3]
-        result = VmTest._runner.invoke(
-            vm, args=['eject-cd', VAppConstants.name, VAppConstants.vm1_name,
-                      '--media-id', media_id])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0110_add_nic(self):
-        """Add a nic to the VM."""
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'add-nic', VAppConstants.name, VAppConstants.vm1_name,
-                '--adapter-type', VmTest.DEFAULT_ADAPTER_TYPE, '--connect',
-                '--primary', '--network', VAppConstants.network1_name,
-                '--ip-address-mode', VmTest.DEFAULT_IP_MODE
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0115_update_nic(self):
-        """update nic of the VM."""
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'update-nic', VAppConstants.name, VAppConstants.vm1_name,
-                '--network', VAppConstants.network1_name
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0120_list_nics(self):
-        """List all nics of the VM."""
-        result = VmTest._runner.invoke(
-            vm, args=['list-nics', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0130_delete_nic(self):
-        """Delete a nic of the VM."""
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'delete-nic', VAppConstants.name, VAppConstants.vm1_name,
-                '--index', 0
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0140_create_snapshot(self):
-        """Create snapshot of VM"""
-        result = VmTest._runner.invoke(
-            vm, args=['create-snapshot', VAppConstants.name,
-                      VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0150_revert_to_snapshot(self):
-        """Revert VM to current snapshot."""
-        result = VmTest._runner.invoke(
-            vm, args=['revert-to-snapshot', VAppConstants.name,
-                      VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0160_attach_disk_to_vm(self):
-        """Attach independent disk to VM."""
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'attach-disk', VAppConstants.name, VAppConstants.vm1_name,
-                '--idisk-id',
-                VmTest._idisk_id
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0170_detach_disk_from_vm(self):
-        """Detach independent disk from VM."""
-        vdc = Environment.get_test_vdc(VmTest._client)
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'detach-disk', VAppConstants.name, VAppConstants.vm1_name,
-                '--idisk-id',
-                VmTest._idisk_id
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0180_deploy_undeploy_vm(self):
-        # Undeploy VM
-        result = VmTest._runner.invoke(
-            vm, args=['undeploy', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        result = VmTest._runner.invoke(
-            vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0190_upgrade_virtual_hardware(self):
-        # Undeploy VM
-        result = VmTest._runner.invoke(
-            vm, args=['undeploy', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        # Upgrade virtual hardware of VM.
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'upgrade-virtual-hardware', VAppConstants.name,
-                VAppConstants.vm1_name
-            ])
-        self.assertEqual(0, result.exit_code)
-        # Again deploy VM for further test cases.
-        result = VmTest._runner.invoke(
-            vm, args=['deploy', VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0200_general_setting_detail(self):
-        # general setting details
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'general-setting', VAppConstants.name, VAppConstants.vm1_name
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0210_list_storage_profile(self):
-        result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'list-storage-profile', VAppConstants.name,
-                VAppConstants.vm1_name
-            ])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0220_reload_from_vc(self):
-        # Reload VM from VC
-        default_org = self._config['vcd']['default_org_name']
-        self._sys_login()
-        VmTest._runner.invoke(org, ['use', default_org])
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-        result = VmTest._runner.invoke(
-            vm, args=['reload-from-vc',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0230_check_compliance(self):
-        # Check compliance of VM
-        result = VmTest._runner.invoke(
-            vm, args=['check-compliance',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        self._logout()
-        self._login()
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-
-    def test_0240_customize_on_next_power_on(self):
-        # Customize on next power on
-        result = VmTest._runner.invoke(
-            vm, args=['customize-on-next-poweron',
-                      VAppConstants.name, VAppConstants.vm1_name])
-
-    def test_0250_gc_enable(self):
-        # Enable guest customization
-        result = VmTest._runner.invoke(
-            vm, args=['gc-enable',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name, '--enable'])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0260_get_gc_status(self):
-        # Get guest customization status
-        result = VmTest._runner.invoke(
-            vm, args=['gc-status',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0270_poweron_and_force_recustomizations(self):
-        # Power off VM.
-        result = VmTest._runner.invoke(
-            vm, args=['undeploy', VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name])
-        self.assertEqual(0, result.exit_code)
-        # Power on and force recustomize VM.
-        result = VmTest._runner.invoke(
-            vm, args=['poweron-force-recustomize',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0280_list_virtual_hardware_section(self):
-        # list virtual hardware section
-        result = VmTest._runner.invoke(
-            vm, args=['list-virtual-hardware-section',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0290_get_compliance_result(self):
-        # Get compliance result
-        default_org = self._config['vcd']['default_org_name']
-        self._sys_login()
-        VmTest._runner.invoke(org, ['use', default_org])
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-        result = VmTest._runner.invoke(
-            vm, args=['get-compliance-result',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-        self._logout()
-        self._login()
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-
-    def test_0300_list_current_metrics(self):
-        # list current metrics
-        result = VmTest._runner.invoke(
-            vm, args=['list-current-metrics',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0310_list_subset_current_metrics(self):
-        # list subset of current metrics based on metric pattern
-        result = VmTest._runner.invoke(
-            vm, args=['list-subset-current-metrics',
+            vm, args=['set-metadata',
                       VAppConstants.name, VAppConstants.vm1_name,
-                      '--metric-pattern', VmTest._metric_pattern])
+                      '--domain', 'GENERAL', '--visibility', 'READ_WRITE',
+                      '--key', 'key1', '--value',
+                      'value1'])
         self.assertEqual(0, result.exit_code)
 
-    def test_0320_update_general_setting(self):
-        # System admin login
-        self._sys_login()
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-        # update general setting
+    def test_0440_update_metadata(self):
+        # update metadata
         result = VmTest._runner.invoke(
-            vm,
-            args=[
-                'update-general-setting', VmTest._vapp_name, VmTest._vm_name,
-                '--name', VmTest._vm_name_update, '--d',
-                VmTest._description_update, '--cn',
-                VmTest._computer_name_update, '--bd',
-                VmTest._boot_delay_update, '--ebs',
-                VmTest._enter_bios_setup_update
-            ])
-        self.assertEqual(0, result.exit_code)
-        # logging out sys_client
-        self._logout()
-        # logging with org admin user
-        self._login()
-
-    def test_0330_relocate(self):
-        # relocate VM to given datastore
-        default_org = self._config['vcd']['default_org_name']
-        self._sys_login()
-        VmTest._runner.invoke(org, ['use', default_org])
-        VmTest._runner.invoke(vdc, ['use', VmTest._default_ovdc])
-        result = VmTest._runner.invoke(
-            vm, args=['relocate',
+            vm, args=['update-metadata',
                       VAppConstants.name, VAppConstants.vm1_name,
-                      '--datastore-id', VmTest._datastore_id])
+                      '--domain', 'GENERAL', '--visibility', 'READ_WRITE',
+                      '--key', 'key1', '--value',
+                      'value2'])
         self.assertEqual(0, result.exit_code)
 
-    def _power_off_and_undeploy(self, vapp):
-        if vapp.is_powered_on():
-            task = vapp.power_off()
-            VmTest._client.get_task_monitor().wait_for_success(task)
-            task = vapp.undeploy()
-            VmTest._client.get_task_monitor().wait_for_success(task)
-
-    def test_0340_list_os_section(self):
-        # list os section properties
+    def test_0450_list_metadata(self):
+        # list metadata
         result = VmTest._runner.invoke(
-            vm, args=['list-os-section',
+            vm, args=['list-metadata',
                       VAppConstants.name, VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
-    def test_0340_update_os_section(self):
-        # update os section properties
+    def test_0460_remove_metadata(self):
+        # remove metadata
         result = VmTest._runner.invoke(
-            vm, args=['update-os-section',
+            vm, args=['remove-metadata',
                       VAppConstants.name, VAppConstants.vm1_name,
-                      '--ovf-info', VmTest._new_ovf_info])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0350_list_gc_section(self):
-        # list gc section properties
-        result = VmTest._runner.invoke(
-            vm, args=['list-gc-section',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0360_update_gc_section(self):
-        # update os section properties
-        result = VmTest._runner.invoke(
-            vm, args=['update-gc-section',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name,
-                      '--disable'])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0370_check_post_gc_script_status(self):
-        # check post gc script status
-        result = VmTest._runner.invoke(
-            vm, args=['check-post-gc-script',
-                      VmTest._test_vapp_vmtools_name,
-                      VmTest._test_vapp_vmtools_vm_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0380_list_vm_capabilities(self):
-        # list vm capabilities section properties
-        result = VmTest._runner.invoke(
-            vm, args=['list-vm-capabilities',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0390_update_vm_capabilities(self):
-        # update vm capabilities section properties
-        result = VmTest._runner.invoke(
-            vm, args=['update-vm-capabilities',
-                      VAppConstants.name, VAppConstants.vm1_name,
-                      '--disable-memory-hot-add'])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0400_list_runtime_info(self):
-        # list runtime info properties
-        result = VmTest._runner.invoke(
-            vm, args=['list-runtime-info',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0410_list_boot_options(self):
-        # list boot options properties
-        result = VmTest._runner.invoke(
-            vm, args=['list-boot-options',
-                      VAppConstants.name, VAppConstants.vm1_name])
-        self.assertEqual(0, result.exit_code)
-
-    def test_0420_update_boot_options(self):
-        # update boot options properties
-        result = VmTest._runner.invoke(
-            vm, args=['update-boot-options',
-                      VAppConstants.name, VAppConstants.vm1_name,
-                      '--disable-enter-bios-setup'])
+                      '--domain', 'GENERAL', '--key', 'key1'])
         self.assertEqual(0, result.exit_code)
 
     def test_9998_tearDown(self):
@@ -655,8 +229,7 @@ class VmTest(BaseTestCase):
         This test passes if the task for deleting the vApp succeed.
         """
         vapps_to_delete = []
-        """
-        Commenting for debug purpose.
+
         if VmTest._empty_vapp_href is not None:
             vapps_to_delete.append(VmTest._empty_vapp_name)
         vapp = VApp(VmTest._client, href=VmTest._test_old_vapp_href)
@@ -667,7 +240,7 @@ class VmTest(BaseTestCase):
         self._power_off_and_undeploy(vapp = vapp)
         vapps_to_delete.append(VmTest._vapp_name)
         vapps_to_delete.append(VmTest._test_vapp_vmtools_name)
-        vapps_to_delete.append(VAppConstants.name)"""
+        vapps_to_delete.append(VAppConstants.name)
         self._sys_login()
         vdc = Environment.get_test_vdc(VmTest._client)
         vdc.delete_disk(name=self._idisk_name)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -288,9 +288,37 @@ def vm(ctx):
             List boot options properties of VM.
 
 \b
-        vcd vm update-boot-options
+        vcd vm update-boot-options vapp1 vm1
                 --enable-enter-bios-setup
             Update boot options properties of VM.
+
+\b
+        vcd vm set-metadata vapp1 vm1
+                --domain GENERAL
+                --visibility READWRITE
+                --key key1
+                --value value1
+                --value-type MetadataStringValue
+            Set metadata of VM.
+
+\b
+        vcd vm update-metadata vapp1 vm1
+                --domain GENERAL
+                --visibility READWRITE
+                --key key1
+                --value value2
+                --value-type MetadataStringValue
+            Update metadata of VM.
+
+\b
+        vcd vm list-metadata vapp1 vm1
+            List metadata of VM.
+
+\b
+        vcd vm remove-metadata vapp1 vm1
+                --domain GENERAL
+                --key key1
+            Remove metadata of VM.
     """
     pass
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -15,6 +15,7 @@
 import click
 from pyvcloud.vcd.client import IpAddressMode
 from pyvcloud.vcd.client import NetworkAdapterType
+from pyvcloud.vcd.utils import metadata_to_dict
 from pyvcloud.vcd.platform import Platform
 from pyvcloud.vcd.utils import vm_to_dict
 from pyvcloud.vcd.vapp import VApp
@@ -1550,5 +1551,164 @@ def update_boot_options(ctx, vapp_name, vm_name,
         task = vm.update_boot_options(boot_delay=boot_delay,
                                       enter_bios_setup=enter_bios_setup)
         stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('list-metadata', short_help='list metadata of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def show_metadata(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = metadata_to_dict(vm.get_metadata())
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('set-metadata', short_help='set an entity as metadata of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'domain',
+    '--domain',
+    type=click.Choice(['GENERAL', 'SYSTEM']),
+    required=True,
+    default=None,
+    metavar='<domain>',
+    help='domain')
+@click.option(
+    'visibility',
+    '--visibility',
+    type=click.Choice(['PRIVATE', 'READONLY', 'READ_WRITE']),
+    required=True,
+    default=None,
+    metavar='<visibility>',
+    help='visibility')
+@click.option(
+    'value_type',
+    '--value-type',
+    type=click.Choice(['STRING', 'NUMBER', 'BOOLEAN', 'DATA_TIME']),
+    required=False,
+    default=None,
+    metavar='<value_type>',
+    help='value_type')
+@click.option(
+    'key',
+    '--key',
+    required=True,
+    default=None,
+    metavar='<key>',
+    help='key')
+@click.option(
+    'value',
+    '--value',
+    required=True,
+    default=None,
+    metavar='<value>',
+    help='value')
+def set_metadata(ctx, vapp_name, vm_name, domain, visibility, value_type, key,
+                 value):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.set_metadata(domain=domain,
+                                 visibility=visibility,
+                                 key=key,
+                                 value=value,
+                                 metadata_type=value_type)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('update-metadata', short_help='update metadata of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'domain',
+    '--domain',
+    type=click.Choice(['GENERAL', 'SYSTEM']),
+    required=True,
+    default=None,
+    metavar='<domain>',
+    help='domain')
+@click.option(
+    'visibility',
+    '--visibility',
+    type=click.Choice(['PRIVATE', 'READONLY', 'READ_WRITE']),
+    required=True,
+    default=None,
+    metavar='<visibility>',
+    help='visibility')
+@click.option(
+    'value_type',
+    '--value-type',
+    type=click.Choice(['STRING', 'NUMBER', 'BOOLEAN', 'DATA_TIME']),
+    required=False,
+    default=None,
+    metavar='<value_type>',
+    help='value_type')
+@click.option(
+    'key',
+    '--key',
+    required=True,
+    default=None,
+    metavar='<key>',
+    help='key')
+@click.option(
+    'value',
+    '--value',
+    required=True,
+    default=None,
+    metavar='<value>',
+    help='value')
+def update_metadata(ctx, vapp_name, vm_name, domain, visibility, value_type,
+                    key,
+                    value):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.set_metadata(domain=domain,
+                                 visibility=visibility,
+                                 key=key,
+                                 value=value,
+                                 metadata_type=value_type)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('remove-metadata', short_help='remove metadata of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+@click.option(
+    'domain',
+    '--domain',
+    type=click.Choice(['GENERAL', 'SYSTEM']),
+    required=True,
+    default=None,
+    metavar='<domain>',
+    help='domain')
+@click.option(
+    'key',
+    '--key',
+    required=True,
+    default=None,
+    metavar='<key>',
+    help='key')
+def remove_metadata(ctx, vapp_name, vm_name, domain, key):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.remove_metadata(domain=domain,
+                                    key=key)
+        stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -14,6 +14,7 @@
 
 import click
 from pyvcloud.vcd.client import IpAddressMode
+from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import NetworkAdapterType
 from pyvcloud.vcd.utils import metadata_to_dict
 from pyvcloud.vcd.platform import Platform
@@ -1584,7 +1585,7 @@ def show_metadata(ctx, vapp_name, vm_name):
 @click.option(
     'visibility',
     '--visibility',
-    type=click.Choice(['PRIVATE', 'READONLY', 'READ_WRITE']),
+    type=click.Choice(['PRIVATE', 'READONLY', 'READWRITE']),
     required=True,
     default=None,
     metavar='<visibility>',
@@ -1592,8 +1593,10 @@ def show_metadata(ctx, vapp_name, vm_name):
 @click.option(
     'value_type',
     '--value-type',
-    type=click.Choice(['STRING', 'NUMBER', 'BOOLEAN', 'DATA_TIME']),
-    required=False,
+    type=click.Choice(
+        ['MetadataStringValue', 'MetadataNumberValue', 'MetadataBooleanValue',
+         'MetadataDateTimeValue']),
+    required=True,
     default=None,
     metavar='<value_type>',
     help='value_type')
@@ -1641,7 +1644,7 @@ def set_metadata(ctx, vapp_name, vm_name, domain, visibility, value_type, key,
 @click.option(
     'visibility',
     '--visibility',
-    type=click.Choice(['PRIVATE', 'READONLY', 'READ_WRITE']),
+    type=click.Choice(['PRIVATE', 'READONLY', 'READWRITE']),
     required=True,
     default=None,
     metavar='<visibility>',
@@ -1649,7 +1652,9 @@ def set_metadata(ctx, vapp_name, vm_name, domain, visibility, value_type, key,
 @click.option(
     'value_type',
     '--value-type',
-    type=click.Choice(['STRING', 'NUMBER', 'BOOLEAN', 'DATA_TIME']),
+    type=click.Choice(
+        ['MetadataStringValue', 'MetadataNumberValue', 'MetadataBooleanValue',
+         'MetadataDateTimeValue']),
     required=False,
     default=None,
     metavar='<value_type>',
@@ -1707,7 +1712,7 @@ def remove_metadata(ctx, vapp_name, vm_name, domain, key):
     try:
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
-        result = vm.remove_metadata(domain=domain,
+        result = vm.remove_metadata(domain=MetadataDomain(domain),
                                     key=key)
         stdout(result, ctx)
     except Exception as e:


### PR DESCRIPTION
VP-2622:[VCD-CLI] list metadata
VP-2849:[VCD-CLI] Update metadat
VP-2851:[VCD-CLI] Remove metadata
VP-2856:[VCD-CLI] get metadata

This CLN contains VM metadata CRUD operations.

Testing Done:
test methods test_0430_set_metadata, test_0440_update_metadata,
test_0450_list_metadata and test_0460_remove_metadata added in
vm_tests.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/479)
<!-- Reviewable:end -->
