### PR TITLE
Fix arg names for dhcp pool crete, update docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,6 +22,10 @@
 <a href="vcd_catalog_upload">upload</a></li>
 </ul></li>
 <li>
+<a href="vcd_datastore">datastore</a><ul><li>
+<a href="vcd_datastore_list">list</a></li>
+</ul></li>
+<li>
 <a href="vcd_disk">disk</a><ul><li>
 <a href="vcd_disk_change-owner">change-owner</a></li><li>
 <a href="vcd_disk_create">create</a></li><li>
@@ -259,6 +263,7 @@
 <li>
 <a href="vcd_role">role</a><ul><li>
 <a href="vcd_role_add-right">add-right</a></li><li>
+<a href="vcd_role_clone">clone</a></li><li>
 <a href="vcd_role_create">create</a></li><li>
 <a href="vcd_role_delete">delete</a></li><li>
 <a href="vcd_role_info">info</a></li><li>
@@ -312,6 +317,7 @@
 <li>
 <a href="vcd_vapp_add-disk">add-disk</a></li><li>
 <a href="vcd_vapp_add-vm">add-vm</a></li><li>
+<a href="vcd_vapp_add-vm-scratch">add-vm-scratch</a></li><li>
 <a href="vcd_vapp_attach">attach</a></li><li>
 <a href="vcd_vapp_capture">capture</a></li><li>
 <a href="vcd_vapp_change-owner">change-owner</a></li><li>
@@ -322,9 +328,11 @@
 <a href="vcd_vapp_delete">delete</a></li><li>
 <a href="vcd_vapp_deploy">deploy</a></li><li>
 <a href="vcd_vapp_detach">detach</a></li><li>
+<a href="vcd_vapp_disable-download">disable-download</a></li><li>
 <a href="vcd_vapp_discard-suspended-state">discard-suspended-state</a></li><li>
 <a href="vcd_vapp_disconnect">disconnect</a></li><li>
 <a href="vcd_vapp_download">download</a></li><li>
+<a href="vcd_vapp_enable-download">enable-download</a></li><li>
 <a href="vcd_vapp_enter-maintenance-mode">enter-maintenance-mode</a></li><li>
 <a href="vcd_vapp_exit-maintenance-mode">exit-maintenance-mode</a></li><li>
 <a href="vcd_vapp_info">info</a></li><li>
@@ -335,11 +343,14 @@
 <a href="vcd_vapp_network_add-ip-range">add-ip-range</a></li><li>
 <a href="vcd_vapp_network_connect-ovdc">connect-ovdc</a></li><li>
 <a href="vcd_vapp_network_create">create</a></li><li>
+<a href="vcd_vapp_network_create-ovdc-network">create-ovdc-network</a></li><li>
 <a href="vcd_vapp_network_delete">delete</a></li><li>
 <a href="vcd_vapp_network_delete-ip-range">delete-ip-range</a></li><li>
 <a href="vcd_vapp_network_dns-info">dns-info</a></li><li>
+<a href="vcd_vapp_network_enable-fence">enable-fence</a></li><li>
 <a href="vcd_vapp_network_list">list</a></li><li>
 <a href="vcd_vapp_network_list-allocated-ip">list-allocated-ip</a></li><li>
+<a href="vcd_vapp_network_list-vm-interface">list-vm-interface</a></li><li>
 <a href="vcd_vapp_network_reset">reset</a></li><li>
 <a href="vcd_vapp_network_services">services</a><ul><li>
 <a href="vcd_vapp_network_services_dhcp">dhcp</a><ul><li>
@@ -348,7 +359,30 @@
 </ul></li>
 <li>
 <a href="vcd_vapp_network_services_firewall">firewall</a><ul><li>
-<a href="vcd_vapp_network_services_firewall_enable-firewall">enable-firewall</a></li>
+<a href="vcd_vapp_network_services_firewall_add">add</a></li><li>
+<a href="vcd_vapp_network_services_firewall_delete">delete</a></li><li>
+<a href="vcd_vapp_network_services_firewall_enable-firewall">enable-firewall</a></li><li>
+<a href="vcd_vapp_network_services_firewall_list">list</a></li><li>
+<a href="vcd_vapp_network_services_firewall_set-default-action">set-default-action</a></li><li>
+<a href="vcd_vapp_network_services_firewall_update">update</a></li>
+</ul></li>
+<li>
+<a href="vcd_vapp_network_services_nat">nat</a><ul><li>
+<a href="vcd_vapp_network_services_nat_add">add</a></li><li>
+<a href="vcd_vapp_network_services_nat_delete">delete</a></li><li>
+<a href="vcd_vapp_network_services_nat_enable-nat">enable-nat</a></li><li>
+<a href="vcd_vapp_network_services_nat_get-nat-type">get-nat-type</a></li><li>
+<a href="vcd_vapp_network_services_nat_list">list</a></li><li>
+<a href="vcd_vapp_network_services_nat_set-nat-type">set-nat-type</a></li><li>
+<a href="vcd_vapp_network_services_nat_update">update</a></li>
+</ul></li>
+<li>
+<a href="vcd_vapp_network_services_static-route">static-route</a><ul><li>
+<a href="vcd_vapp_network_services_static-route_add">add</a></li><li>
+<a href="vcd_vapp_network_services_static-route_delete">delete</a></li><li>
+<a href="vcd_vapp_network_services_static-route_enable-service">enable-service</a></li><li>
+<a href="vcd_vapp_network_services_static-route_list">list</a></li><li>
+<a href="vcd_vapp_network_services_static-route_update">update</a></li>
 </ul></li>
 </ul></li>
 <li>
@@ -364,12 +398,18 @@
 <a href="vcd_vapp_remove-snapshot">remove-snapshot</a></li><li>
 <a href="vcd_vapp_reset">reset</a></li><li>
 <a href="vcd_vapp_revert-to-snapshot">revert-to-snapshot</a></li><li>
+<a href="vcd_vapp_show-lease">show-lease</a></li><li>
+<a href="vcd_vapp_show-metadata">show-metadata</a></li><li>
+<a href="vcd_vapp_show-product-section">show-product-section</a></li><li>
+<a href="vcd_vapp_show-startup-section">show-startup-section</a></li><li>
 <a href="vcd_vapp_shutdown">shutdown</a></li><li>
 <a href="vcd_vapp_stop">stop</a></li><li>
 <a href="vcd_vapp_suspend">suspend</a></li><li>
 <a href="vcd_vapp_undeploy">undeploy</a></li><li>
 <a href="vcd_vapp_update">update</a></li><li>
 <a href="vcd_vapp_update-lease">update-lease</a></li><li>
+<a href="vcd_vapp_update-product-section">update-product-section</a></li><li>
+<a href="vcd_vapp_update-startup-section">update-startup-section</a></li><li>
 <a href="vcd_vapp_upgrade-virtual-hardware">upgrade-virtual-hardware</a></li><li>
 <a href="vcd_vapp_use">use</a></li>
 </ul></li>
@@ -399,6 +439,8 @@
 <a href="vcd_vdc_enable">enable</a></li><li>
 <a href="vcd_vdc_info">info</a></li><li>
 <a href="vcd_vdc_list">list</a></li><li>
+<a href="vcd_vdc_list-disk">list-disk</a></li><li>
+<a href="vcd_vdc_list-media">list-media</a></li><li>
 <a href="vcd_vdc_use">use</a></li>
 </ul></li>
 <li>
@@ -407,6 +449,7 @@
 <a href="vcd_vm_add-nic">add-nic</a></li><li>
 <a href="vcd_vm_attach-disk">attach-disk</a></li><li>
 <a href="vcd_vm_check-compliance">check-compliance</a></li><li>
+<a href="vcd_vm_check-post-gc-script">check-post-gc-script</a></li><li>
 <a href="vcd_vm_consolidate">consolidate</a></li><li>
 <a href="vcd_vm_copy">copy</a></li><li>
 <a href="vcd_vm_create-snapshot">create-snapshot</a></li><li>
@@ -417,24 +460,56 @@
 <a href="vcd_vm_detach-disk">detach-disk</a></li><li>
 <a href="vcd_vm_discard-suspend">discard-suspend</a></li><li>
 <a href="vcd_vm_eject-cd">eject-cd</a></li><li>
+<a href="vcd_vm_enable-nested-hypervisor">enable-nested-hypervisor</a></li><li>
+<a href="vcd_vm_gc-enable">gc-enable</a></li><li>
+<a href="vcd_vm_gc-status">gc-status</a></li><li>
 <a href="vcd_vm_general-setting">general-setting</a></li><li>
+<a href="vcd_vm_get-compliance-result">get-compliance-result</a></li><li>
 <a href="vcd_vm_info">info</a></li><li>
 <a href="vcd_vm_insert-cd">insert-cd</a></li><li>
 <a href="vcd_vm_install-vmware-tools">install-vmware-tools</a></li><li>
 <a href="vcd_vm_list">list</a></li><li>
+<a href="vcd_vm_list-boot-options">list-boot-options</a></li><li>
+<a href="vcd_vm_list-current-metrics">list-current-metrics</a></li><li>
+<a href="vcd_vm_list-gc-section">list-gc-section</a></li><li>
+<a href="vcd_vm_list-historic-metrics">list-historic-metrics</a></li><li>
+<a href="vcd_vm_list-metadata">list-metadata</a></li><li>
+<a href="vcd_vm_list-mks-ticket">list-mks-ticket</a></li><li>
 <a href="vcd_vm_list-nics">list-nics</a></li><li>
+<a href="vcd_vm_list-os-section">list-os-section</a></li><li>
+<a href="vcd_vm_list-product-sections">list-product-sections</a></li><li>
+<a href="vcd_vm_list-runtime-info">list-runtime-info</a></li><li>
+<a href="vcd_vm_list-sample-historic-data">list-sample-historic-data</a></li><li>
+<a href="vcd_vm_list-screen-ticket">list-screen-ticket</a></li><li>
 <a href="vcd_vm_list-storage-profile">list-storage-profile</a></li><li>
+<a href="vcd_vm_list-subset-current-metrics">list-subset-current-metrics</a></li><li>
+<a href="vcd_vm_list-virtual-hardware-section">list-virtual-hardware-section</a></li><li>
+<a href="vcd_vm_list-vm-capabilities">list-vm-capabilities</a></li><li>
 <a href="vcd_vm_move">move</a></li><li>
 <a href="vcd_vm_power-off">power-off</a></li><li>
 <a href="vcd_vm_power-on">power-on</a></li><li>
+<a href="vcd_vm_poweron-force-recustomize">poweron-force-recustomize</a></li><li>
 <a href="vcd_vm_reboot">reboot</a></li><li>
 <a href="vcd_vm_reload-from-vc">reload-from-vc</a></li><li>
