### PR TITLE
[Fix] System test - Can't use custom sysadmin login

### DIFF
--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -74,7 +74,7 @@ fi
 auto_base_config=$SRCROOT/auto.base_config.yaml
 sed -e "s/<vcd ip>/${VCD_HOST}/" \
 -e "s/30.0/${VCD_API_VERSION}/" \
--e "s/\(sys_admin_username: \'\)administrator/\1${VCD_USER}/" \
+-e "s/\(sys_admin_username: '\)administrator/\1${VCD_USER}/" \
 -e "s/<root-password>/${VCD_PASSWORD}/" \
 -e "s/<vc ip>/${VC_IP}/" \
 -e "s/<vc root password>/${VC_PASSWORD}/" \


### PR DESCRIPTION
Fixed Issue:
The script run_system_tests.sh doesn't set sys_admin_username in $SRCROOT/auto.base_config.yaml

Now it take correctly VCD_USER in $HOME/vcd_connexion to set the value. 

Signed-off-by: Olivier DRAGHI <odraghi@gmail.com>