### PR TITLE
[VCDA - 1341] Added JWT based authorization support in vcd-cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ keyring >= 10.6.0, <= 12.0.0
 # Pycryptodome 3.5.0 does not compile on Mac OS X.
 pycryptodome >= 3.4.7,<3.5
 pypiwin32 >= 223;platform_system=="Windows"
-pyvcloud >= 20.1.1.dev26
+pyvcloud >= 21.0.1.dev7
 tabulate >= 0.7.5
 unittest-xml-reporting >= 2.2.1

--- a/vcd_cli/profiles.py
+++ b/vcd_cli/profiles.py
@@ -61,7 +61,6 @@ class Profiles(object):
                user,
                token,
                api_version,
-               wkep,
                verify,
                disable_warnings,
                vdc,
@@ -72,34 +71,38 @@ class Profiles(object):
                log_body,
                vapp,
                vapp_href,
-               name='default'):
+               name='default',
+               is_jwt_token=False):
         if self.data is None:
             self.data = {}
         if 'profiles' not in self.data:
             self.data['profiles'] = []
+
         profile = {}
         profile['name'] = str(name)
         profile['host'] = str(host)
         profile['org'] = str(org)
         profile['user'] = str(user)
         profile['token'] = str(token)
+        profile['is_jwt_token'] = is_jwt_token
         profile['api_version'] = str(api_version)
         profile['verify'] = verify
         profile['log_request'] = log_request
         profile['log_header'] = log_header
         profile['log_body'] = log_body
         profile['disable_warnings'] = disable_warnings
-        profile['wkep'] = wkep
         profile['org_in_use'] = str(org)
         profile['vdc_in_use'] = str(vdc)
         profile['vapp_in_use'] = str(vapp)
         profile['org_href'] = str(org_href)
         profile['vdc_href'] = str(vdc_href)
         profile['vapp_href'] = str(vapp_href)
+
         tmp = [profile]
         for p in self.data['profiles']:
             if p['name'] != name:
                 tmp.append(p)
+
         self.data['profiles'] = tmp
         self.data['active'] = str(name)
         self.save()

--- a/vcd_cli/task.py
+++ b/vcd_cli/task.py
@@ -55,7 +55,7 @@ def info(ctx, task_id):
     try:
         restore_session(ctx)
         client = ctx.obj['client']
-        result = client.get_resource('%s/task/%s' % (client._uri, task_id))
+        result = client.get_resource(f"{client.get_api_uri()}/task/{task_id}")
         stdout(task_to_dict(result), ctx, show_id=True)
     except Exception as e:
         stderr(e, ctx)
@@ -96,7 +96,7 @@ def wait(ctx, task_id):
     try:
         restore_session(ctx)
         client = ctx.obj['client']
-        task = client.get_resource('%s/task/%s' % (client._uri, task_id))
+        task = client.get_resource(f"{client.get_api_uri()}/task/{task_id}")
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
@@ -114,7 +114,7 @@ def update(ctx, status, task_id):
     try:
         restore_session(ctx)
         client = ctx.obj['client']
-        task = client.get_resource('%s/task/%s' % (client._uri, task_id))
+        task = client.get_resource(f"{client.get_api_uri()}/task/{task_id}")
         task.set('status', status)
         result = client.put_linked_resource(task, RelationType.EDIT,
                                             EntityType.TASK.value, task)

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -13,7 +13,6 @@
 #
 import collections
 import json
-import logging
 from os import environ
 import re
 import sys
@@ -26,8 +25,8 @@ from pygments import formatters
 from pygments import highlight
 from pygments import lexers
 from pyvcloud.vcd.client import Client
-from pyvcloud.vcd.client import get_logger
 from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import get_logger
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import AccessForbiddenException

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -92,9 +92,7 @@ def as_metavar(values):
 
 
 def restore_session(ctx, vdc_required=False):
-    if type(
-            ctx.obj
-    ) is dict and 'client' in ctx.obj and ctx.obj['client'] is not None:
+    if type(ctx.obj) is dict and 'client' in ctx.obj and ctx.obj['client']:
         return
     profiles = Profiles.load()
     token = profiles.get('token')
@@ -112,6 +110,7 @@ def restore_session(ctx, vdc_required=False):
                 fg='yellow',
                 err=True)
         requests.packages.urllib3.disable_warnings()
+
     client = Client(
         profiles.get('host'),
         api_version=profiles.get('api_version'),
@@ -120,7 +119,9 @@ def restore_session(ctx, vdc_required=False):
         log_requests=profiles.get('log_request'),
         log_headers=profiles.get('log_header'),
         log_bodies=profiles.get('log_body'))
-    client.rehydrate(profiles)
+    client.rehydrate_from_token(
+        profiles.get('token'), profiles.get('is_jwt_token'))
+
     ctx.obj = {}
     ctx.obj['client'] = client
     ctx.obj['profiles'] = profiles


### PR DESCRIPTION
In response to https://github.com/vmware/pyvcloud/pull/637, made the necessary changes in vcd-cli so that vcd-cli can leverage the JWT token for authentication and session restoration.

This changes made in this PR are as follows
* Added a new field in profile to distinguish between x-vcloud-authorization and jwt token
* Addressed removal of rehydrate methods from pyvcloud's client.py
* Adjusted code to accomodate the new streamlined api version negotiation code in pyvcloud.
* Got rid of well known endpoints from profiles, it was not being used anywhere.
* Minor flake8 changes

Testing done:
Manually invoke vcd login command with different api versions, and looked at the logs and profile.yaml to make sure that the correct end points are being used and the right token is being saved. Also tested that subsequent operations e.g. listing of orgs, info on vdc etc. are working fine for all both sys admins and regular tenant users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/510)
<!-- Reviewable:end -->
