### PR TITLE
VP-2754, VP-2756, VP-2758, VP-2760, VP-2811

### DIFF
--- a/system_tests/vapp_network_static_route_tests.py
+++ b/system_tests/vapp_network_static_route_tests.py
@@ -91,9 +91,9 @@ class TestVappStaticRoute(BaseTestCase):
             args=[
                 'network', 'services', 'static-route', 'add',
                 TestVappStaticRoute._vapp_name,
-                TestVappStaticRoute._network_name,
-                TestVappStaticRoute._route_name,
-                TestVappStaticRoute._network_cidr,
+                TestVappStaticRoute._network_name, '--name',
+                TestVappStaticRoute._route_name, '--network',
+                TestVappStaticRoute._network_cidr, '--nhip',
                 TestVappStaticRoute._next_hop_ip
             ])
         self.assertEqual(0, result.exit_code)

--- a/system_tests/vapp_network_static_route_tests.py
+++ b/system_tests/vapp_network_static_route_tests.py
@@ -1,0 +1,180 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.vapp_constants import VAppConstants
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.system_test_framework.environment import developerModeAware
+
+from pyvcloud.vcd.client import TaskStatus
+
+from vcd_cli.login import login, logout
+from vcd_cli.vapp import vapp
+from vcd_cli.org import org
+
+
+class TestVappStaticRoute(BaseTestCase):
+    """Test vapp static route functionalities implemented in pyvcloud."""
+    _vapp_name = VAppConstants.name
+    _network_name = VAppConstants.network1_name
+    _org_vdc_network_name = 'test-direct-vdc-network'
+    _enable = True
+    _disable = False
+    _route_name = 'test_route'
+    _network_cidr = '2.2.3.0/24'
+    _next_hop_ip = '2.2.3.4'
+
+    _update_route_name = 'update_test_route'
+    _update_next_hop_ip = '2.2.3.10'
+
+    def test_0000_setup(self):
+        self._config = Environment.get_config()
+        TestVappStaticRoute._logger = Environment.get_default_logger()
+        TestVappStaticRoute._client = Environment.get_sys_admin_client()
+        TestVappStaticRoute._runner = CliRunner()
+        default_org = self._config['vcd']['default_org_name']
+        self._login()
+        TestVappStaticRoute._runner.invoke(org, ['use', default_org])
+
+        vapp = Environment.get_test_vapp_with_network(
+            TestVappStaticRoute._client)
+        vapp.reload()
+        task = vapp.connect_vapp_network_to_ovdc_network(
+            network_name=TestVappStaticRoute._network_name,
+            orgvdc_network_name=TestVappStaticRoute._org_vdc_network_name)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0010_enable_service(self):
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network',
+                'services',
+                'static-route',
+                'enable-service',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name,
+                '--disable',
+            ])
+        self.assertEqual(0, result.exit_code)
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network',
+                'services',
+                'static-route',
+                'enable-service',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name,
+                '--enable',
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0020_add(self):
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'static-route', 'add',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name,
+                TestVappStaticRoute._route_name,
+                TestVappStaticRoute._network_cidr,
+                TestVappStaticRoute._next_hop_ip
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0030_list(self):
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'static-route', 'list',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0040_update(self):
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'static-route', 'update',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name,
+                TestVappStaticRoute._route_name, '--name',
+                TestVappStaticRoute._update_route_name, '--nhip',
+                TestVappStaticRoute._update_next_hop_ip
+            ])
+        self.assertEqual(0, result.exit_code)
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'static-route', 'update',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name,
+                TestVappStaticRoute._update_route_name, '--name',
+                TestVappStaticRoute._route_name, '--nhip',
+                TestVappStaticRoute._next_hop_ip
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0090_delete(self):
+        result = TestVappStaticRoute._runner.invoke(
+            vapp,
+            args=[
+                'network', 'services', 'static-route', 'delete',
+                TestVappStaticRoute._vapp_name,
+                TestVappStaticRoute._network_name,
+                TestVappStaticRoute._route_name
+            ])
+        self.assertEqual(0, result.exit_code)
+
+    def _login(self):
+        """Logs in using admin credentials"""
+        host = self._config['vcd']['host']
+        org = self._config['vcd']['sys_org_name']
+        admin_user = self._config['vcd']['sys_admin_username']
+        admin_pass = self._config['vcd']['sys_admin_pass']
+        login_args = [
+            host, org, admin_user, "-i", "-w",
+            "--password={0}".format(admin_pass)
+        ]
+        result = TestVappStaticRoute._runner.invoke(login, args=login_args)
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue("logged in" in result.output)
+
+    def _logout(self):
+        """Logs out current session, ignoring errors"""
+        TestVappStaticRoute._runner.invoke(logout)
+
+    @developerModeAware
+    def test_0098_teardown(self):
+        """Test the  method vdc.delete_vapp().
+
+        Invoke the method for all the vApps created by setup.
+
+        This test passes if all the tasks for deleting the vApps succeed.
+        """
+        vdc = Environment.get_test_vdc(TestVappStaticRoute._client)
+        task = vdc.delete_vapp(name=TestVappStaticRoute._vapp_name, force=True)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0099_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        self._logout()