+<a href="vcd_vm_relocate">relocate</a></li><li>
+<a href="vcd_vm_remove-metadata">remove-metadata</a></li><li>
+<a href="vcd_vm_remove-snapshot">remove-snapshot</a></li><li>
 <a href="vcd_vm_reset">reset</a></li><li>
 <a href="vcd_vm_revert-to-snapshot">revert-to-snapshot</a></li><li>
+<a href="vcd_vm_set-metadata">set-metadata</a></li><li>
 <a href="vcd_vm_shutdown">shutdown</a></li><li>
 <a href="vcd_vm_suspend">suspend</a></li><li>
 <a href="vcd_vm_undeploy">undeploy</a></li><li>
 <a href="vcd_vm_update">update</a></li><li>
+<a href="vcd_vm_update-boot-options">update-boot-options</a></li><li>
+<a href="vcd_vm_update-gc-section">update-gc-section</a></li><li>
+<a href="vcd_vm_update-general-setting">update-general-setting</a></li><li>
+<a href="vcd_vm_update-metadata">update-metadata</a></li><li>
+<a href="vcd_vm_update-nic">update-nic</a></li><li>
+<a href="vcd_vm_update-os-section">update-os-section</a></li><li>
+<a href="vcd_vm_update-vhs-disk">update-vhs-disk</a></li><li>
+<a href="vcd_vm_update-vhs-media">update-vhs-media</a></li><li>
+<a href="vcd_vm_update-vm-capabilities">update-vm-capabilities</a></li><li>
 <a href="vcd_vm_upgrade-virtual-hardware">upgrade-virtual-hardware</a></li></ul>
 </li></ul>
 </li></ul>

--- a/docs/vcd.md
+++ b/docs/vcd.md
@@ -19,30 +19,31 @@ Options:
   -h, --help                    Show this message and exit.
 
 Commands:
-  catalog  work with catalogs
-  disk     manage independent disks
-  gateway  manage edge gateways
-  help     show help
-  info     show resource details
-  login    login to vCD
-  logout   logout from vCD
-  netpool  work with network pools
-  network  work with vcd networks
-  nsxt     manage NSX-T managers
-  org      work with organizations
-  profile  manage profiles
-  pvdc     work with provider virtual datacenters
-  pwd      current resources in use
-  right    work with rights
-  role     work with roles
-  search   search resources
-  system   manage system settings
-  task     work with tasks
-  user     work with users in current organization
-  vapp     manage vApps
-  vc       manage vCenter Servers
-  vdc      work with virtual datacenters
-  version  show version
-  vm       manage VMs
+  catalog    work with catalogs
+  datastore  manage datastores
+  disk       manage independent disks
+  gateway    manage edge gateways
+  help       show help
+  info       show resource details
+  login      login to vCD
+  logout     logout from vCD
+  netpool    work with network pools
+  network    work with vcd networks
+  nsxt       manage NSX-T managers
+  org        work with organizations
+  profile    manage profiles
+  pvdc       work with provider virtual datacenters
+  pwd        current resources in use
+  right      work with rights
+  role       work with roles
+  search     search resources
+  system     manage system settings
+  task       work with tasks
+  user       work with users in current organization
+  vapp       manage vApps
+  vc         manage vCenter Servers
+  vdc        work with virtual datacenters
+  version    show version
+  vm         manage VMs
 
 ```

--- a/docs/vcd_catalog_acl_share.md
+++ b/docs/vcd_catalog_acl_share.md
@@ -4,6 +4,7 @@ Usage: vcd catalog acl share [OPTIONS] <catalog-name>
 Options:
   --access-level <access-level>  access level at which the catalog is shared.
                                  ReadOnly by default
+
   -h, --help                     Show this message and exit.
 
 ```

--- a/docs/vcd_datastore.md
+++ b/docs/vcd_datastore.md
@@ -1,0 +1,18 @@
+```
+Usage: vcd datastore [OPTIONS] COMMAND [ARGS]...
+
+  Manage datastores in vCloud Director.
+
+      Examples
+          vcd datastore list
+              Get list of datastores attached to the vCD system.
+
+
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  list  list datastores
+
+```

--- a/docs/vcd_datastore_list.md
+++ b/docs/vcd_datastore_list.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd datastore list [OPTIONS]
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_disk_create.md
+++ b/docs/vcd_disk_create.md
@@ -6,6 +6,7 @@ Options:
                                   Description of the new disk
   -s, --storage-profile <name>    Name of the Storage Profile to be used for
                                   the new disk.
+
   -i, --iops <iops>               Iops requirements of the new disk
   -h, --help                      Show this message and exit.
 

--- a/docs/vcd_disk_update.md
+++ b/docs/vcd_disk_update.md
@@ -8,6 +8,7 @@ Options:
                                   New Description of the disk
   -S, --storage-profile <name>    Name of the new Storage Profile to be used
                                   for the disk.
+
   -i, --iops <iops>               New iops requirement of the disk
   -h, --help                      Show this message and exit.
 

--- a/docs/vcd_gateway_configure-default-gateway_update.md
+++ b/docs/vcd_gateway_configure-default-gateway_update.md
@@ -5,6 +5,7 @@ Options:
   -e, --external-network <external network>
                                   external network connected to the gateway.
                                   [required]
+
   -i, --gateway-ip <ip>           IP of the gateway.  [required]
   --enable / --disable            enables/disables the default gateway
   -h, --help                      Show this message and exit.

--- a/docs/vcd_gateway_configure-external-network_add.md
+++ b/docs/vcd_gateway_configure-external-network_add.md
@@ -5,6 +5,7 @@ Options:
   -e, --external-network <external network>
                                   external network to which the gateway can
                                   connect.  [required]
+
   --configure-ip-setting <subnet> <configured IP>
                                   configuring multiple IP settings
   -h, --help                      Show this message and exit.

--- a/docs/vcd_gateway_configure-external-network_remove.md
+++ b/docs/vcd_gateway_configure-external-network_remove.md
@@ -5,6 +5,7 @@ Options:
   -e, --external-network <external network>
                                   external network that needs to be removed
                                   from the gateway.  [required]
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_gateway_configure-ip-settings.md
+++ b/docs/vcd_gateway_configure-ip-settings.md
@@ -5,6 +5,7 @@ Options:
   -e, --external-network <external network>
                                   external networks to which the new gateway
                                   can connect.  [required]
+
   -s, --subnet-available <subnet> <enable> <ip>
                                   set the subnet settings  [required]
   -h, --help                      Show this message and exit.

--- a/docs/vcd_gateway_configure-rate-limits_disable.md
+++ b/docs/vcd_gateway_configure-rate-limits_disable.md
@@ -5,6 +5,7 @@ Options:
   -e, --external-network <external network>
                                   external network connected to the gateway.
                                   [required]
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_gateway_create.md
+++ b/docs/vcd_gateway_create.md
@@ -5,13 +5,16 @@ Options:
   -e, --external-network <external network>
                                   list of external networks to which the new
                                   gateway can connect.  [required]
+
   --description <description>     description
   --default-gateway <external_network>
                                   name of external network for default gateway
                                   configuration
+
   --default-gateway-ip <default gateway IP>
                                   IP from the external network for the default
                                   gateway
+
   --dns-relay-enabled / --dns-relay-disabled
                                   DNS relay enabled/disabled
   -c, --gateway-config <gateway_config>
@@ -22,19 +25,24 @@ Options:
   --distributed-routing-enabled / --distributed-routing-disabled
                                   enable distributed routing for networks
                                   connected to this gateway.
+
   --configure-ip-setting <external network> <subnet> <configured IP>
                                   configuring multiple ip settings
   --sub-allocate-ip <external network>
                                   sub-allocate the IP Pools provided by the
                                   externally connected interfaces
+
   --subnet <external network subnet>
                                   subnet for the selected external network for
                                   IP sub allocation
+
   --ip-range <IP ranges>          IP ranges pertaining to external network's
                                   IP Pool
+
   --configure-rate-limit <external network> <incoming rate limit> <outgoing rate limit>
                                   specify the inbound and outbound rate limits
                                   for each externally connected interface.
+
   --flip-flop-enabled / --flip-flop-disabled
                                   flip flip mode
   --gateway-type NSXV_BACKED/NSXT_BACKED/NSXT_IMPORTED

--- a/docs/vcd_gateway_enable-distributed-routing.md
+++ b/docs/vcd_gateway_enable-distributed-routing.md
@@ -4,6 +4,7 @@ Usage: vcd gateway enable-distributed-routing [OPTIONS] <gateway name>
 Options:
   --enable / --disable  Enable distributed routing for networks connected to
                         this gateway.
+
   -h, --help            Show this message and exit.
 
 ```

--- a/docs/vcd_gateway_services_dhcp-pool_create.md
+++ b/docs/vcd_gateway_services_dhcp-pool_create.md
@@ -6,14 +6,14 @@ Options:
                                   IP range of the DHCP pool  [required]
   --enable-auto-dns / --disable-auto-dns
                                   Auto configure DNS
-  -g--gateway-ip <default-gateway-ip>
+  -g, --gateway-ip <default-gateway-ip>
                                   Default gateway ip
-  -d--domain <domain-name>        domain name
-  -p--primary-server <primary-name-server>
+  -d, --domain <domain-name>      domain name
+  -p, --primary-server <primary-name-server>
                                   primary server ip
-  -s--secondary-server <secondary-name-server>
+  -s, --secondary-server <secondary-name-server>
                                   secondary server ip
-  -l--lease <lease-time>          lease time
+  -l, --lease <lease-time>        lease time
   --never-expire-lease / --expire-lease
                                   lease lease expire
   --subnet <subnet>               subnet mask

--- a/docs/vcd_gateway_services_firewall.md
+++ b/docs/vcd_gateway_services_firewall.md
@@ -79,6 +79,7 @@ Commands:
   delete              delete firewall rule
   delete-destination  delete firewall rule's destination value of a firewall
                       rule
+
   delete-service      delete firewall rule's service of a firewall rule
   delete-source       delete firewall rule's source value of a firewall rule
   disable             disable firewall rule

--- a/docs/vcd_gateway_services_firewall_list-object-types.md
+++ b/docs/vcd_gateway_services_firewall_list-object-types.md
@@ -5,6 +5,7 @@ Usage: vcd gateway services firewall list-object-types [OPTIONS] <gateway
 Options:
   --type <source/destination>  type. possible value will be source/destination
                                [required]
+
   -h, --help                   Show this message and exit.
 
 ```

--- a/docs/vcd_gateway_services_firewall_list-objects.md
+++ b/docs/vcd_gateway_services_firewall_list-objects.md
@@ -4,6 +4,7 @@ Usage: vcd gateway services firewall list-objects [OPTIONS] <gateway name>
 Options:
   --type <source/destination>  type. possible value will be source/destination
                                [required]
