### PR TITLE
[VCD-CLI] Remove snapshot of VM.

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -386,6 +386,13 @@ class VmTest(BaseTestCase):
                       VAppConstants.vm1_name])
         self.assertEqual(0, result.exit_code)
 
+    def test_0155_remove_snapshot(self):
+        """Remove VM snapshot."""
+        result = VmTest._runner.invoke(
+            vm, args=['remove-snapshot', VAppConstants.name,
+                      VAppConstants.vm1_name])
+        self.assertEqual(0, result.exit_code)
+
     def test_0160_attach_disk_to_vm(self):
         """Attach independent disk to VM."""
         result = VmTest._runner.invoke(

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -143,6 +143,10 @@ def vm(ctx):
             Revert VM to current snapshot.
 
 \b
+        vcd vm remove-snapshot vapp1 vm1
+            Remove VM snapshot.
+
+\b
         vcd vm copy vapp1 vm1 vapp2 vm2
             Copy VM from one vapp to another vapp.
 
@@ -802,6 +806,19 @@ def revert_to_snapshot(ctx, vapp_name, vm_name):
         restore_session(ctx, vdc_required=True)
         vm = _get_vm(ctx, vapp_name, vm_name)
         task = vm.snapshot_revert_to_current()
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vm.command('remove-snapshot', short_help='remove VM snaphot')
+@click.pass_context
+@click.argument('vapp-name', metavar='<vapp-name>', required=True)
+@click.argument('vm-name', metavar='<vm-name>', required=True)
+def remove_snapshot(ctx, vapp_name, vm_name):
+    try:
+        restore_session(ctx, vdc_required=True)
+        vm = _get_vm(ctx, vapp_name, vm_name)
+        task = vm.snapshot_remove_all()
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)


### PR DESCRIPTION
[VCD-CLI] Remove snapshot of VM.

This can be called from comand line as :

vcd vm remove-snapshot vapp1 vm1

Testing Done:
Test method test_0155_remove_snapshot is added in vm_tests.py.