--- a/vcd_cli/vapp_network_static_route.py
+++ b/vcd_cli/vapp_network_static_route.py
@@ -37,7 +37,7 @@ def static_route(ctx):
 
     \b
         vcd vapp network services static-route add vapp_name network_name
-                route_name network_cidr next_hop_ip
+                --name route_name --nhip next_hop_ip --network network_cidr
             Add static route in static route service.
 
     \b
@@ -94,9 +94,21 @@ def enable_service(ctx, vapp_name, network_name, is_enabled):
 @click.pass_context
 @click.argument('vapp_name', metavar='<vapp-name>', required=True)
 @click.argument('network_name', metavar='<network-name>', required=True)
-@click.argument('route_name', metavar='<route-name>', required=True)
-@click.argument('network_cidr', metavar='<network-cidr>', required=True)
-@click.argument('next_hop_ip', metavar='<next-hop-ip>', required=True)
+@click.option('--name',
+              'route_name',
+              required=True,
+              metavar='<route-name>',
+              help='route name')
+@click.option('--network',
+              'network_cidr',
+              required=True,
+              metavar='<network-cidr>',
+              help='network CIDR')
+@click.option('--nhip',
+              'next_hop_ip',
+              required=True,
+              metavar='<next-hop-ip>',
+              help='next hop IP')
 def add(ctx, vapp_name, network_name, route_name, network_cidr, next_hop_ip):
     try:
         static_route = get_vapp_network_static_route(ctx, vapp_name,

--- a/vcd_cli/vapp_network_static_route.py
+++ b/vcd_cli/vapp_network_static_route.py
@@ -37,7 +37,9 @@ def static_route(ctx):
 
     \b
         vcd vapp network services static-route add vapp_name network_name
-                --name route_name --nhip next_hop_ip --network network_cidr
+                --name route_name
+                --nhip next_hop_ip
+                --network network_cidr
             Add static route in static route service.
 
     \b
@@ -46,8 +48,10 @@ def static_route(ctx):
 
     \b
         vcd vapp network services static-route update vapp_name network_name
-                route_name --name new_route_name --nhip next_hop_ip --network
-                network_cidr
+                route_name
+                --name new_route_name
+                --network network_cidr
+                --nhip next_hop_ip
             Update static route in static route service.
 
     \b

--- a/vcd_cli/vapp_network_static_route.py
+++ b/vcd_cli/vapp_network_static_route.py
@@ -1,0 +1,173 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import click
+from pyvcloud.vcd.vapp_static_route import VappStaticRoute
+from vcd_cli.utils import restore_session
+from vcd_cli.utils import stderr
+from vcd_cli.utils import stdout
+from vcd_cli.vapp_network import services
+
+
+@services.group('static-route',
+                short_help='manage static route service of vapp network')
+@click.pass_context
+def static_route(ctx):
+    """Manage static route service of vapp network.
+
+    \b
+        vcd vapp network services static-route enable-service vapp_name
+                network_name --enable
+            Enable static route service.
+
+    \b
+        vcd vapp network services static-route enable-service vapp_name
+                network_name --disable
+            Disable static route service.
+
+    \b
+        vcd vapp network services static-route add vapp_name network_name
+                route_name network_cidr next_hop_ip
+            Add static route in static route service.
+
+    \b
+        vcd vapp network services static-route list vapp_name network_name
+            List static route in static route service.
+
+    \b
+        vcd vapp network services static-route update vapp_name network_name
+                route_name --name new_route_name --nhip next_hop_ip --network
+                network_cidr
+            Update static route in static route service.
+
+    \b
+        vcd vapp network services static-route delete vapp_name network_name
+                route_name
+            Delete static route in static route service.
+    """
+
+
+def get_vapp_network_static_route(ctx, vapp_name, network_name):
+    """Get the VappStaticRoute object.
+
+    It will restore sessions if expired. It will reads the client and
+    creates the VappStaticRoute object.
+    """
+    restore_session(ctx, vdc_required=True)
+    client = ctx.obj['client']
+    vapp_static_route = VappStaticRoute(client, vapp_name, network_name)
+    return vapp_static_route
+
+
+@static_route.command('enable-service',
+                      short_help='enable static route service')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.option('--enable/--disable',
+              'is_enabled',
+              default=True,
+              metavar='<is_enable>',
+              help='enable static route service')
+def enable_service(ctx, vapp_name, network_name, is_enabled):
+    try:
+        static_route = get_vapp_network_static_route(ctx, vapp_name,
+                                                     network_name)
+        result = static_route.enable_service(is_enabled)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@static_route.command('add',
+                      short_help='add static route in static route service')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.argument('route_name', metavar='<route-name>', required=True)
+@click.argument('network_cidr', metavar='<network-cidr>', required=True)
+@click.argument('next_hop_ip', metavar='<next-hop-ip>', required=True)
+def add(ctx, vapp_name, network_name, route_name, network_cidr, next_hop_ip):
+    try:
+        static_route = get_vapp_network_static_route(ctx, vapp_name,
+                                                     network_name)
+        result = static_route.add(route_name, network_cidr, next_hop_ip)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@static_route.command('list',
+                      short_help='list static route in static route service')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+def list(ctx, vapp_name, network_name):
+    try:
+        static_route = get_vapp_network_static_route(ctx, vapp_name,
+                                                     network_name)
+        result = static_route.list()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@static_route.command('update',
+                      short_help='update static route in static route service')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.argument('route_name', metavar='<route-name>', required=True)
+@click.option('--name',
+              'route_new_name',
+              default=None,
+              metavar='<route-new-name>',
+              help='route new name')
+@click.option('--network',
+              'network_cidr',
+              default=None,
+              metavar='<network-cidr>',
+              help='network CIDR')
+@click.option('--nhip',
+              'next_hop_ip',
+              default=None,
+              metavar='<next-hop-ip>',
+              help='next hop IP')
+def update(ctx, vapp_name, network_name, route_name, route_new_name,
+           network_cidr, next_hop_ip):
+    try:
+        static_route = get_vapp_network_static_route(ctx, vapp_name,
+                                                     network_name)
+        result = static_route.update(name=route_name,
+                                     new_name=route_new_name,
+                                     network_cidr=network_cidr,
+                                     next_hop_ip=next_hop_ip)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@static_route.command('delete',
+                      short_help='delete static route in static route service')
+@click.pass_context
+@click.argument('vapp_name', metavar='<vapp-name>', required=True)
+@click.argument('network_name', metavar='<network-name>', required=True)
+@click.argument('route_name', metavar='<route-name>', required=True)
+def list(ctx, vapp_name, network_name, route_name):
+    try:
+        static_route = get_vapp_network_static_route(ctx, vapp_name,
+                                                     network_name)
+        result = static_route.delete(route_name)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)