+
   --object-type <object type>  object type  [required]
   -h, --help                   Show this message and exit.
 

--- a/docs/vcd_gateway_services_firewall_update.md
+++ b/docs/vcd_gateway_services_firewall_update.md
@@ -4,9 +4,11 @@ Usage: vcd gateway services firewall update [OPTIONS] <gateway name> <rule id>
 Options:
   --source <value:value_type>     it should be in value:value_type format. for
                                   ex: Extnw:gatewayinterface
+
   --destination <value:value_type>
                                   it should be in value:value_type format. for
                                   ex: Extnw:gatewayinterface
+
   --service <protocol> <source port> <destination port>
                                   configure services of firewall
   --name <name>                   new name of the firewall rule

--- a/docs/vcd_gateway_services_ipsec-vpn.md
+++ b/docs/vcd_gateway_services_ipsec-vpn.md
@@ -69,6 +69,7 @@ Commands:
   set-log-level             set log level of IPsec VPN. It's value should be
                             from the domain:{emergency, alert, critical,
                             error, warning, notice, info, debug)
+
   update                    update IPsec VPN
 
 ```

--- a/docs/vcd_gateway_services_ipsec-vpn_create.md
+++ b/docs/vcd_gateway_services_ipsec-vpn_create.md
@@ -7,14 +7,18 @@ Options:
   -pid, --peer-id <peer-id>       Peer id of IPsec VPN.  [required]
   -lip, --local-ip <local-ip>     Local IP/Local end point of IPsec VPN.
                                   [required]
+
   -pip, --peer-ip <peer-ip>       Peer IP/Peer end point of IPsec VPN.
                                   [required]
+
   -lsubnet, --local-subnet <local-subnet>
                                   Local subnets of IPsec VPN.These should be
                                   given comma separated.  [required]
+
   -psubnet, --peer-subnet <peer-subnet>
                                   Peer subnets of IPsec VPN.These should be
                                   given comma separated.  [required]
+
   -psk, --pre-shared-key <pre-shared-key>
                                   Pre shared key of IPsec VPN.  [required]
   --description <description>     Description of IPsec VPN.

--- a/docs/vcd_gateway_services_ipsec-vpn_update.md
+++ b/docs/vcd_gateway_services_ipsec-vpn_update.md
@@ -11,9 +11,11 @@ Options:
   -lsubnet, --local-subnet <local-subnet>
                                   Local subnets of IPsec VPN.These should be
                                   given comma separated.
+
   -psubnet, --peer-subnet <peer-subnet>
                                   Peer subnets of IPsec VPN.These should be
                                   given comma separated.
+
   -psk, --pre-shared-key <pre-shared-key>
                                   Pre shared key of IPsec VPN.
   --description <description>     Description of IPsec VPN.

--- a/docs/vcd_gateway_sub-allocate-ip_add.md
+++ b/docs/vcd_gateway_sub-allocate-ip_add.md
@@ -5,8 +5,10 @@ Options:
   -e, --external-network <external network>
                                   external network connected to the gateway.
                                   [required]
+
   -i, --ip-range <ip range>       ip ranges used for static pool allocation in
                                   the network.  [required]
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_gateway_sub-allocate-ip_remove.md
+++ b/docs/vcd_gateway_sub-allocate-ip_remove.md
@@ -5,8 +5,10 @@ Options:
   -e, --external-network <external network>
                                   external network connected to the gateway.
                                   [required]
+
   -i, --ip-range <old-ip-range>   IP ranges that needs to be removed.
                                   [required]
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_gateway_sub-allocate-ip_update.md
+++ b/docs/vcd_gateway_sub-allocate-ip_update.md
@@ -5,12 +5,15 @@ Options:
   -e, --external-network <external network>
                                   external network connected to the gateway.
                                   [required]
+
   -o, --old-ip-range <old-ip-range>
                                   existing IP ranges used for static pool
                                   allocation in the network.  [required]
+
   -n, --new-ip-range <new-ip-range>
                                   new IP range to replace the existing IP
                                   range.  [required]
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_login.md
+++ b/docs/vcd_login.md
@@ -32,12 +32,13 @@ Usage: vcd login [OPTIONS] host organization user
 
 Options:
   -p, --password <password>       Password
-  -V, --version [29.0|30.0|31.0|32.0|33.0]
+  -V, --version [29.0|30.0|31.0|32.0|33.0|34.0|35.0|36.0]
                                   API version
   -s, --verify-ssl-certs / -i, --no-verify-ssl-certs
                                   Verify SSL certificates
   -w, --disable-warnings          Do not display warnings when not verifying
                                   SSL certificates
+
   -v, --vdc TEXT                  virtual datacenter
   -d, --session-id TEXT           session id
   -b, --use-browser-session       Use browser session

--- a/docs/vcd_network_direct_create.md
+++ b/docs/vcd_network_direct_create.md
@@ -5,11 +5,13 @@ Options:
   -p, --parent <external network name>
                                   Name of the external network to be connected
                                   to  [required]
+
   -d, --description <description>
                                   Description of the network to be created
   -s, --shared / -n, --not-shared
                                   Share/Don't share the network with other
                                   VDC(s) in the organization
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_network_external.md
+++ b/docs/vcd_network_external.md
@@ -107,12 +107,14 @@ Options:
 Commands:
   add-ip-range                 add an IP range to a subnet in an external
                                network
+
   add-subnet                   add subnet to an external network
   attach-port-group            attach a port group to an external network
   create                       create a new external network
   delete                       delete an external network
   delete-ip-range              delete an IP range of a subnet in an external
                                network
+
   detach-port-group            detach port group from an external network
   enable-subnet                enable subnet of an external network
   info                         show external network details
@@ -125,6 +127,7 @@ Commands:
   list-vsphere-network         list associated vSphere networks
   update                       update name and description of an external
                                network
+
   update-ip-range              update an IP range of a subnet in an external
                                network
 

--- a/docs/vcd_network_external_add-subnet.md
+++ b/docs/vcd_network_external_add-subnet.md
@@ -6,6 +6,7 @@ Options:
   -n, --netmask <netmask>  network mask of the subnet  [required]
   -i, --ip-range <ip>      ip range in StartAddress-EndAddress format
                            [required]
+
   --dns1 <ip>              ip of the primary dns server of the subnet
   --dns2 <ip>              ip of the secondary dns server of the subnet
   --dns-suffix <name>      dns suffix

--- a/docs/vcd_network_external_create.md
+++ b/docs/vcd_network_external_create.md
@@ -5,13 +5,16 @@ Options:
   -v, --vc <vc-name>              name of the vCenter  [required]
   -p, --port-group <name>         portgroup to create external network
                                   [required]
+
   -g, --gateway <ip>              gateway of the subnet  [required]
   -n, --netmask <netmask>         network mask of the subnet  [required]
   -i, --ip-range <ip>             IP range in StartAddress-EndAddress format
                                   [required]
+
   -d, --description <description>
                                   Description of the external network to be
                                   created
+
   --dns1 <ip>                     IP of the primary DNS server of the subnet
   --dns2 <ip>                     IP of the secondary DNS server of the subnet
   --dns-suffix <name>             DNS suffix

--- a/docs/vcd_network_external_update-ip-range.md
+++ b/docs/vcd_network_external_update-ip-range.md
@@ -5,8 +5,10 @@ Options:
   -g, --gateway <ip>       gateway ip of the subnet  [required]
   -i, --ip-range <ip>      ip range in StartAddress-EndAddress format
                            [required]
+
   -n, --new-ip-range <ip>  ip range in StartAddress-EndAddress format
                            [required]
+
   -h, --help               Show this message and exit.
 
 ```

--- a/docs/vcd_network_isolated_create.md
+++ b/docs/vcd_network_isolated_create.md
@@ -4,6 +4,7 @@ Usage: vcd network isolated create [OPTIONS] <name>
 Options:
   -g, --gateway <ip>              IP address of the gateway of the new network
                                   [required]
+
   -n, --netmask <netmask>         network mask for the gateway  [required]
   -d, --description <description>
                                   Description of the network to be created
@@ -12,19 +13,25 @@ Options:
   --dns-suffix <name>             DNS suffix
   --ip-range-start <ip>           Start address of the IP ranges used for
                                   static pool allocation in the network
+
   --ip-range-end <ip>             End address of the IP ranges used for static
                                   pool allocation in the network
+
   --dhcp-enabled / --dhcp-disabled
                                   Enable/Disable DHCP service on the new
                                   network
+
   --default-lease-time <integer>  Default lease in seconds for DHCP addresses
   --max-lease-time <integer>      Max lease in seconds for DHCP addresses
   --dhcp-ip-range-start <ip>      Start address of the IP range used for DHCP
                                   addresses
+
   --dhcp-ip-range-end <ip>        End address of the IP range used for DHCP
                                   addresses
+
   --shared / --not-shared         Share/Don't share the network with other
                                   VDC(s) in the organization
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_network_routed.md
+++ b/docs/vcd_network_routed.md
@@ -92,15 +92,18 @@ Commands:
   delete                          delete org vdc routed network
   delete-ip-range                 delete an IP range from a routed org vdc
                                   network
+
   edit                            Edit a routed org vdc network
   info                            show routed network information
   list                            list all routed org vdc networks in the
                                   selected vdc
+
   list-allocated-ip               list allocated IP addresses
   list-connected-vapps            list connected vApps
   list-metadata                   list metadata of a routed org vdc network
   remove-metadata                 remove metadata from a routed org vdc
                                   network
+
   set-metadata                    set metadata to a routed org vdc network
   update-ip-range                 Update IP range of routed org vdc network.
 

--- a/docs/vcd_network_routed_create.md
+++ b/docs/vcd_network_routed_create.md
@@ -4,6 +4,7 @@ Usage: vcd network routed create [OPTIONS] <name>
 Options:
   -g, --gateway-name <name>       name of gateway to which this network will
                                   connect  [required]
+
   --subnet <CIDR format. e.g.,x.x.x.x/20>
                                   Network CIDR  [required]
   --description <description>     description

--- a/docs/vcd_network_routed_edit.md
+++ b/docs/vcd_network_routed_edit.md
@@ -7,6 +7,7 @@ Options:
   --shared-enabled / --shared-disabled
                                   share this network with other VDCs in the
                                   organization
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_network_routed_update-ip-range.md
+++ b/docs/vcd_network_routed_update-ip-range.md
@@ -4,8 +4,10 @@ Usage: vcd network routed update-ip-range [OPTIONS] <name>
 Options:
   -i, --ip-range <ip>      ip range in StartAddress-EndAddress format
                            [required]
+
   -n, --new-ip-range <ip>  ip range in StartAddress-EndAddress format
                            [required]
