### PR TITLE
Updating pycryptodome to 3.6.6

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,4 +44,5 @@ pandeys <pandeys@vmware.com>
 rajeshk2013 <43401283+rajeshk2013@users.noreply.github.com>
 rocknes <aritra.iitkgp@gmail.com>
 sahithi <sahithi.ayloo@gmail.com>
+shashim <shashim@vmware.com>
 shashim22 <43600948+shashim22@users.noreply.github.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,24 @@
 CHANGES
 =======
 
+23.0.0
+------
+
+* Restricting pyvcloud version to >= 22.0.0 and < 23.0.0
+
+22.0.2
+------
+
+* Updating pyvcloud version to latest release version (#513)
+* Updating pyvcloud version to latest release version
+
+22.0.1
+------
+
+* [VCDA - 1341] Added JWT based authorization support in vcd-cli (#510)
+* [VCD-CLI] Remove snapshot of VM. (#496)
+* Updating Authors and ChangeLOg in github
+
 22.0.0
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 click >= 7.0
 colorama >= 0.3.9
 keyring >= 10.6.0, <= 12.0.0
-# Pycryptodome 3.5.0 does not compile on Mac OS X.
-pycryptodome >= 3.4.7,<3.5
+pycryptodome == 3.6.6
 pypiwin32 >= 223;platform_system=="Windows"
 pyvcloud >= 22.0.0, < 23.0.0
 tabulate >= 0.7.5


### PR DESCRIPTION
[Bug-2423198]: [OSS] - CSE/VCD-CLI fixed pycryptodome version is vulnerable to integer overflow when version < 3.6.6

Updating Changelog and AUTHORS too.

@rajeshk2013 
