### PR TITLE
Update keyring to fix collections.abc alias to support python3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click >= 7.0
 colorama >= 0.3.9
-keyring >= 10.6.0, <= 12.0.0
+keyring >= 19.0.0, <= 23.5.0
 pycryptodome == 3.6.6
 pypiwin32 >= 223;platform_system=="Windows"
 pyvcloud >= 23.0.1, < 24.0.0

--- a/vcd_cli/utils.py
+++ b/vcd_cli/utils.py
@@ -11,7 +11,7 @@
 # code for the these subcomponents is subject to the terms and
 # conditions of the subcomponent's license, as noted in the LICENSE file.
 #
-import collections
+from collections import abc
 import json
 from os import environ
 import re
@@ -219,7 +219,7 @@ def stdout(obj, ctx=None, alt_text=None, show_id=False,
                                     task.get('operation'),
                                     task.get('status'))
                 elif ctx.command.name == 'list' and \
-                        isinstance(obj, collections.Iterable):
+                        isinstance(obj, abc.Iterable):
                     text = as_table(obj)
                 elif ctx.command.name == 'info':
                     text = as_table(


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

* Updated keyring requirement
* This makes vcd-cli comply with python3.10

Testing done
* vcd login
* vcd cse commands
* vcd logout
* vcd cse ovdc list
* vcd role list-rights clusteradmin -o cseorg

@rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-cli/566)
<!-- Reviewable:end -->