+
   -h, --help               Show this message and exit.
 
 ```

--- a/docs/vcd_nsxt_register.md
+++ b/docs/vcd_nsxt_register.md
@@ -4,6 +4,7 @@ Usage: vcd nsxt register [OPTIONS] <nsxt-name>
 Options:
   -U, --url [url]            https://<FQDN or IP address> of NSX-T host
                              [required]
+
   -u, --user [username]      NSX-T admin user name  [required]
   -p, --password [password]  NSX-T admin password  [required]
   -d, --desc [description]   description of NSX-T manager

--- a/docs/vcd_org_delete.md
+++ b/docs/vcd_org_delete.md
@@ -4,8 +4,10 @@ Usage: vcd org delete [OPTIONS] <name>
 Options:
   -r, --recursive  removes the Org and any objects it contains that are in a
                    state that normally allows removal
+
   -f, --force      pass this option along with --recursive to remove an Org
                    and any objects it contains, regardless of their state
+
   -h, --help       Show this message and exit.
 
 ```

--- a/docs/vcd_pvdc_create.md
+++ b/docs/vcd_pvdc_create.md
@@ -4,20 +4,25 @@ Usage: vcd pvdc create [OPTIONS] <pvdc-name> <vc-name>
 Options:
   -s, --storage-profile TEXT      storage profile name (required parameter,
                                   can have multiple)  [required]
+
   -r, --resource-pool TEXT        resource pool name (required parameter, can
                                   have multiple)  [required]
+
   -n, --vxlan-network-pool [vxlan-network-pool]
                                   vxlan network pool name
   -t, --nsxt-manager-name [nsxt-manager-name]
                                   nsx-t manager name (valid for vCD API
                                   version 31.0 and above)
+
   -d, --description [description]
                                   description of PVDC
   -e, --enable                    enable flag (enables PVDC when it is
                                   created)
+
   -v, --highest-supp-hw-vers [highest-supp-hw-vers]
                                   highest supported hw version, e.g. vmx-11,
                                   vmx-10, vmx-09, etc.
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_role.md
+++ b/docs/vcd_role.md
@@ -37,15 +37,22 @@ Usage: vcd role [OPTIONS] COMMAND [ARGS]...
           vcd role remove-right myRole myRight1 myRight2  -o myOrg
               Removes one or more rights from a given role.
 
-
+          vcd role clone "Organization Adminstrator" cloned_role
+              Creates a new role 'cloned_role' with the same rights and
+              description as "Organization Administrator"
+      
 
 Options:
   -h, --help  Show this message and exit.
 
 Commands:
   add-right     Adds one or more rights to the role
+  clone         Creates a role that is a copy of an existing role in the
+                specified org(defaults to the current org in use)
+
   create        Creates role in the specified Organization (defaults to the
                 current Organization in use)
+
   delete        Deletes role in the specified Organization
   info          show details of a role
   link          Link the role of a given org to its template

--- a/docs/vcd_role_clone.md
+++ b/docs/vcd_role_clone.md
@@ -1,0 +1,12 @@
+```
+Usage: vcd role clone [OPTIONS] <original-role-name> <new-role-name>
+
+Options:
+  -o, --org [org-name]            Name of the org
+  -d, --description [description]
+                                  Role description (Defaults to description of
+                                  role being cloned)
+
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_user_create.md
+++ b/docs/vcd_user_create.md
@@ -14,8 +14,10 @@ Options:
   --alert-email-prefix [alert_email_prefix]
                                   String to prepend to the alert message
                                   subject line
+
   --external                      Indicates if user is imported from an
                                   external source
+
   --default-cached                Indicates if user should be cached
   -g, --group-role                Indicates if the user has a group role
   -s, --stored-vm-quota [stored_vm_quota]
@@ -23,6 +25,7 @@ Options:
   -d, --deployed-vm-quota [deployed_vm_quota]
                                   Quota of vApps that this user can deploy
                                   concurrently
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_vapp.md
+++ b/docs/vcd_vapp.md
@@ -172,6 +172,38 @@ Usage: vcd vapp [OPTIONS] COMMAND [ARGS]...
 
           vcd vapp remove-snapshot vapp1
               Remove snapshot of the vapp.
+
+          vcd vapp enable-download vapp1
+              Enable download of the vapp.
+
+          vcd vapp disable-download vapp1
+              Disable download of the vapp.
+
+          vcd vapp show-lease vapp1
+              Show vApp lease details.
+
+          vcd vapp show-metadata vapp1
+              Show metadata of vapp.
+
+          vcd vapp update-startup-section vapp1 testvm1 --o 1 --start-action
+              powerOn --start-delay 4 --stop-action guestShutdown --stop-delay 3
+              Update startup section of vapp
+
+          vcd vapp show-startup-section vapp1
+              Show startup section data of vapp.
+
+          vcd vapp show-product-section vapp1
+              Show product section data of vapp.
+
+          vcd vapp update-product-section vapp1 --key testkey --value testvalue
+              --class_name testclassname --instance_name testinstancename --label
+              labledata --is_password true --user_configurable false
+              Update product section of vapp.
+
+          vcd vapp add-vm-scratch vapp1 -vm vm1 -cn computer_name -d description
+                  -os windows7_64Guest -cpu 2 -cps 2 -crm 2 -m 1024 -media
+                  pb1.iso -aae -deploy -power-on
+              Add a VM from scratch to a vApp.
       
 
 Options:
@@ -181,6 +213,7 @@ Commands:
   acl                       work with vapp acl
   add-disk                  add disk to vm
   add-vm                    add VM to vApp
+  add-vm-scratch            add VM from scratch to vApp
   attach                    attach disk to VM in vApp
   capture                   Capture a vApp as template
   change-owner              change vApp owner
@@ -191,9 +224,11 @@ Commands:
   delete                    delete a vApp or VM(s)
   deploy                    Deploy a vApp or VM(s)
   detach                    detach disk from VM in vApp
+  disable-download          disbale a vapp for download
   discard-suspended-state   discard suspended state of vApp
   disconnect                disconnect an ovdc network from a vapp
   download                  Download a vApp
+  enable-download           enable a vapp for download
   enter-maintenance-mode    Place a vApp in Maintenance Mode
   exit-maintenance-mode     exit maintenance mode a vApp
   info                      show vApp details
@@ -206,12 +241,18 @@ Commands:
   remove-snapshot           rmove snapshot of vapp
   reset                     Reset a vApp or VM(s)
   revert-to-snapshot        revert vapp to current snapshot
+  show-lease                show a vapp lease details
+  show-metadata             show metadata of vapp
+  show-product-section      show product sections of vapp
+  show-startup-section      show startup section of vapp
   shutdown                  shutdown a vApp
   stop                      stop a vApp
   suspend                   suspend a vApp
   undeploy                  undeploy a vApp or VM(s)
   update                    update vapp's name and description
   update-lease              update vApp lease
+  update-product-section    update product section of vapp
+  update-startup-section    update startup section of vapp for vm
   upgrade-virtual-hardware  upgrade virtual hardware of a vApp
   use                       set active vApp
 

--- a/docs/vcd_vapp_acl_share.md
+++ b/docs/vcd_vapp_acl_share.md
@@ -4,6 +4,7 @@ Usage: vcd vapp acl share [OPTIONS] <vapp-name>
 Options:
   --access-level <access-level>  access level at which the vapp is shared.
                                  ReadOnly by default
+
   -h, --help                     Show this message and exit.
 
 ```

--- a/docs/vcd_vapp_add-vm-scratch.md
+++ b/docs/vcd_vapp_add-vm-scratch.md
@@ -1,0 +1,25 @@
+```
+Usage: vcd vapp add-vm-scratch [OPTIONS] <target-vapp>
+
+Options:
+  -vm, --vm_name <vm_name>        name of vm  [required]
+  -cn, --computer_name <computer_name>
+                                  computer name of vm  [required]
+  -d, --description <description>
+                                  description of vm
+  -os, --os_type <os_type>        os name of vm  [required]
+  -cpu, --virtual_cpu <virtual_cpu>
+                                  no of virtual cpu
+  -cps, --core_per_socket <core_per_socket>
+                                  core per socket
+  -crm, --cpu_resource_mhz <cpu_resource_mhz>
+                                  cpu resource in Mhz
+  -m, --memory <memory>           memory in MB
+  -media, --media_name <media_name>
+                                  media name of boot image
+  -aae, --accept-all-eulas        Accept all EULAs
+  -deploy, --deploy               deploy vm
+  -power-on, --power_on           power on vm
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vapp_add-vm.md
+++ b/docs/vcd_vapp_add-vm.md
@@ -4,6 +4,7 @@ Usage: vcd vapp add-vm [OPTIONS] <target-vapp> <source-vapp> <source-vm>
 Options:
   -c, --catalog name             Name of the catalog if the source vApp is a
                                  template
+
   -t, --target-vm name           Rename the target VM with this name
   -o, --hostname hostname        Customize VM and set hostname in the guest OS
   -n, --network name             vApp network to connect to

--- a/docs/vcd_vapp_connect.md
+++ b/docs/vcd_vapp_connect.md
@@ -4,8 +4,10 @@ Usage: vcd vapp connect [OPTIONS] <vapp-name> <orgvdc-network-name>
 Options:
   --retain-ip    True if the network resources such as IP/MAC of router will
                  be retained across deployments. False by default
+
   --is-deployed  True if this orgvdc network has been deployed. False by
                  default
+
   -h, --help     Show this message and exit.
 
 ```

--- a/docs/vcd_vapp_copy.md
+++ b/docs/vcd_vapp_copy.md
@@ -5,6 +5,7 @@ Options:
   -n, --name <vapp_new_name>      name of copy vapp  [required]
   -v, --vdc <vdc>                 virtual datacenter name where need to copy
                                   vapp
+
   -d, --description <description>
                                   description of copy vapp
   -h, --help                      Show this message and exit.

--- a/docs/vcd_vapp_deploy.md
+++ b/docs/vcd_vapp_deploy.md
@@ -4,8 +4,10 @@ Usage: vcd vapp deploy [OPTIONS] NAME [VM_NAMES]...
 Options:
   --power-on / --power-off  Specifies whether to power on/off vApp/VM on
                             deployment,if not specified, default is power on
+
   --force-customization     Specifies whether to force customization on
                             deployment,if not specified, default is False
