### PR TITLE
Implement 'vdc list-compute-policies'.

### DIFF
--- a/docs/vcd_vdc.md
+++ b/docs/vcd_vdc.md
@@ -31,13 +31,14 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  acl      work with vdc acl
-  create   create a virtual datacenter
-  delete   delete a virtual datacenter
-  disable  disable a virtual datacenter
-  enable   enable a virtual datacenter
-  info     show virtual datacenter details
-  list     list of virtual datacenters
-  use      set active virtual datacenter
+  acl                    work with vdc acl
+  create                 create a virtual datacenter
+  delete                 delete a virtual datacenter
+  disable                disable a virtual datacenter
+  enable                 enable a virtual datacenter
+  info                   show virtual datacenter details
+  list                   list of virtual datacenters
+  list-compute-policies  list compute policies available in a VDC
+  use                    set active virtual datacenter
 
 ```


### PR DESCRIPTION
Option '--show-id' to show compute policy id.

The command show compute policies of the VDC and some details:
- is_default
- is_sizing
- is_vm_placement

Tech note:
Notice that I have used a private function _do_request_prim(). We should use class VcdClient and method client.call_api() but rehydrate_from_token() need to be surgarged to work proprely.
I have a pending pull request to fix that in pyvcloud.

Signed-off-by: Olivier DRAGHI <odraghi@gmail.com>

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name
