### PR TITLE
Add login with API Access Token

### DIFF
--- a/docs/vcd_login.md
+++ b/docs/vcd_login.md
@@ -22,6 +22,11 @@ Usage: vcd login [OPTIONS] host organization user
               --session-id ee968665bf3412d581bbc6192508eec4
               Login using active session id.
   
+          vcd login mysp.com org1 api_token \
+              --session-id ee968665bf3412d581bbc6192508eec4
+              Login using API Access Token (external identity provider - oAuth
+              2.0).
+  
       Environment Variables
           VCD_PASSWORD
               If this environment variable is set, the command will use its value


### PR DESCRIPTION
# Description
Add support for authentication using [API Access Tokens][1]. The authentication follows RFC6749 (OAuth 2.0). If the `user` argument of the login cli is set to "api_token" the `session-id` is interpreted as API Access Token. An oAuth 2.0 authentication request is made to the token endpoint and the access_token from the response is used as `session-id`. Furthermore, the pyvcloud client's `rehydrate_from_token` function must be called with the optional argument `is_jwt_token=True`.

API Access Token authentication is useful when vCloud Director is configured to authenticate through an [external identity provider][2].

Implements feature request: #581

# Usage
1. [Generate an API Access Token][1]
2. Login with the generated API Access Token
    ```
    vcd login <VCD_HOST> <VCD_ORG> api_token --session-id <API_ACCESS_TOKEN>
    ```

[1]: https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html
[2]: https://docs.vmware.com/en/VMware-Cloud-Director/10.5/VMware-Cloud-Director-Service-Provider-Admin-Guide/GUID-3326986B-931C-4FDE-AF47-D5A863191072.html