+
   -h, --help                Show this message and exit.
 
 ```

--- a/docs/vcd_vapp_disable-download.md
+++ b/docs/vcd_vapp_disable-download.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp disable-download [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_enable-download.md
+++ b/docs/vcd_vapp_enable-download.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp enable-download [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network.md
+++ b/docs/vcd_vapp_network.md
@@ -62,6 +62,15 @@ Usage: vcd vapp network [OPTIONS] COMMAND [ARGS]...
 
           vcd vapp network sync-syslog-settings vapp1 vapp-network1
               Sync syslog settings of vapp network
+
+          vdc vapp network create-ovdc-network vapp1 ovdc-network1
+              Create a vApp network using org vdc network.
+
+          vdc vapp network enable-fence vapp1
+              Enable fence mode of vApp network.
+
+          vdc vapp network list-vm-interface vapp1 vapp-network1
+              List vm interfaces of network.
       
 
 Options:
@@ -72,11 +81,14 @@ Commands:
   add-ip-range          add IP range/s to the network
   connect-ovdc          connect a vapp network to org vdc network
   create                create a vApp network
+  create-ovdc-network   create a vapp network using org vdc network
   delete                delete a vApp network
   delete-ip-range       delete an IP range in network
   dns-info              show DNS details of vapp network
+  enable-fence          enable fence mode of vapp network
   list                  list vapp networks
   list-allocated-ip     list allocated IP
+  list-vm-interface     list vm interfaces of network
   reset                 reset a vApp network
   services              manage vapp network services
   sync-syslog-settings  sync syslog settings of vapp network

--- a/docs/vcd_vapp_network_create-ovdc-network.md
+++ b/docs/vcd_vapp_network_create-ovdc-network.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vapp network create-ovdc-network [OPTIONS] <vapp-name> <ovdc-
+                                            network-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_enable-fence.md
+++ b/docs/vcd_vapp_network_enable-fence.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp network enable-fence [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_list-vm-interface.md
+++ b/docs/vcd_vapp_network_list-vm-interface.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp network list-vm-interface [OPTIONS] <vapp-name> <network_name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services.md
+++ b/docs/vcd_vapp_network_services.md
@@ -7,7 +7,9 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  dhcp      manage DHCP service of vapp network
-  firewall  manage firewall service of vapp network
+  dhcp          manage DHCP service of vapp network
+  firewall      manage firewall service of vapp network
+  nat           manage NAT service of vapp network
+  static-route  manage static route service of vapp network
 
 ```

--- a/docs/vcd_vapp_network_services_dhcp_set.md
+++ b/docs/vcd_vapp_network_services_dhcp_set.md
@@ -4,6 +4,7 @@ Usage: vcd vapp network services dhcp set [OPTIONS] <vapp-name> <network-name>
 Options:
   -i, --ip-range <ip>             IP range in StartAddress-EndAddress format
                                   [required]
+
   -dlt, --default-lease-time <ip>
                                   default lease time
   -mlt, --max-lease-time <ip>     max lease time

--- a/docs/vcd_vapp_network_services_firewall.md
+++ b/docs/vcd_vapp_network_services_firewall.md
@@ -8,10 +8,39 @@ Usage: vcd vapp network services firewall [OPTIONS] COMMAND [ARGS]...
                   network_name --enable
               Enable firewall service.
 
+      vcd vapp network services firewall set-default-action vapp_name
+              network_name --action allow --log-action False
+          Set deault action in firewall service.
+
+      vcd vapp network services firewall list vapp_name network_name
+          List firewall rules in firewall service.
+
+      vcd vapp network services firewall add vapp_name network_name rule_name
+              --enable --policy drop --protocols Tcp,Udp --source-ip Any
+               --source-port-range Any --destination-port-range Any
+              --destination-ip Any --enable-logging
+          Add firewall rule in firewall service.
+
+      vcd vapp network services firewall update vapp_name network_name
+              rule_name --name rule_new_name --enable --policy
+              drop --protocols Tcp,Udp --source-ip Any
+              --source-port-range Any --destination-port-range Any
+              --destination-ip Any --enable-logging
+          Update firewall rule in firewall service.
+
+      vcd vapp network services firewall delete vapp_name network_name
+              --name firewall_rule_name
+          Delete firewall rule in firewall service.
+
 Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  enable-firewall  Enable firewall service
+  add                 add firewall rule to firewall service
+  delete              delete firewall rule in firewall service
+  enable-firewall     Enable firewall service
+  list                list firewall rules in firewall service
+  set-default-action  set default action of firewall service
+  update              update firewall rule of firewall service
 
 ```

--- a/docs/vcd_vapp_network_services_firewall_add.md
+++ b/docs/vcd_vapp_network_services_firewall_add.md
@@ -1,0 +1,20 @@
+```
+Usage: vcd vapp network services firewall add [OPTIONS] <vapp-name> <network-
+                                              name> <firewall-rule-name>
+
+Options:
+  --enable / --disable            enable firewall rule
+  --policy <policy>               policy on firewall rule
+  --protocols <protocols>         all protocol names in comma separated format
+  --source-port-range <source_port_range>
+                                  source port range on firewall rule
+  --source-ip <source_ip>         source ip on firewall rule
+  --destination-port-range <destination_port_range>
+                                  destination port range on firewall rule
+  --destination-ip <destination_ip>
+                                  destination ip on firewall rule
+  --enable-logging / --disable-logging
+                                  enable logging on firewall rule
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_firewall_delete.md
+++ b/docs/vcd_vapp_network_services_firewall_delete.md
@@ -1,0 +1,9 @@
+```
+Usage: vcd vapp network services firewall delete [OPTIONS] <vapp-name>
+                                                 <network-name> <firewall-
+                                                 rule-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_firewall_enable-firewall.md
+++ b/docs/vcd_vapp_network_services_firewall_enable-firewall.md
@@ -3,7 +3,7 @@ Usage: vcd vapp network services firewall enable-firewall [OPTIONS] <vapp-
                                                           name> <network-name>
 
 Options:
-  --enable / --disable
+  --enable / --disable  enable firewall service
   -h, --help            Show this message and exit.
 
 ```

--- a/docs/vcd_vapp_network_services_firewall_list.md
+++ b/docs/vcd_vapp_network_services_firewall_list.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vapp network services firewall list [OPTIONS] <vapp-name> <network-
+                                               name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_firewall_set-default-action.md
+++ b/docs/vcd_vapp_network_services_firewall_set-default-action.md
@@ -1,0 +1,11 @@
+```
+Usage: vcd vapp network services firewall set-default-action 
+           [OPTIONS] <vapp-name> <network-name>
+
+Options:
+  --action <action>               deafult action on firewall service
+  --enable-log-action / --disable-log-action
+                                  default action on firewall service log
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_firewall_update.md
+++ b/docs/vcd_vapp_network_services_firewall_update.md
@@ -1,0 +1,22 @@
+```
+Usage: vcd vapp network services firewall update [OPTIONS] <vapp-name>
+                                                 <network-name> <firewall-
+                                                 rule-name>
+
+Options:
+  --name <new_name>               new name of firewall rule
+  --enable / --disable            enable firewall rule
+  --policy <policy>               policy on firewall rule
+  --protocols <protocols>         all protocol names in comma separated format
+  --source-port-range <source_port_range>
+                                  source port range on firewall rule
+  --source-ip <source_ip>         source ip on firewall rule
+  --destination-port-range <destination_port_range>
+                                  destination port range on firewall rule
+  --destination-ip <destination_ip>
+                                  destination ip on firewall rule
+  --enable-logging / --disable-logging
+                                  enable logging on firewall rule
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat.md
+++ b/docs/vcd_vapp_network_services_nat.md
@@ -1,0 +1,64 @@
+```
+Usage: vcd vapp network services nat [OPTIONS] COMMAND [ARGS]...
+
+  Manages NAT service of vapp network.
+
+      Examples
+          vcd vapp network services nat enable-nat vapp_name network_name
+                  --enable
+              Enable NAT service.
+
+      vcd vapp network services nat set-nat-type vapp_name network_name
+              --type ipTranslation --policy allowTrafficIn
+          Set NAT type in NAT service.
+
+      vcd vapp network services nat get-nat-type vapp_name network_name
+          Get  NAT type and policy in NAT service.
+
+      vcd vapp network services nat add vapp_name network_name
+              --type ipTranslation --vm_id testvm1 --nic_id 1
+          Add  NAT rule to NAT service.
+
+      vcd vapp network services nat add vapp_name network_name
+              --type ipTranslation --vm_id testvm1 --nic_id 1 --mapping_mode
+               manual --ext_ip 10.1.1.1
+          Add  NAT rule to NAT service.
+
+      vcd vapp network services nat add vapp_name network_name
+              --type portForwarding  --vm_id testvm1 --nic_id 1 --ext_port -1
+              --int_port -1 --protocol TCP_UDP
+          Add  NAT rule to NAT service.
+
+      vcd vapp network services nat list vapp_name network_name
+          List NAT rules in NAT service.
+
+      vcd vapp network services nat delete vapp_name network_name id
+          Delete NAT rule from NAT service.
+
+      vcd vapp network services nat update vapp_name network_name rule_id
+          --vm_id testvm1 --nic_id 1
+          Update  NAT rule to NAT service.
+
+      vcd vapp network services nat update vapp_name network_name rule_id
+              --vm_id testvm1 --nic_id 1 --mapping_mode manual
+              --ext_ip 10.1.1.1
+          Update  NAT rule to NAT service.
+
+      vcd vapp network services nat update vapp_name network_name rule_id
+              --vm_id testvm1 --nic_id 1 --ext_port -1 --int_port -1
+              --protocol TCP_UDP
+          Update  NAT rule to NAT service.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  add           add NAT rule
+  delete        delete NAT rules
+  enable-nat    enable NAT service
+  get-nat-type  get NAT type
+  list          list NAT rules
+  set-nat-type  set NAT type
+  update        update NAT rule
+
+```

