### PR TITLE
VP-2647,VP-2645,VP-2628: Ticket, mks ticket and product sections oper…

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -703,6 +703,27 @@ class VmTest(BaseTestCase):
                       '--domain', 'GENERAL', '--key', 'key1'])
         self.assertEqual(0, result.exit_code)
 
+    def test_0470_list_screen_ticket(self):
+        # list screen ticket
+        result = VmTest._runner.invoke(
+            vm, args=['list-screen-ticket',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0480_mks_ticket(self):
+        # list mks ticket
+        result = VmTest._runner.invoke(
+            vm, args=['list-screen-ticket',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_0490_list_product_sections(self):
+        # list product sections
+        result = VmTest._runner.invoke(
+            vm, args=['list-product-sections',
+                      VAppConstants.name, VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_9998_tearDown(self):
         """Delete the vApp created during setup.
 

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -319,6 +319,18 @@ def vm(ctx):
                 --domain GENERAL
                 --key key1
             Remove metadata of VM.
+
+\b
+        vcd vm list-screen-ticket vapp1 vm1
+            List screen ticket of VM.
+
+\b
+        vcd vm list-mks-ticket vapp1 vm1
+            List mks ticket of VM.
+
+\b
+        vcd vm list-product-sections vapp1 vm1
+            List product sections of VM.
     """
     pass
 
@@ -1742,6 +1754,48 @@ def remove_metadata(ctx, vapp_name, vm_name, domain, key):
         vm = _get_vm(ctx, vapp_name, vm_name)
         result = vm.remove_metadata(domain=MetadataDomain(domain),
                                     key=key)
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('list-screen-ticket', short_help='list screen ticket of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_screen_ticket(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_screen_ticket()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('list-mks-ticket', short_help='list mks ticket of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_mks_ticket(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_mks_ticket()
+        stdout(result, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+
+@vm.command('list-product-sections', short_help='list product sections of VM')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def list_product_sections(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        result = vm.list_product_sections()
         stdout(result, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
VP-2647:[VCD-CLI] [PYSDK]screen:acquireMksTicket
VP-2645:[VCD-CLI] screen:acquireTicket
VP-2628:[VCD-CLI] get product section

This CLN contains ticket and product sections operations. These can be
called from command line as follows:
vcd vm list-screen-ticket vapp1 vm1
vcd vm list-mks-ticket vapp1 vm1
vcd vm list-product-sections vapp1 vm1

Testing Done:
Test methods test_0470_list_screen_ticket, test_0480_mks_ticket and
test_0490_list_product_sections are added in vm_tests.py file.
