### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/system_tests/login_and_vcd_tests.py
+++ b/system_tests/login_and_vcd_tests.py
@@ -141,7 +141,7 @@ class LoginAndVcdTest(BaseTestCase):
         result = self._runner.invoke(version)
         self.assertEqual(0, result.exit_code)
         self.assertTrue("vcd-cli" in result.output, msg=result.output)
-        version_pattern = re.compile('[0-9]+\.[0-3]+\.[0-9]+')
+        version_pattern = re.compile(r'[0-9]+\.[0-3]+\.[0-9]+')
         self.assertTrue(
             version_pattern.search(result.output) is not None,
             msg=result.output)

--- a/vcd_cli/catalog.py
+++ b/vcd_cli/catalog.py
@@ -62,7 +62,7 @@ def catalog(ctx):
             Get list of items in a catalog.
 \b
         vcd catalog list '*'
-        vcd catalog list \*
+        vcd catalog list \\*
             Get list of items in all catalogs in current organization.
 \b
         vcd catalog upload my-catalog photon.ova

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -11,7 +11,7 @@
 # code for the these subcomponents is subject to the terms and
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
-import collections
+import collections.abc
 import json
 from os import environ
 import re
@@ -219,7 +219,7 @@ def stdout(obj, ctx=None, alt_text=None, show_id=False,
                                     task.get('operation'),
                                     task.get('status'))
                 elif ctx.command.name == 'list' and \
-                        isinstance(obj, collections.Iterable):
+                        isinstance(obj, collections.abc.Iterable):
                     text = as_table(obj)
                 elif ctx.command.name == 'info':
                     text = as_table(


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- Importing ABC directly from collections has been deprecated and will be removed in Python 3.10. Use collections.abc since Python 2 is not supported.