--- a/docs/vcd_vapp_network_services_nat_add.md
+++ b/docs/vcd_vapp_network_services_nat_add.md
@@ -1,0 +1,15 @@
+```
+Usage: vcd vapp network services nat add [OPTIONS] <vapp-name> <network-name>
+
+Options:
+  --type <type>                  type of NAT service  [required]
+  --vm_id <vm_id>                VM local id  [required]
+  --nic_id <nic_id>              NIC id of vapp network in vm   [required]
+  --mapping_mode <mapping_mode>  mapping mode of NAT rule
+  --ext_ip <ext_ip>              external IP address
+  --ext_port <ext_port>          external port
+  --int_port <int_port>          internal port
+  --protocol <protocol>          protocol
+  -h, --help                     Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat_delete.md
+++ b/docs/vcd_vapp_network_services_nat_delete.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vapp network services nat delete [OPTIONS] <vapp-name> <network-
+                                            name> <rule_id>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat_enable-nat.md
+++ b/docs/vcd_vapp_network_services_nat_enable-nat.md
@@ -1,0 +1,9 @@
+```
+Usage: vcd vapp network services nat enable-nat [OPTIONS] <vapp-name>
+                                                <network-name>
+
+Options:
+  --enable / --disable  enable NAT service
+  -h, --help            Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat_get-nat-type.md
+++ b/docs/vcd_vapp_network_services_nat_get-nat-type.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vapp network services nat get-nat-type [OPTIONS] <vapp-name>
+                                                  <network-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat_list.md
+++ b/docs/vcd_vapp_network_services_nat_list.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp network services nat list [OPTIONS] <vapp-name> <network-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat_set-nat-type.md
+++ b/docs/vcd_vapp_network_services_nat_set-nat-type.md
@@ -1,0 +1,10 @@
+```
+Usage: vcd vapp network services nat set-nat-type [OPTIONS] <vapp-name>
+                                                  <network-name>
+
+Options:
+  --type <type>      type of NAT service
+  --policy <policy>  policy of NAT service
+  -h, --help         Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_nat_update.md
+++ b/docs/vcd_vapp_network_services_nat_update.md
@@ -1,0 +1,15 @@
+```
+Usage: vcd vapp network services nat update [OPTIONS] <vapp-name> <network-
+                                            name> <rule-id>
+
+Options:
+  --vm_id <vm_id>                VM local id
+  --nic_id <nic_id>              NIC id of vapp network in vm
+  --mapping_mode <mapping_mode>  mapping mode of NAT rule
+  --ext_ip <ext_ip>              external IP address
+  --ext_port <ext_port>          external port
+  --int_port <int_port>          internal port
+  --protocol <protocol>          protocol
+  -h, --help                     Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_static-route.md
+++ b/docs/vcd_vapp_network_services_static-route.md
@@ -1,0 +1,44 @@
+```
+Usage: vcd vapp network services static-route [OPTIONS] COMMAND [ARGS]...
+
+  Manage static route service of vapp network.
+
+      vcd vapp network services static-route enable-service vapp_name
+              network_name --enable
+          Enable static route service.
+
+      vcd vapp network services static-route enable-service vapp_name
+              network_name --disable
+          Disable static route service.
+
+      vcd vapp network services static-route add vapp_name network_name
+              --name route_name
+              --nhip next_hop_ip
+              --network network_cidr
+          Add static route in static route service.
+
+      vcd vapp network services static-route list vapp_name network_name
+          List static route in static route service.
+
+      vcd vapp network services static-route update vapp_name network_name
+              route_name
+              --name new_route_name
+              --network network_cidr
+              --nhip next_hop_ip
+          Update static route in static route service.
+
+      vcd vapp network services static-route delete vapp_name network_name
+              route_name
+          Delete static route in static route service.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  add             add static route in static route service
+  delete          delete static route in static route service
+  enable-service  enable static route service
+  list            list static route in static route service
+  update          update static route in static route service
+
+```

--- a/docs/vcd_vapp_network_services_static-route_add.md
+++ b/docs/vcd_vapp_network_services_static-route_add.md
@@ -1,0 +1,11 @@
+```
+Usage: vcd vapp network services static-route add [OPTIONS] <vapp-name>
+                                                  <network-name>
+
+Options:
+  --name <route-name>       route name  [required]
+  --network <network-cidr>  network CIDR  [required]
+  --nhip <next-hop-ip>      next hop IP  [required]
+  -h, --help                Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_static-route_delete.md
+++ b/docs/vcd_vapp_network_services_static-route_delete.md
@@ -1,0 +1,9 @@
+```
+Usage: vcd vapp network services static-route delete [OPTIONS] <vapp-name>
+                                                     <network-name> <route-
+                                                     name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_static-route_enable-service.md
+++ b/docs/vcd_vapp_network_services_static-route_enable-service.md
@@ -1,0 +1,9 @@
+```
+Usage: vcd vapp network services static-route enable-service 
+           [OPTIONS] <vapp-name> <network-name>
+
+Options:
+  --enable / --disable  enable static route service
+  -h, --help            Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_static-route_list.md
+++ b/docs/vcd_vapp_network_services_static-route_list.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vapp network services static-route list [OPTIONS] <vapp-name>
+                                                   <network-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_services_static-route_update.md
+++ b/docs/vcd_vapp_network_services_static-route_update.md
@@ -1,0 +1,12 @@
+```
+Usage: vcd vapp network services static-route update [OPTIONS] <vapp-name>
+                                                     <network-name> <route-
+                                                     name>
+
+Options:
+  --name <route-new-name>   route new name
+  --network <network-cidr>  network CIDR
+  --nhip <next-hop-ip>      next hop IP
+  -h, --help                Show this message and exit.
+
+```

--- a/docs/vcd_vapp_network_update-ip-range.md
+++ b/docs/vcd_vapp_network_update-ip-range.md
@@ -4,8 +4,10 @@ Usage: vcd vapp network update-ip-range [OPTIONS] <vapp-name> <network-name>
 Options:
   -i, --ip-range <ip>      IP range in StartAddress-EndAddress format
                            [required]
+
   -n, --new-ip-range <ip>  new IP range in StartAddress-EndAddress format
                            [required]
+
   -h, --help               Show this message and exit.
 
 ```