--- a/vcd_cli/vcd.py
+++ b/vcd_cli/vcd.py
@@ -140,6 +140,7 @@ else:
     from vcd_cli import vapp_network_dhcp  # NOQA
     from vcd_cli import vapp_network_firewall  # NOQA
     from vcd_cli import vapp_network_nat  # NOQA
+    from vcd_cli import vapp_network_static_route  # NOQA
     from vcd_cli import vc  # NOQA
     from vcd_cli import vdc  # NOQA
     from vcd_cli import vm  # NOQA


### PR DESCRIPTION
VP-2754: [VcdCli] Enable static routing in vapp network
VP-2756: [VcdCli] Add static route in vapp network
VP-2758: [VcdCli] Update static route in vapp network
VP-2760: [VcdCli] Delete static route in vapp network
VP-2811: [VcdCli] List static route in vapp network

This CLN contains a commands for Enable, Add, Update, Delete, List static route in vapp network and corresponding test case.
It can be called as
     vcd vapp network services static-route enable-service vapp_name   network_name --enable
     vcd vapp network services static-route enable-service vapp_name   network_name --disable
     vcd vapp network services static-route add vapp_name network_name route_name network_cidr 
          next_hop_ip
     vcd vapp network services static-route list vapp_name network_name 
     vcd vapp network services static-route update vapp_name network_name  route_name --name 
          new_route_name --nhip next_hop_ip --network network_cidr
     vcd vapp network services static-route delete vapp_name network_name route_name           


Testing Done:
Test methods test_0010_enable_service(), test_0020_add(),  test_0030_list(), test_0040_update() and test_0090_delete()  are added in
class vapp_network_static_route_tests.py and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/480)
<!-- Reviewable:end -->