--- a/docs/vcd_vapp_show-lease.md
+++ b/docs/vcd_vapp_show-lease.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp show-lease [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_show-metadata.md
+++ b/docs/vcd_vapp_show-metadata.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp show-metadata [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_show-product-section.md
+++ b/docs/vcd_vapp_show-product-section.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp show-product-section [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_show-startup-section.md
+++ b/docs/vcd_vapp_show-startup-section.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vapp show-startup-section [OPTIONS] <vapp-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vapp_update-product-section.md
+++ b/docs/vcd_vapp_update-product-section.md
@@ -1,0 +1,23 @@
+```
+Usage: vcd vapp update-product-section [OPTIONS] <vapp_name>
+
+Options:
+  --key <key>                     key for property of product section
+                                  [required]
+
+  --value <value>                 value for property of product section
+  --type <type>                   type for property value of product section
+  --class_name <class_name>       class name of product section
+  --instance_name <instance_name>
+                                  instance name of product section
+  --label <label>                 label for property of product section
+  --is_password <is_password>     is password for property value of product
+                                  section
+
+  --user_configurable <is_password>
+                                  is user configurable property of product
+                                  section
+
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vapp_update-startup-section.md
+++ b/docs/vcd_vapp_update-startup-section.md
@@ -1,0 +1,12 @@
+```
+Usage: vcd vapp update-startup-section [OPTIONS] <vapp_name> <vm_name>
+
+Options:
+  --o <order>                    start order of vm
+  --start-action <start_action>  start action on VM
+  --start-delay <start_delay>    start delay on VM
+  --stop-action <stop_action>    stop action on VM
+  --stop-delay <stop_delay>      stop delay on VM
+  -h, --help                     Show this message and exit.
+
+```

--- a/docs/vcd_vc_attach.md
+++ b/docs/vcd_vc_attach.md
@@ -4,17 +4,21 @@ Usage: vcd vc attach [OPTIONS] <vc-name>
 Options:
   --vc-host [vc-host]             vc host name (vc.server.example.com, or
                                   something similar)  [required]
+
   --vc-user [vc-user]             VC admin user name  [required]
   --vc-pwd [vc-pwd]               VC admin password  [required]
   -e, --enable [enable]           enable flag (boolean: True or False)
                                   [required]
+
   --vc-root-folder [vc-root-folder]
                                   VC root folder (for a future release - VCD
                                   API version 31.0)
+
   --nsx-server-name [nsx-server-name]
                                   NSX server name
   --nsx-host [nsx-host]           NSX host name (nsx.server.example.com, or
                                   something similar)
+
   --nsx-user [nsx-user]           NSX admin user name
   --nsx-pwd [nsx-pwd]             NSX admin password
   -h, --help                      Show this message and exit.

--- a/docs/vcd_vdc.md
+++ b/docs/vcd_vdc.md
@@ -6,38 +6,46 @@ Usage: vcd vdc [OPTIONS] COMMAND [ARGS]...
       Examples
           vcd vdc list
               Get list of virtual datacenters in current organization.
-  
+
           vcd vdc info my-vdc
               Get details of the virtual datacenter 'my-vdc'.
-  
+
           vcd vdc use my-vdc
               Set virtual datacenter 'my-vdc' as default.
-  
+
           vcd vdc create dev-vdc -p prov-vdc -n net-pool -s '*' \
               -a ReservationPool -d 'vDC for development'
               Create new virtual datacenter.
-  
+
           vcd vdc disable dev-vdc
               Disable virtual datacenter.
-  
+
           vcd vdc enable dev-vdc
               Enable virtual datacenter.
-  
+
           vcd vdc delete -y dev-vdc
               Delete virtual datacenter.
+
+          vcd vdc list-media
+              Get list of media in virtual datacenter.
+
+          vcd vdc list-disk
+              Get list of disks in virtual datacenter.
       
 
 Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  acl      work with vdc acl
-  create   create a virtual datacenter
-  delete   delete a virtual datacenter
-  disable  disable a virtual datacenter
-  enable   enable a virtual datacenter
-  info     show virtual datacenter details
-  list     list of virtual datacenters
-  use      set active virtual datacenter
+  acl         work with vdc acl
+  create      create a virtual datacenter
+  delete      delete a virtual datacenter
+  disable     disable a virtual datacenter
+  enable      enable a virtual datacenter
+  info        show virtual datacenter details
+  list        list of virtual datacenters
+  list-disk   list disks from VDC
+  list-media  list media from VDC
+  use         set active virtual datacenter
 
 ```

--- a/docs/vcd_vdc_create.md
+++ b/docs/vcd_vdc_create.md
@@ -13,12 +13,18 @@ Options:
   --storage-profile-limit [storage-profile-limit]
                                   Provider VDC Storage Profile limit (MB), 0
                                   means unlimited.
+
   -D, --description [description]
                                   description.
   --cpu-allocated <cpu-allocated>
                                   Capacity that is commited to be available.
   --cpu-limit <cpu-limit>         Capacity limit relative to the value
                                   specified for Allocation.
+
+  --network-quota <network-quota>
+                                  Maximum number of network objects that can
+                                  be deployed in this vdc.
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_vdc_list-disk.md
+++ b/docs/vcd_vdc_list-disk.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vdc list-disk [OPTIONS] <vdc-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vdc_list-media.md
+++ b/docs/vcd_vdc_list-media.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vdc list-media [OPTIONS] <vdc-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm.md
+++ b/docs/vcd_vm.md
@@ -31,6 +31,15 @@ Usage: vcd vm [OPTIONS] COMMAND [ARGS]...
                   --ip-address 192.168.1.10
               Adds a nic to the VM.
 
+          vcd vm update-nic vapp1 vm1
+                  --adapter-type VMXNET3
+                  --primary
+                  --connect
+                  --network network_name
+                  --ip-address-mode MANUAL
+                  --ip-address 192.168.1.10
+              Update a nic of the VM.
+
           vcd vm list-nics vapp1 vm1
               Lists the nics of the VM.
 
@@ -63,11 +72,11 @@ Usage: vcd vm [OPTIONS] COMMAND [ARGS]...
               Install vmware tools in the VM.
 
           vcd vm insert-cd vapp1 vm1
-                  --media-href https://10.11.200.00/api/media/76e53c34-1845-43ca-bd5a-759c0d537433
+                  --media-id 76e53c34-1845-43ca-bd5a-759c0d537433
               Insert CD from catalog to the VM.
 
           vcd vm eject-cd vapp1 vm1
-                  --media-href https://10.11.200.00/api/media/76e53c34-1845-43ca-bd5a-759c0d537433
+                  --media-id 76e53c34-1845-43ca-bd5a-759c0d537433
               Eject CD from the VM.
 
           vcd vm consolidate vapp1 vm1
@@ -78,6 +87,9 @@ Usage: vcd vm [OPTIONS] COMMAND [ARGS]...
 
           vcd vm revert-to-snapshot vapp1 vm1
               Revert VM to current snapshot.
+
+          vcd vm remove-snapshot vapp1 vm1
+              Remove VM snapshot.
 
           vcd vm copy vapp1 vm1 vapp2 vm2
               Copy VM from one vapp to another vapp.
@@ -117,46 +129,206 @@ Usage: vcd vm [OPTIONS] COMMAND [ARGS]...
           vcd vm check-compliance vapp1 vm1
               Check compliance of VM.
 
+          vcd vm gc-enable vapp1 vm1
+                  --enable
+              Enable guest customization of VM.
+
+          vcd vm gc-status vapp1 vm1
+              Returns guest customization status of VM.
+
           vcd vm customize-on-next-poweron vapp1 vm1
               Customize on next power on of VM.
 
+          vcd vm poweron-force-recustomize vapp1 vm1
+              Power on and force re-customize VM.
 
+          vcd vm list-virtual-hardware-section vapp1 vm1
+              List virtual hadware section of VM.
+
+          vcd vm get-compliance-result vapp1 vm1
+              Get compliance result of VM.
+
+          vcd vm list-current-metrics vapp1 vm1
+              List current metrics of VM.
+
+          vcd vm list-subset-current-metrics vapp1 vm1
+                  --metric-pattern *.average
+              List subset of current metrics of VM based on metric pattern.
+
+          vcd vm list-historic-metrics vapp1 vm1
+              List historic metrics of VM.
+
+          vcd vm list-sample-historic-data vapp1 vm1
+                  --metric-name disk.read.average
+              List historic sample data of given metric of VM.
+
+          vcd vm update-general-setting vapp1 vm1 --name vm_new_name
+              --d vm_new_description --cn new_computer_name --bd 60
+              --ebs True
+              Update general setting details of VM.
+
+          vcd vm relocate vapp1 vm1
+                  --datastore-id 0d8c7358-3e8d-4862-9364-68155069d252
+              Relocate VM to given datastore.
+
+          vcd vm list-os-section vapp1 vm1
+              List OS section properties of VM.
+
+          vcd vm update-os-section vapp1 vm1
+                  --ovf-info newInfo
+                  --description newDescription
+              Update OS section properties of VM.
+
+          vcd vm list-gc-section vapp1 vm1
+              List guest customization section properties of VM.
+
+          vcd vm update-gc-section
+                  --disable
+              Update guest customization section properties of VM.
+
+          vcd vm check-post-gc-script vapp1 vm1
+              Check post guest customization script status of VM.
+
+          vcd vm list-vm-capabilities vapp1 vm1
+              List VM capabilities section properties of VM.
+
+          vcd vm update-vm-capabilities
+                  --enable-memory-hot-add
+              Update VM capabilities section properties of VM.
+
+          vcd vm list-runtime-info vapp1 vm1
+              List runtime info properties of VM.
+
+          vcd vm list-boot-options vapp1 vm1
+              List boot options properties of VM.
+
+          vcd vm update-boot-options vapp1 vm1
+                  --enable-enter-bios-setup
+              Update boot options properties of VM.
+
+          vcd vm set-metadata vapp1 vm1
+                  --domain GENERAL
+                  --visibility READWRITE
+                  --key key1
+                  --value value1
+                  --value-type MetadataStringValue
+              Set metadata of VM.
+
+          vcd vm update-metadata vapp1 vm1
+                  --domain GENERAL
+                  --visibility READWRITE
+                  --key key1
+                  --value value2
+                  --value-type MetadataStringValue
+              Update metadata of VM.
+
+          vcd vm list-metadata vapp1 vm1
+              List metadata of VM.
+
+          vcd vm remove-metadata vapp1 vm1
+                  --domain GENERAL
+                  --key key1
+              Remove metadata of VM.
+
+          vcd vm list-screen-ticket vapp1 vm1
+              List screen ticket of VM.
+
+          vcd vm list-mks-ticket vapp1 vm1
+              List mks ticket of VM.
+
+          vcd vm list-product-sections vapp1 vm1
+              List product sections of VM.
+
+          vcd vm update-vhs-disk vapp1 vm1
+                  --e-name 'Hard Disk 1'
+                  --v-quantity 694487
+              Update virtual hardware section disk of VM.
+
+          vcd vm update-vhs-media  vapp1 vm1
+                  --e-name 'CD DVD DRive'
+                  --host-resource pb1.iso
+              Update virtual hardware section media of VM.
+
+          vcd vm enable-nested-hypervisor vapp1 vm1
+              Enable nested hypervisor of VM.
+      
 
 Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  add-nic                    Add a nic to the VM
-  attach-disk                attach independent disk to VM
-  check-compliance           check compliance of VM
-  consolidate                consolidate VM
-  copy                       copy vm from one vapp to another vapp
-  create-snapshot            create snapshot of a VM
-  customize-on-next-poweron  customize on next power on of VM
-  delete                     delete VM
-  delete-nic                 Delete the nic with the index
-  deploy                     deploy a VM
-  detach-disk                detach independent disk from VM
-  discard-suspend            discard suspend state of a VM
-  eject-cd                   eject CD from VM
-  general-setting            general setting detail of VM
-  info                       show VM details
-  insert-cd                  insert CD from catalog
-  install-vmware-tools       instal vmware tools
-  list                       list VMs
-  list-nics                  List all the nics of the VM
-  list-storage-profile       list all storage profiles of VM
-  move                       move VM from one vapp to another vapp
-  power-off                  power off a VM
-  power-on                   power on a VM
-  reboot                     reboot a VM
-  reload-from-vc             reload VM from VC
-  reset                      reset a VM
-  revert-to-snapshot         revert VM to current snapshot
-  shutdown                   shutdown a VM
-  suspend                    suspend a VM
-  undeploy                   undeploy a VM
-  update                     Update the VM properties and configurations
-  upgrade-virtual-hardware   upgrade virtual hardware of VM
+  add-nic                        Add a nic to the VM
+  attach-disk                    attach independent disk to VM
+  check-compliance               check compliance of VM
+  check-post-gc-script           check post guest customizationscript of VM
+  consolidate                    consolidate VM
+  copy                           copy vm from one vapp to another vapp
+  create-snapshot                create snapshot of a VM
+  customize-on-next-poweron      customize on next power on of VM
+  delete                         delete VM
+  delete-nic                     Delete the nic with the index
+  deploy                         deploy a VM
+  detach-disk                    detach independent disk from VM
+  discard-suspend                discard suspend state of a VM
+  eject-cd                       eject CD from VM
+  enable-nested-hypervisor       enable nested hypervisor of VM
+  gc-enable                      enable/disable the guest customization
+  gc-status                      get guest customization status
+  general-setting                general setting detail of VM
+  get-compliance-result          get compliance result of VM
+  info                           show VM details
+  insert-cd                      insert CD from catalog
+  install-vmware-tools           instal vmware tools
+  list                           list VMs
+  list-boot-options              list boot options properties of VM
+  list-current-metrics           list current metrics of VM
+  list-gc-section                list guest customization section properties
+                                 of VM
+
+  list-historic-metrics          list historic metrics of VM
+  list-metadata                  list metadata of VM
+  list-mks-ticket                list mks ticket of VM
+  list-nics                      List all the nics of the VM
+  list-os-section                list operating system section properties of
+                                 VM
+
+  list-product-sections          list product sections of VM
+  list-runtime-info              list runtime info properties of VM
+  list-sample-historic-data      list sample historic data of given metric of
+                                 VM
+
+  list-screen-ticket             list screen ticket of VM
+  list-storage-profile           list all storage profiles of VM
+  list-subset-current-metrics    list subset of current metrics of VM
+  list-virtual-hardware-section  list virtual hardware section of VM
+  list-vm-capabilities           list VM capabilities section properties
+  move                           move VM from one vapp to another vapp
+  power-off                      power off a VM
+  power-on                       power on a VM
+  poweron-force-recustomize      power on and force recustomize VM
+  reboot                         reboot a VM
+  reload-from-vc                 reload VM from VC
+  relocate                       relocate VM to given datastore
+  remove-metadata                remove metadata of VM
+  remove-snapshot                remove VM snaphot
+  reset                          reset a VM
+  revert-to-snapshot             revert VM to current snapshot
+  set-metadata                   set an entity as metadata of VM
+  shutdown                       shutdown a VM
+  suspend                        suspend a VM
+  undeploy                       undeploy a VM
+  update                         Update the VM properties and configurations
+  update-boot-options            update boot options properties
+  update-gc-section              update guest customization section properties
+                                 of VM
+
+  update-general-setting         update general setting of VM
+  update-metadata                update metadata of VM
+  update-nic                     Update a nic to the VM
+  update-os-section              update os section properties of VM
+  update-vhs-disk                update virtual hardware section disk of VM
+  update-vhs-media               update virtual hardware section media of VM
+  update-vm-capabilities         update VM capabilities properties
+  upgrade-virtual-hardware       upgrade virtual hardware of VM
 
 ```

--- a/docs/vcd_vm_add-nic.md
+++ b/docs/vcd_vm_add-nic.md
@@ -4,14 +4,17 @@ Usage: vcd vm add-nic [OPTIONS] <vapp-name> <vm-name>
 Options:
   --adapter-type <adapter-type>   adapter type of nic - one of
                                   VLANCE|VMXNET|VMXNET2|VMXNET3|E1000
+
   --primary                       whether nic has to be a primary
   --connect                       whether nic has to be connected
   --network <network>             network to connect to
   --ip-address-mode <ip-address-mode>
                                   IP address allocation mode - one of
                                   DHCP|POOL|MANUAL|NONE
+
   --ip-address <ip-address>       nanual IP address that needs to be allocated
                                   to the nic
+
   -h, --help                      Show this message and exit.
 
 ```

--- a/docs/vcd_vm_check-post-gc-script.md
+++ b/docs/vcd_vm_check-post-gc-script.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm check-post-gc-script [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_eject-cd.md
+++ b/docs/vcd_vm_eject-cd.md
@@ -2,7 +2,7 @@
 Usage: vcd vm eject-cd [OPTIONS] <vapp-name> <vm-name>
 
 Options:
-  --media-href <media-href>  media href to be ejected  [required]
-  -h, --help                 Show this message and exit.
+  --media-id <media-id>  media id to be ejected  [required]
+  -h, --help             Show this message and exit.
 
 ```

--- a/docs/vcd_vm_enable-nested-hypervisor.md
+++ b/docs/vcd_vm_enable-nested-hypervisor.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm enable-nested-hypervisor [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_gc-enable.md
+++ b/docs/vcd_vm_gc-enable.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vm gc-enable [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --enable / --disable  enable/disable the guest customization
+  -h, --help            Show this message and exit.
+
+```

--- a/docs/vcd_vm_gc-status.md
+++ b/docs/vcd_vm_gc-status.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm gc-status [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_get-compliance-result.md
+++ b/docs/vcd_vm_get-compliance-result.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm get-compliance-result [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_insert-cd.md
+++ b/docs/vcd_vm_insert-cd.md
@@ -2,7 +2,7 @@
 Usage: vcd vm insert-cd [OPTIONS] <vapp-name> <vm-name>
 
 Options:
-  --media-href <media-href>  media href to be inserted  [required]
-  -h, --help                 Show this message and exit.
+  --media-id <media-id>  media id to be inserted  [required]
+  -h, --help             Show this message and exit.
 
 ```

--- a/docs/vcd_vm_list-boot-options.md
+++ b/docs/vcd_vm_list-boot-options.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-boot-options [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-current-metrics.md
+++ b/docs/vcd_vm_list-current-metrics.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-current-metrics [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-gc-section.md
+++ b/docs/vcd_vm_list-gc-section.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-gc-section [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-historic-metrics.md
+++ b/docs/vcd_vm_list-historic-metrics.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-historic-metrics [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-metadata.md
+++ b/docs/vcd_vm_list-metadata.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-metadata [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-mks-ticket.md
+++ b/docs/vcd_vm_list-mks-ticket.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-mks-ticket [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-os-section.md
+++ b/docs/vcd_vm_list-os-section.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-os-section [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-product-sections.md
+++ b/docs/vcd_vm_list-product-sections.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-product-sections [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-runtime-info.md
+++ b/docs/vcd_vm_list-runtime-info.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-runtime-info [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-sample-historic-data.md
+++ b/docs/vcd_vm_list-sample-historic-data.md
@@ -1,0 +1,10 @@
+```
+Usage: vcd vm list-sample-historic-data [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --metric-name <metric_name>  list sample historic data based on metric name
+                               [required]
+
+  -h, --help                   Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-screen-ticket.md
+++ b/docs/vcd_vm_list-screen-ticket.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-screen-ticket [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-subset-current-metrics.md
+++ b/docs/vcd_vm_list-subset-current-metrics.md
@@ -1,0 +1,11 @@
+```
+Usage: vcd vm list-subset-current-metrics [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --metric-pattern <metric_pattern>
+                                  list subset of current metrics based on
+                                  metric pattern  [required]
+
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-virtual-hardware-section.md
+++ b/docs/vcd_vm_list-virtual-hardware-section.md
@@ -1,0 +1,14 @@
+```
+Usage: vcd vm list-virtual-hardware-section [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --is-include-cpu <is_cpu>       list the virtual machine CPU
+  --is-include-memory <is_memory>
+                                  list the virtual machine memory
+  --is-include-disk <is_disk>     list the virtual machine disk
+  --is-include-media <is_media>   list the virtual machine media
+  --is-include-network <is_network>
+                                  list the virtual machine network
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_list-vm-capabilities.md
+++ b/docs/vcd_vm_list-vm-capabilities.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm list-vm-capabilities [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_poweron-force-recustomize.md
+++ b/docs/vcd_vm_poweron-force-recustomize.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm poweron-force-recustomize [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_relocate.md
+++ b/docs/vcd_vm_relocate.md
@@ -1,0 +1,8 @@
+```
+Usage: vcd vm relocate [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --datastore-id <datastore-id>  datastore id  [required]
+  -h, --help                     Show this message and exit.
+
+```

--- a/docs/vcd_vm_remove-metadata.md
+++ b/docs/vcd_vm_remove-metadata.md
@@ -1,0 +1,9 @@
+```
+Usage: vcd vm remove-metadata [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --domain <domain>  domain  [required]
+  --key <key>        key  [required]
+  -h, --help         Show this message and exit.
+
+```

--- a/docs/vcd_vm_remove-snapshot.md
+++ b/docs/vcd_vm_remove-snapshot.md
@@ -1,0 +1,7 @@
+```
+Usage: vcd vm remove-snapshot [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  -h, --help  Show this message and exit.
+
+```

--- a/docs/vcd_vm_set-metadata.md
+++ b/docs/vcd_vm_set-metadata.md
@@ -1,0 +1,12 @@
+```
+Usage: vcd vm set-metadata [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --domain <domain>          domain  [required]
+  --visibility <visibility>  visibility  [required]
+  --value-type <value_type>  value_type  [required]
+  --key <key>                key  [required]
+  --value <value>            value  [required]
+  -h, --help                 Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-boot-options.md
+++ b/docs/vcd_vm_update-boot-options.md
@@ -1,0 +1,10 @@
+```
+Usage: vcd vm update-boot-options [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --bool-delay <int>              boot delay option
+  --enable-enter-bios-setup / --disable-enter-bios-setup
+                                  enable enter bios set-up
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-gc-section.md
+++ b/docs/vcd_vm_update-gc-section.md
@@ -1,0 +1,28 @@
+```
+Usage: vcd vm update-gc-section [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --enable / --disable            enable guest customization
+  --enable-change-sid / --disable-change-sid
+                                  change sid
+  --enable-join-domain / --disable-join-domain
+                                  enable join domain
+  --enable-use-org-settings / --disable-use-org-settings
+                                  enable use org settings
+  --domain-name <str>             domain name
+  --domain-user-name <str>        domain user name
+  --domain-user-password <str>    domain user password
+  --enable-admin-password / --disable-admin-password
+                                  enable admin password
+  --enable-admin-password-auto / --disable-admin-password-auto
+                                  enable admin password auto
+  --admin-password <str>          admin password
+  --enable-admin-auto-logon / --disable-admin-auto-logon
+                                  enable admin auto logon
+  --admin-auto-logon-count <int>  admin auto logon count
+  --enable-reset-password / --disable-reset-password
+                                  enable reset password
+  --customization-script <str>    customization scipt
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-general-setting.md
+++ b/docs/vcd_vm_update-general-setting.md
@@ -1,0 +1,13 @@
+```
+Usage: vcd vm update-general-setting [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --name <vm_name>          vm name
+  --d <description>         vm description
+  --cn <computer_name>      vm computer name
+  --bd <boot_delay>         boot delay of VM.
+  --ebs <enter_bios_setup>  enter bios setup of VM.
+  --sp <storage_policy>     vm storage policy
+  -h, --help                Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-metadata.md
+++ b/docs/vcd_vm_update-metadata.md
@@ -1,0 +1,12 @@
+```
+Usage: vcd vm update-metadata [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --domain <domain>          domain  [required]
+  --visibility <visibility>  visibility  [required]
+  --value-type <value_type>  value_type  [required]
+  --key <key>                key  [required]
+  --value <value>            value  [required]
+  -h, --help                 Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-nic.md
+++ b/docs/vcd_vm_update-nic.md
@@ -1,0 +1,20 @@
+```
+Usage: vcd vm update-nic [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --adapter-type <adapter-type>   adapter type of nic - one of
+                                  VLANCE|VMXNET|VMXNET2|VMXNET3|E1000
+
+  --primary                       whether nic has to be a primary
+  --connect                       whether nic has to be connected
+  --network <network>             network to connect to  [required]
+  --ip-address-mode <ip-address-mode>
+                                  IP address allocation mode - one of
+                                  DHCP|POOL|MANUAL|NONE
+
+  --ip-address <ip-address>       nanual IP address that needs to be allocated
+                                  to the nic
+
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-os-section.md
+++ b/docs/vcd_vm_update-os-section.md
@@ -1,0 +1,9 @@
+```
+Usage: vcd vm update-os-section [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --ovf-info <ovf_info>  ovf info
+  --d <description>      description
+  -h, --help             Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-vhs-disk.md
+++ b/docs/vcd_vm_update-vhs-disk.md
@@ -1,0 +1,10 @@
+```
+Usage: vcd vm update-vhs-disk [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --e-name <element-name>         element name  [required]
+  --v-quantity <virtual_quantity>
+                                  virtual quantity in bytes  [required]
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-vhs-media.md
+++ b/docs/vcd_vm_update-vhs-media.md
@@ -1,0 +1,10 @@
+```
+Usage: vcd vm update-vhs-media [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --e-name <element-name>         element name  [required]
+  --host-resource <host resource>
+                                  host resource  [required]
+  -h, --help                      Show this message and exit.
+
+```

--- a/docs/vcd_vm_update-vm-capabilities.md
+++ b/docs/vcd_vm_update-vm-capabilities.md
@@ -1,0 +1,11 @@
+```
+Usage: vcd vm update-vm-capabilities [OPTIONS] <vapp-name> <vm-name>
+
+Options:
+  --enable-memory-hot-add / --disable-memory-hot-add
+                                  enable memory hot add
+  --enable-cpu-hot-add / --disable-cpu-hot-add
+                                  enable CPU hot add
+  -h, --help                      Show this message and exit.
+
+```

--- a/vcd_cli/dhcp_pool.py
+++ b/vcd_cli/dhcp_pool.py
@@ -68,35 +68,35 @@ def dhcp_pool(ctx):
    default=False,
    help='Auto configure DNS')
 @click.option(
-   '-g'
+   '-g',
    '--gateway-ip',
    'gateway_ip',
    metavar='<default-gateway-ip>',
    default=None,
    help='Default gateway ip')
 @click.option(
-   '-d'
+   '-d',
    '--domain',
    'domain',
    metavar='<domain-name>',
    default=None,
    help='domain name')
 @click.option(
-   '-p'
+   '-p',
    '--primary-server',
    'primary_server',
    metavar='<primary-name-server>',
    default=None,
    help='primary server ip')
 @click.option(
-   '-s'
+   '-s',
    '--secondary-server',
    'secondary_server',
    metavar='<secondary-name-server>',
    default=None,
    help='secondary server ip')
 @click.option(
-   '-l'
+   '-l',
    '--lease',
    'lease',
    metavar='<lease-time>',


### PR DESCRIPTION
Fix the command line arguments definition for "dhcp-pool create". It was missing some commas in the code.
Thanks to this fix, eg.: `-g` and `--gateway-ip` are separate options, instead of `-g--gateway-ip`.
Also re-generated docs to reflect changes. I used the script present in repo (`generate-docs.py`). This is why so many docs files are changed.